### PR TITLE
Extract and emit complex components for geneontology/pathways2GO#154

### DIFF
--- a/models/ACETATEUTIL2-PWY-ACETATEUTIL2-PWY.ttl
+++ b/models/ACETATEUTIL2-PWY-ACETATEUTIL2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetate utilization - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/AERO-GLYCEROL-CAT-PWY-AERO-GLYCEROL-CAT-PWY.ttl
+++ b/models/AERO-GLYCEROL-CAT-PWY-AERO-GLYCEROL-CAT-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ALANINE-DEG3-PWY-ALANINE-DEG3-PWY.ttl
+++ b/models/ALANINE-DEG3-PWY-ALANINE-DEG3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ALANINE-SYN2-PWY-ALANINE-SYN2-PWY.ttl
+++ b/models/ALANINE-SYN2-PWY-ALANINE-SYN2-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ALL-CHORISMATE-PWY-1-ALL-CHORISMATE-PWY-1.ttl
+++ b/models/ALL-CHORISMATE-PWY-1-ALL-CHORISMATE-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,19 +126,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -173,20 +173,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -194,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -202,19 +204,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -222,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -241,19 +243,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_29934_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
@@ -265,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,38 +277,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_8bb0a914-c459-4666-8a9b-8eaf76f7a189_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -321,9 +323,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/7f42f4c0-e030-4248-b9e2-055e39e8d7f4_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/e6503160-3dc5-40f1-8dda-5a990c36d45c_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -331,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,27 +346,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -372,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,19 +401,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -417,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -438,20 +442,22 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' 'null' '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/ADCLY-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29748_CHORISMATEMUT-RXN>
@@ -463,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -484,57 +490,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +538,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -553,19 +557,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_8bb0a914-c459-4666-8a9b-8eaf76f7a189_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8bb0a914-c459-4666-8a9b-8eaf76f7a189_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_PABASYN-RXN_null_ALL-CHORISMATE-PWY-1>
@@ -573,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -581,19 +585,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
+          <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -601,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -637,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -645,36 +649,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -682,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -754,19 +758,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57451>
@@ -791,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,44 +808,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/e23619ed-3afe-4465-8df9-0a7ee91a9fcb_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
+          <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_32364>
@@ -849,19 +841,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
@@ -873,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,20 +877,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
+          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
@@ -908,30 +902,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53094> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_188aa327-465c-42f3-a141-4196dd7ea195_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/188aa327-465c-42f3-a141-4196dd7ea195_RXN3O-9789>
-] .
 
 <http://model.geneontology.org/CHEBI_29985_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -942,13 +919,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53012> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
+] .
 
 <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -967,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1000,11 +994,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18005> ;
@@ -1015,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,36 +1020,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+<http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000004801> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,30 +1064,31 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,41 +1111,41 @@
           <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://identifiers.org/sgd/S000001378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000001378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -1149,7 +1153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1163,19 +1167,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
@@ -1187,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1216,19 +1220,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17001>
@@ -1236,19 +1240,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -1256,32 +1260,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000001788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1290,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1317,19 +1322,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -1341,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1354,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1368,29 +1373,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
@@ -1400,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,7 +1419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1426,10 +1429,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "NAD-dependent 5,10-methylenetetrahydrafolate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,48 +1444,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
+          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_e23619ed-3afe-4465-8df9-0a7ee91a9fcb_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57451> ;
@@ -1491,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1500,37 +1513,41 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
+          <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_7f42f4c0-e030-4248-b9e2-055e39e8d7f4_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7f42f4c0-e030-4248-b9e2-055e39e8d7f4_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -1538,29 +1555,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' '(1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + L-serine &rarr; L-tryptophan + D-glyceraldehyde 3-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPSYN-RXN>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
@@ -1572,9 +1587,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/94e8b5b1-c5e4-44e4-be09-98c3ac46fbdf_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b0d3a6ee-00ff-42ed-aa06-8ceb064b3937_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1582,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1594,19 +1609,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -1614,7 +1629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1622,44 +1637,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1687,40 +1713,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0008841>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "anthranilate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component> , <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1728,38 +1753,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/162b6180-0957-4836-a58a-dceb8974b0e0_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/GO_0008841>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58406>
@@ -1777,13 +1788,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53107> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -1794,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1804,19 +1826,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -1824,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1839,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1852,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1867,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1883,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1891,23 +1913,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
+          <http://model.geneontology.org/9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/RXN3O-4157>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016212> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1925,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1941,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1959,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1969,19 +1991,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_9d52d6ad-1349-4d13-bd30-fdb3fa99c4b0_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9d52d6ad-1349-4d13-bd30-fdb3fa99c4b0_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
@@ -1993,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2017,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2028,27 +2050,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2059,39 +2081,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2102,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2119,28 +2143,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52610> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/6756e285-0df2-4d16-8941-15ba5a31b362_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2153,7 +2160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2166,7 +2173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2191,36 +2198,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_de002e7c-7a20-44e5-80be-b437ab5759b4_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/de002e7c-7a20-44e5-80be-b437ab5759b4_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
@@ -2242,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2255,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2266,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2274,19 +2281,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2297,7 +2304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2310,55 +2317,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
@@ -2368,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2376,27 +2381,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_137dff24-7dc5-4e2a-99e2-d09e4c5d5d65_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2404,19 +2409,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
@@ -2428,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,13 +2467,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53419> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2462,7 +2504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2473,23 +2515,6 @@
 <http://purl.obolibrary.org/obo/GO_0003934>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/b0d3a6ee-00ff-42ed-aa06-8ceb064b3937_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/THYMIDYLATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004799> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2499,9 +2524,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6b134658-c2b6-4f04-9e60-4a9f834e7fcf_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9d52d6ad-1349-4d13-bd30-fdb3fa99c4b0_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2509,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2520,12 +2545,34 @@
 <http://purl.obolibrary.org/obo/GO_0004664>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2536,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2544,19 +2591,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -2564,18 +2611,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2586,7 +2650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2594,19 +2658,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -2614,7 +2678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2625,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2633,19 +2697,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -2653,28 +2717,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
-] .
 
 <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -2684,19 +2731,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002411_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10814> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
@@ -2708,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2728,7 +2794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2737,59 +2803,59 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004765>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -2797,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2808,18 +2874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_9d52d6ad-1349-4d13-bd30-fdb3fa99c4b0_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2827,55 +2882,57 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GCVMULTI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_6756e285-0df2-4d16-8941-15ba5a31b362_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2886,7 +2943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2897,7 +2954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2910,7 +2967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2927,7 +2984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2937,19 +2994,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2958,7 +3032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2970,7 +3044,7 @@
 ] .
 
 <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004329> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2978,9 +3052,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/de002e7c-7a20-44e5-80be-b437ab5759b4_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/e23619ed-3afe-4465-8df9-0a7ee91a9fcb_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2988,7 +3062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2996,31 +3070,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
-] .
-
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3031,7 +3086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3046,7 +3101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3062,7 +3117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3078,7 +3133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3089,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3097,19 +3152,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -3117,7 +3172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3131,7 +3186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3139,19 +3194,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002411_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4157>
+          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
@@ -3163,7 +3218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3179,11 +3234,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0046820> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3204,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3219,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3232,7 +3304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3240,19 +3312,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -3260,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3268,19 +3340,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -3288,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3299,19 +3371,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
+          <http://model.geneontology.org/bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004834>
@@ -3324,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3341,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3354,7 +3426,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3365,7 +3448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3380,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3388,23 +3471,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3412,19 +3484,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller>
+          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
 ] .
 
 <http://identifiers.org/sgd/S000004719>
@@ -3432,17 +3504,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
@@ -3455,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3466,7 +3538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3474,19 +3546,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_37ee9d46-5402-4bee-976d-6d2f870e2ea7_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/37ee9d46-5402-4bee-976d-6d2f870e2ea7_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
@@ -3497,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3507,61 +3579,65 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
+          <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3585,7 +3661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3595,19 +3671,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
@@ -3619,7 +3695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3632,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3640,19 +3716,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
@@ -3664,7 +3740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3681,7 +3757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3694,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3702,36 +3778,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_e6503160-3dc5-40f1-8dda-5a990c36d45c_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e6503160-3dc5-40f1-8dda-5a990c36d45c_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
+          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -3739,7 +3815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3750,7 +3826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3761,7 +3837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3776,7 +3852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3789,7 +3865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3797,19 +3873,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -3821,7 +3897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3832,38 +3908,21 @@
           <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/37ee9d46-5402-4bee-976d-6d2f870e2ea7_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN>
@@ -3875,7 +3934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3890,7 +3949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3906,19 +3965,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_36242>
@@ -3933,7 +3992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3946,61 +4005,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/137dff24-7dc5-4e2a-99e2-d09e4c5d5d65_RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
+          <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
@@ -4012,7 +4054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4027,7 +4069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4037,19 +4079,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
@@ -4061,7 +4103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4074,20 +4116,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_c1edd7e4-02cc-47ed-9114-faa5cacad3f8_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4110,7 +4141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4119,39 +4150,37 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_94e8b5b1-c5e4-44e4-be09-98c3ac46fbdf_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/94e8b5b1-c5e4-44e4-be09-98c3ac46fbdf_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -4159,7 +4188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4167,36 +4196,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4205,7 +4236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4221,7 +4252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4229,19 +4260,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+          <http://model.geneontology.org/4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -4249,35 +4280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4292,13 +4295,52 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53305> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29748_ANTHRANSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29748> ;
@@ -4309,7 +4351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4322,7 +4364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4333,7 +4375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4344,39 +4386,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005260> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "prephenate dehydratase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4390,7 +4430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4403,19 +4443,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
@@ -4426,7 +4466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4441,7 +4481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4458,7 +4498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4473,7 +4513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4486,19 +4526,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -4506,7 +4546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4517,7 +4557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4535,7 +4575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4548,7 +4588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4556,17 +4596,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4577,7 +4606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4585,21 +4614,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_RXN3O-9789>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -4607,7 +4647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4615,19 +4655,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -4635,7 +4675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4646,7 +4686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4657,7 +4697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4670,7 +4710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4680,27 +4720,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller>
+          <http://model.geneontology.org/d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789>
 ] .
+
+<http://model.geneontology.org/0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4711,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4736,7 +4793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4749,7 +4806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4762,7 +4819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4782,7 +4839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4799,7 +4856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4807,40 +4864,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
+
 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Complex52793> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
-] .
-
-<http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4850,7 +4911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4870,28 +4931,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53321> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/6b134658-c2b6-4f04-9e60-4a9f834e7fcf_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4900,19 +4944,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -4920,7 +4964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4935,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4944,22 +4988,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
@@ -4971,7 +5013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4983,19 +5025,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -5003,7 +5045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5014,7 +5056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5023,52 +5065,69 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -5076,49 +5135,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/188aa327-465c-42f3-a141-4196dd7ea195_RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_CHORISMATEMUT-RXN_location_lociGO_0005829>
@@ -5130,7 +5170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5146,7 +5186,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
+        a       <http://identifiers.org/sgd/S000000892> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5155,43 +5215,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/8bb0a914-c459-4666-8a9b-8eaf76f7a189_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5209,7 +5241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5217,21 +5249,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57701_CHORISMATE-SYNTHASE-RXN>
@@ -5243,7 +5294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5256,7 +5307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5267,7 +5318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5282,7 +5333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5291,7 +5342,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/2.6.1.58-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0016212> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -5307,7 +5358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5317,19 +5368,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_145989_2.5.1.19-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_18005_RXN-10814>
@@ -5341,7 +5392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5350,22 +5401,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRAISOM-RXN>
+          <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000003116>
@@ -5376,27 +5425,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003848>
@@ -5414,7 +5465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5431,7 +5482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5450,9 +5501,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5463,7 +5525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5471,91 +5533,74 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10814> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/GO_0004799>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
-] .
-
-<http://model.geneontology.org/c1edd7e4-02cc-47ed-9114-faa5cacad3f8_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0004799>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_7f42f4c0-e030-4248-b9e2-055e39e8d7f4_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5566,7 +5611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5579,7 +5624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5592,7 +5637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5600,19 +5645,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
+          <http://model.geneontology.org/2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -5620,27 +5665,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' '(1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + L-serine &rarr; L-tryptophan + D-glyceraldehyde 3-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/TRYPSYN-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -5650,20 +5697,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -5671,7 +5720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5686,7 +5735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5703,7 +5752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5716,7 +5765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5727,36 +5776,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/2.5.1.19-RXN>
@@ -5778,7 +5827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5792,7 +5841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5808,7 +5857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5833,7 +5882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5843,47 +5892,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
+          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_e6503160-3dc5-40f1-8dda-5a990c36d45c_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
@@ -5895,7 +5933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5905,19 +5943,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_453b5ed3-3723-4856-b369-4a7b5606ca81_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/453b5ed3-3723-4856-b369-4a7b5606ca81_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58462>
@@ -5932,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5940,12 +5978,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+] .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5958,24 +6013,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53536> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -5986,7 +6030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5999,18 +6043,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_9e5aeff2-e5fa-4018-b757-a3b32c424cba_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6035,7 +6079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6045,19 +6089,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
@@ -6069,7 +6113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6096,7 +6140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6106,52 +6150,84 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
+          <http://model.geneontology.org/ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN>
 ] .
+
+<http://model.geneontology.org/e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000288>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -6159,7 +6235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6167,20 +6243,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_162b6180-0957-4836-a58a-dceb8974b0e0_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/162b6180-0957-4836-a58a-dceb8974b0e0_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32364> ;
@@ -6191,24 +6278,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53699> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6218,7 +6294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6226,19 +6302,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16567_PRTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -6246,7 +6322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6257,7 +6333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6271,7 +6347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6286,7 +6362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6299,7 +6375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6310,7 +6386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6318,36 +6394,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29748_PABASYN-RXN>
+          <http://model.geneontology.org/3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -6355,7 +6431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6363,17 +6439,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_94e8b5b1-c5e4-44e4-be09-98c3ac46fbdf_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PRTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004048> ;
@@ -6394,7 +6459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6403,40 +6468,66 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
+
+<http://model.geneontology.org/CHEBI_145989_2.5.1.19-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_145989> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "shikimate 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53626> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004425> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6457,7 +6548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6465,72 +6556,59 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_145989_2.5.1.19-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_145989> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "shikimate 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53626> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
+          <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -6538,7 +6616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6549,7 +6627,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6557,51 +6646,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b0d3a6ee-00ff-42ed-aa06-8ceb064b3937_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0d3a6ee-00ff-42ed-aa06-8ceb064b3937_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_3a6ad99b-c1e2-4325-a14e-a82b4ba975e6_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6609,7 +6687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6629,7 +6707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6642,7 +6720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6653,7 +6731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6664,7 +6742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6672,19 +6750,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
@@ -6696,7 +6774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6709,7 +6787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6720,7 +6798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6733,7 +6811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6750,7 +6828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6763,9 +6841,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -6780,27 +6867,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000002426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_CHORISMATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -6808,7 +6898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6825,7 +6915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6833,47 +6923,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://identifiers.org/sgd/S000006264>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
-] .
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6886,7 +6970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6894,23 +6978,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6925,7 +7015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6935,19 +7025,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN>
@@ -6969,7 +7059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6986,7 +7076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6997,49 +7087,46 @@
 <http://purl.obolibrary.org/obo/GO_0003856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/9d52d6ad-1349-4d13-bd30-fdb3fa99c4b0_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
+          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7056,7 +7143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7067,7 +7154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7078,7 +7165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7089,7 +7176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7097,36 +7184,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
@@ -7137,7 +7226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7148,7 +7237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7165,7 +7254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7178,36 +7267,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9789>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -7215,7 +7304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7223,19 +7312,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_73083_H2PTEROATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
@@ -7247,7 +7336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7256,20 +7345,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7278,7 +7369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7294,7 +7385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7305,7 +7396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7320,7 +7411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of chorismate metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -7330,19 +7421,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_ANTHRANSYN-RXN>
@@ -7354,7 +7445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7367,7 +7458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7385,7 +7476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7393,16 +7484,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_6b134658-c2b6-4f04-9e60-4a9f834e7fcf_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002411_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-4157>
+] .
 
 <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -7413,7 +7510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7426,7 +7523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7444,9 +7541,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9e5aeff2-e5fa-4018-b757-a3b32c424cba_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/8bb0a914-c459-4666-8a9b-8eaf76f7a189_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -7454,7 +7551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7475,7 +7572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7491,7 +7588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7499,19 +7596,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_137dff24-7dc5-4e2a-99e2-d09e4c5d5d65_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/137dff24-7dc5-4e2a-99e2-d09e4c5d5d65_RXN3O-9789>
+          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -7519,7 +7616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7527,19 +7624,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -7547,7 +7644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7558,7 +7655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7566,19 +7663,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
@@ -7590,7 +7687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7598,66 +7695,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
-] .
-
-<http://model.geneontology.org/de002e7c-7a20-44e5-80be-b437ab5759b4_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7665,47 +7708,115 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
+
+<http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PABASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000453>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001694> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7716,19 +7827,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
+          <http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -7736,7 +7847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7747,7 +7858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7755,36 +7866,64 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
@@ -7796,43 +7935,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53554> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7851,7 +7960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7865,7 +7974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7885,7 +7994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7898,7 +8007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7909,20 +8018,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_162b6180-0957-4836-a58a-dceb8974b0e0_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -7931,7 +8029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7946,7 +8044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7959,7 +8057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7974,7 +8072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7983,22 +8081,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' 'null' '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -8006,7 +8102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8017,7 +8113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8032,11 +8128,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52950> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -8051,7 +8164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8074,7 +8187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8087,19 +8200,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_2.5.1.19-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
@@ -8111,7 +8224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8130,7 +8243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8145,7 +8258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8156,32 +8269,21 @@
 <http://purl.obolibrary.org/obo/GO_0004106>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -8189,7 +8291,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8200,7 +8313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8215,7 +8328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8228,7 +8341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8253,7 +8366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8263,19 +8376,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -8283,7 +8396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8294,7 +8407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8309,7 +8422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8319,19 +8432,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -8339,7 +8452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8352,7 +8465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8371,44 +8484,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/TRYPSYN-RXN>
@@ -8428,7 +8543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8441,7 +8556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8449,19 +8564,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
@@ -8473,7 +8588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8489,7 +8604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8500,6 +8615,23 @@
           <http://model.geneontology.org/CHORISMATEMUT-RXN>
 ] .
 
+<http://model.geneontology.org/41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000005762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -8507,7 +8639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8517,53 +8649,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -8571,7 +8703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8579,51 +8711,98 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
+          <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+] .
+
 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -8634,7 +8813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8654,9 +8833,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/c1edd7e4-02cc-47ed-9114-faa5cacad3f8_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/3a6ad99b-c1e2-4325-a14e-a82b4ba975e6_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -8664,7 +8843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8676,22 +8855,20 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -8699,7 +8876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8710,7 +8887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8725,7 +8902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -8735,44 +8912,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_13392_RXN3O-9789>
 ] .
-
-<http://model.geneontology.org/7f42f4c0-e030-4248-b9e2-055e39e8d7f4_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8787,7 +8947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8804,7 +8964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8814,36 +8974,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
@@ -8853,7 +9013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8870,7 +9030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8883,40 +9043,49 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.5.1.19-RXN>
+          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8931,7 +9100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8944,7 +9113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8953,14 +9122,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "thymidylate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8977,7 +9165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8986,93 +9174,98 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+] .
+
+<http://identifiers.org/sgd/S000005260>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004764>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17001_H2NEOPTERINALDOL-RXN>
+          <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_null_ALL-CHORISMATE-PWY-1>
@@ -9080,18 +9273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9106,7 +9288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9114,21 +9296,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -9136,7 +9329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9151,7 +9344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9161,19 +9354,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
@@ -9188,15 +9381,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/137dff24-7dc5-4e2a-99e2-d09e4c5d5d65_RXN3O-9789> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> ;
+                <http://model.geneontology.org/5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/188aa327-465c-42f3-a141-4196dd7ea195_RXN3O-9789> ;
+                <http://model.geneontology.org/d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9212,38 +9405,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9252,7 +9445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9266,30 +9459,13 @@
 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/3a6ad99b-c1e2-4325-a14e-a82b4ba975e6_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9305,7 +9481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9316,7 +9492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9324,19 +9500,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
@@ -9348,40 +9524,40 @@
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_145989_2.5.1.19-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
-] .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9396,9 +9572,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/37ee9d46-5402-4bee-976d-6d2f870e2ea7_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/453b5ed3-3723-4856-b369-4a7b5606ca81_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -9406,7 +9582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9419,7 +9595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9430,21 +9606,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
+          <http://model.geneontology.org/PRAISOM-RXN>
 ] .
 
 <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
@@ -9454,13 +9630,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53355> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9471,7 +9664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9484,19 +9677,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
@@ -9508,7 +9701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9525,7 +9718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9540,7 +9733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9553,7 +9746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9561,47 +9754,60 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
+          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.6.1.58-RXN>
+          <http://model.geneontology.org/IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -9609,44 +9815,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/94e8b5b1-c5e4-44e4-be09-98c3ac46fbdf_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
@@ -9654,36 +9843,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.15-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -9691,7 +9880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9706,7 +9895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9716,36 +9905,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9756,7 +9928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9767,68 +9939,94 @@
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IGPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PABASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -9836,7 +10034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9847,7 +10045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9858,7 +10056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9873,7 +10071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9886,7 +10084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9897,9 +10095,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -9912,7 +10121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9921,20 +10130,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' 'null' '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9789>
@@ -9946,7 +10157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9962,7 +10173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9992,7 +10203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10009,7 +10220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10018,32 +10229,30 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "aminodeoxychorismate lyase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10056,28 +10265,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://identifiers.org/sgd/S000004801>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -10087,29 +10301,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' 'null' '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
@@ -10121,7 +10333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10136,7 +10348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10146,44 +10358,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
+          <http://model.geneontology.org/CHEBI_16567_PRTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/453b5ed3-3723-4856-b369-4a7b5606ca81_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10198,7 +10393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10208,53 +10403,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29748_PABASYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58762>
@@ -10262,19 +10459,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -10282,7 +10479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10293,7 +10490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10304,36 +10501,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_3a6ad99b-c1e2-4325-a14e-a82b4ba975e6_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3a6ad99b-c1e2-4325-a14e-a82b4ba975e6_GCVMULTI-RXN>
+          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
@@ -10343,7 +10540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10356,11 +10553,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002762> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "anthranilate phosphoribosyl transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53571> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -10368,7 +10580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10379,65 +10591,51 @@
           <http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002762> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "anthranilate phosphoribosyl transferase" ;
+<http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53571> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_e23619ed-3afe-4465-8df9-0a7ee91a9fcb_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e23619ed-3afe-4465-8df9-0a7ee91a9fcb_METHYLENETHFDEHYDROG-NADP-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_188aa327-465c-42f3-a141-4196dd7ea195_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN>
+] .
+
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -10448,7 +10646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10463,7 +10661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10475,23 +10673,24 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
 ] .
+
+<http://identifiers.org/sgd/S000005600>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32364> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10502,7 +10701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10519,7 +10718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10532,7 +10731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10547,28 +10746,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52654> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_16810_RXN-10814>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-oxoglutarate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53321> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -10580,11 +10762,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_16810_RXN-10814>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-oxoglutarate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53321> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -10592,23 +10791,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_36208>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b0d3a6ee-00ff-42ed-aa06-8ceb064b3937_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10619,7 +10807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10627,19 +10815,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -10647,7 +10835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10658,7 +10846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10671,7 +10859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10684,7 +10872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10700,7 +10888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10709,39 +10897,37 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
+          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003866>
@@ -10754,7 +10940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10771,7 +10957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10784,7 +10970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10792,19 +10978,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
@@ -10816,7 +11002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10829,7 +11015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10844,7 +11030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10861,7 +11047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10874,29 +11060,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
@@ -10908,7 +11092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10924,29 +11108,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' 'null' '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADCLY-RXN>
+          <http://model.geneontology.org/RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_ALL-CHORISMATE-PWY-1>
@@ -10954,42 +11136,51 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
@@ -10999,7 +11190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11024,7 +11215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11041,7 +11232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11051,36 +11242,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_73083_H2PTEROATESYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
+          <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
@@ -11095,7 +11303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11103,21 +11311,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000892>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11128,7 +11350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11148,7 +11370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11177,7 +11399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11190,7 +11412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11205,7 +11427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11222,7 +11444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11238,7 +11460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11249,7 +11471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11257,19 +11479,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -11277,7 +11499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11292,7 +11514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11305,29 +11527,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-4157>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -11335,7 +11555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11350,7 +11570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11363,7 +11583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11371,19 +11591,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -11391,29 +11611,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
@@ -11425,7 +11643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11433,21 +11651,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -11455,7 +11690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11466,53 +11701,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
+          <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -11520,27 +11755,55 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -11548,7 +11811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11556,19 +11819,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -11576,7 +11839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11593,44 +11856,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11639,7 +11904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11659,7 +11924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11673,7 +11938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11686,19 +11951,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
@@ -11710,7 +11975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11718,41 +11983,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_de002e7c-7a20-44e5-80be-b437ab5759b4_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004425>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_37ee9d46-5402-4bee-976d-6d2f870e2ea7_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' 'null' '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+] .
 
 <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005316> ;
@@ -11761,7 +12023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11774,7 +12036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11789,28 +12051,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52720> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/9e5aeff2-e5fa-4018-b757-a3b32c424cba_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -11822,7 +12067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11833,7 +12078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11843,10 +12088,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11856,19 +12103,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_2.5.1.19-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -11876,7 +12123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11890,19 +12137,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_59776>
@@ -11910,19 +12157,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -11930,7 +12177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11938,38 +12185,49 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -11977,18 +12235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12002,7 +12249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12012,52 +12259,59 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12072,7 +12326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12082,38 +12336,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -12121,7 +12373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12131,58 +12383,54 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_null_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -12190,7 +12438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12198,36 +12446,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_9e5aeff2-e5fa-4018-b757-a3b32c424cba_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9e5aeff2-e5fa-4018-b757-a3b32c424cba_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
@@ -12239,7 +12487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12255,27 +12503,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -12283,7 +12533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12298,7 +12548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12314,7 +12564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12325,7 +12575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12340,7 +12590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12357,7 +12607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12374,7 +12624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12383,20 +12633,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_6756e285-0df2-4d16-8941-15ba5a31b362_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6756e285-0df2-4d16-8941-15ba5a31b362_1.5.1.15-RXN>
+          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000000370>
@@ -12407,7 +12659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12416,43 +12668,52 @@
 <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
@@ -12464,7 +12725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12477,7 +12738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12485,19 +12746,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
+          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
@@ -12509,7 +12770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12522,7 +12783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12530,21 +12791,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/2.5.1.19-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003855>
@@ -12559,7 +12820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12572,7 +12833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12586,7 +12847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12604,7 +12865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12613,49 +12874,57 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IGPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_453b5ed3-3723-4856-b369-4a7b5606ca81_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PRAISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004640> ;
@@ -12676,7 +12945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12687,46 +12956,29 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "mitochondrial C1-tetrahydrofolate synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein52688> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_17001_H2NEOPTERINALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12734,20 +12986,46 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "mitochondrial C1-tetrahydrofolate synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein52688> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -12758,7 +13036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12771,7 +13049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12783,7 +13061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12799,7 +13077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12807,36 +13085,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
@@ -12844,7 +13122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12859,7 +13137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12872,7 +13150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12887,7 +13165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12896,37 +13174,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
+          <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -12935,7 +13215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12955,11 +13235,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53087> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -12968,7 +13265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12983,7 +13280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12991,12 +13288,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13007,7 +13321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13017,20 +13331,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
+          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -13038,7 +13354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13049,7 +13365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13064,7 +13380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13074,19 +13390,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
@@ -13101,7 +13417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13114,7 +13430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13122,49 +13438,64 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002411_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
 ] .
+
+<http://model.geneontology.org/5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
+          <http://model.geneontology.org/2.6.1.58-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_18005>
@@ -13175,7 +13506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13188,7 +13519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13200,22 +13531,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -13223,7 +13552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13231,19 +13560,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -13251,7 +13580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13259,19 +13588,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
@@ -13282,7 +13611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13290,19 +13619,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -13310,29 +13656,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -13340,7 +13684,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13355,7 +13710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13372,7 +13727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13382,19 +13737,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -13402,7 +13757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13410,19 +13765,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -13431,7 +13786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13451,9 +13806,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6756e285-0df2-4d16-8941-15ba5a31b362_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/162b6180-0957-4836-a58a-dceb8974b0e0_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -13461,7 +13816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13478,7 +13833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13491,19 +13846,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -13511,7 +13866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13522,7 +13877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13537,7 +13892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13550,7 +13905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13565,7 +13920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13573,41 +13928,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0016212>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
+          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
+          <http://model.geneontology.org/RXN-10814>
 ] .
 
 <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
@@ -13629,7 +13983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13645,19 +13999,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_6b134658-c2b6-4f04-9e60-4a9f834e7fcf_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6b134658-c2b6-4f04-9e60-4a9f834e7fcf_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_SHIKIMATE-KINASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003849>
@@ -13668,11 +14022,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10814> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
+] .
 
 <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -13693,30 +14075,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53457> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
-] .
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -13728,7 +14093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13743,7 +14108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13757,24 +14122,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_44841>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
+        a       <http://identifiers.org/sgd/S000001788> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004049>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_RXN-10814_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-10814>
+          <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
@@ -13786,7 +14160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13801,7 +14175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13811,38 +14185,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_c1edd7e4-02cc-47ed-9114-faa5cacad3f8_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c1edd7e4-02cc-47ed-9114-faa5cacad3f8_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1>
@@ -13850,29 +14222,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
@@ -13884,7 +14254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13901,51 +14271,51 @@
 <http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13962,7 +14332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13975,19 +14345,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
+          <http://model.geneontology.org/41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -13995,7 +14365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14004,53 +14374,83 @@
 <http://identifiers.org/sgd/S000002534>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/e6503160-3dc5-40f1-8dda-5a990c36d45c_FORMATETHFLIG-RXN>
+<http://model.geneontology.org/d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
+] .

--- a/models/ALLANTOINDEG-PWY-ALLANTOINDEG-PWY.ttl
+++ b/models/ALLANTOINDEG-PWY-ALLANTOINDEG-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of allantoin degradation in yeast - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1175,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1574,7 +1574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1605,7 +1605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1632,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1661,7 +1661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1684,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1697,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1720,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1790,7 +1790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1821,7 +1821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1837,7 +1837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1896,7 +1896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1913,7 +1913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1958,7 +1958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1975,7 +1975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2008,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARG-PRO-PWY-ARG-PRO-PWY.ttl
+++ b/models/ARG-PRO-PWY-ARG-PRO-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -481,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,6 +918,23 @@
           <http://model.geneontology.org/PYRROLINECARBREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ARG-PRO-PWY/ARG-PRO-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_ARG-PRO-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARGINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPL111W-MONOMER_ARGINASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
@@ -929,30 +946,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARG-PRO-PWYSmallMolecule17736> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_ARG-PRO-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARGINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL111W-MONOMER_ARGINASE-RXN_controller>
-] .
 
 <http://model.geneontology.org/ARG-PRO-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine degradation VI (arginase 2 pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1181,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,7 +1336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1399,24 +1399,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,6 +1416,17 @@
           <http://model.geneontology.org/CHEBI_17388_PYRROLINECARBREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16199_ARGINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16199> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1436,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARGDEG-YEAST-PWY-ARGDEG-YEAST-PWY.ttl
+++ b/models/ARGDEG-YEAST-PWY-ARGDEG-YEAST-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,17 +69,6 @@
           <http://model.geneontology.org/YPL111W-MONOMER_ARGINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_5e729e84-fda0-46d2-964e-11f08c6f9bea_RXN-14903_SGD_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58066> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -89,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,6 +88,21 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -112,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -422,11 +426,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_4a0eb994-8e8e-49e4-b10b-7a5f5602299a_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +438,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4a0eb994-8e8e-49e4-b10b-7a5f5602299a_RXN-14903>
+          <http://model.geneontology.org/0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -448,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -572,7 +576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,23 +593,6 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/CHEBI_57540_RXN-14116>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -615,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,13 +610,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_57540_RXN-14116>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_ARGDEG-YEAST-PWY/ARGDEG-YEAST-PWY_SGD_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,16 +655,20 @@
           <http://model.geneontology.org/CHEBI_16199_ARGINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_ARGDEG-YEAST-PWY/ARGDEG-YEAST-PWY_SGD_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-14116>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -660,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -701,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -826,9 +845,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_60039_RXN-14903> , <http://model.geneontology.org/4a0eb994-8e8e-49e4-b10b-7a5f5602299a_RXN-14903> ;
+                <http://model.geneontology.org/0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5e729e84-fda0-46d2-964e-11f08c6f9bea_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -836,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,41 +863,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_null_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_5e729e84-fda0-46d2-964e-11f08c6f9bea_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +905,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5e729e84-fda0-46d2-964e-11f08c6f9bea_RXN-14903>
+          <http://model.geneontology.org/09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -895,7 +914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1046,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,17 +1076,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1077,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,12 +1093,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,7 +1140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,7 +1239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,7 +1282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1294,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1360,33 +1379,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/4a0eb994-8e8e-49e4-b10b-7a5f5602299a_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1434,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,17 +1536,6 @@
           <http://model.geneontology.org/CHEBI_46911_ARGINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004430> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1550,13 +1543,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYProtein55524> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1566,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1581,13 +1585,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55540> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903_SGD_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17388_RXN-14903>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17388> ;
@@ -1598,24 +1624,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55356> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1626,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1654,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1670,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1681,26 +1696,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/5e729e84-fda0-46d2-964e-11f08c6f9bea_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1717,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1748,7 +1748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,7 +1765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1824,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "arginine degradation (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1857,7 +1857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1869,7 +1869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1886,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1916,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1968,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1983,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2011,13 +2011,16 @@
           <http://model.geneontology.org/CHEBI_60039_RXN-14903>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002411_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,15 +2031,12 @@
           <http://model.geneontology.org/SPONTPRO-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_4a0eb994-8e8e-49e4-b10b-7a5f5602299a_RXN-14903_SGD_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903_SGD_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2084,7 +2084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2098,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2132,7 +2132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2143,12 +2143,23 @@
           <http://model.geneontology.org/CHEBI_32682_ARGINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_ARGDEG-YEAST-PWY/ARGDEG-YEAST-PWY_SGD_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2163,7 +2174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2171,23 +2182,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_RXN-14116_null_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2198,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2210,7 +2210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2300,7 +2300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARGSPECAT-PWY-ARGSPECAT-PWY.ttl
+++ b/models/ARGSPECAT-PWY-ARGSPECAT-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -718,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARGSYNBSUB-PWY-ARGSYNBSUB-PWY.ttl
+++ b/models/ARGSYNBSUB-PWY-ARGSYNBSUB-PWY.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_44337_N-ACETYLTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_57288_N-ACETYLTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_29888_ARGSUCCINSYN-RXN_SGD_ARGSYNBSUB-PWY>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,19 +145,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_ARGSYNBSUB-PWY>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -173,19 +173,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002333_YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -307,19 +307,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002411_ACETYLORNTRANSAM-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_57936_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETYLORNTRANSAM-RXN>
+          <http://model.geneontology.org/CHEBI_57936_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -383,38 +383,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-glutamate + acetyl-CoA &rarr; <i>N</i>-acetyl-L-glutamate + coenzyme A + H<SUP>+</SUP>' 'null' '<i>N</i>-acetyl-L-glutamate + ATP &rarr; <i>N</i>-acetylglutamyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002413_ACETYLGLUTKIN-RXN_null_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+          <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ACETYLGLUTKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
+          <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,11 +501,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,11 +599,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_15378_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +611,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_N-ACETYLTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_15378_N-ACETYLTRANSFER-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,22 +717,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' 'null' 'L-aspartate + L-citrulline + ATP &rarr; L-arginino-succinate + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002413_ARGSUCCINSYN-RXN_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ARGSUCCINSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -748,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,22 +755,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-glutamate + <i>N</i>-acetyl-L-ornithine &rarr; <i>N</i>-acetyl-L-glutamate + L-ornithine' 'null' '<i>N</i>-acetyl-L-glutamate + ATP &rarr; <i>N</i>-acetylglutamyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLGLUTKIN-RXN_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETYLGLUTKIN-RXN>
+          <http://model.geneontology.org/CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002413_ACETYLGLUTKIN-RXN_null_ARGSYNBSUB-PWY>
@@ -780,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -806,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -924,19 +920,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002333_YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
+          <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
+          <http://model.geneontology.org/YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
@@ -951,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -976,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,9 +988,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1003,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1014,19 +1019,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46911_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1037,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1048,29 +1053,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
 ] .
 
 <http://model.geneontology.org/reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829>
@@ -1085,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,20 +1100,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58228_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
@@ -1121,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1129,19 +1134,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY>
@@ -1149,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1204,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1234,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1260,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,19 +1275,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1291,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,13 +1307,16 @@
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002333_YOL058W-MONOMER_ARGSUCCINSYN-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,9 +1327,6 @@
           <http://model.geneontology.org/YOL058W-MONOMER_ARGSUCCINSYN-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1331,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1348,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,19 +1380,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller>
+          <http://model.geneontology.org/CHEBI_44337_N-ACETYLTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/CARBPSYN-RXN>
@@ -1409,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1426,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1445,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1521,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1542,22 +1547,40 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-glutamate + <i>N</i>-acetyl-L-ornithine &rarr; <i>N</i>-acetyl-L-glutamate + L-ornithine' 'null' 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002333_YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1566,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1582,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1617,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1631,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1643,22 +1666,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000066_reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002411_ACETYLORNTRANSAM-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
+          <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ACETYLORNTRANSAM-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_ARGSUCCINSYN-RXN>
@@ -1670,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1725,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1741,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1778,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1798,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,19 +1829,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_46911_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_29991_ARGSUCCINSYN-RXN_SGD_ARGSYNBSUB-PWY>
@@ -1828,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1843,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1852,20 +1873,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57805_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57805_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1874,7 +1897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1890,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1918,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1935,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine biosynthesis II (acetyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1952,7 +1975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1962,19 +1985,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY>
@@ -1982,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +2017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,7 +2036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2032,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2048,10 +2071,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "carbamoyl phosphate synthetase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component> , <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2061,19 +2086,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57287_N-ACETYLTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN>
@@ -2095,7 +2120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2108,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2120,7 +2145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2151,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2165,7 +2190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2185,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2193,12 +2218,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' 'null' 'L-aspartate + L-citrulline + ATP &rarr; L-arginino-succinate + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002413_ARGSUCCINSYN-RXN_null_ARGSYNBSUB-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ARGSUCCINSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2209,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2224,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2237,27 +2301,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-glutamate + <i>N</i>-acetyl-L-ornithine &rarr; <i>N</i>-acetyl-L-glutamate + L-ornithine' 'null' '<i>N</i>-acetyl-L-glutamate + ATP &rarr; <i>N</i>-acetylglutamyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLGLUTKIN-RXN_null_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
+          <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
+          <http://model.geneontology.org/ACETYLGLUTKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57936_ACETYLGLUTKIN-RXN>
@@ -2269,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2283,7 +2349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2313,7 +2379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2324,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2337,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2351,7 +2417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2392,19 +2458,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_29985_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_N-ACETYLTRANSFER-RXN>
+          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_ARGSYNBSUB-PWY>
@@ -2412,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2424,7 +2490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2444,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2456,20 +2522,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000066_reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_N-ACETYLTRANSFER-RXN>
+          <http://model.geneontology.org/reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_16810_ACETYLORNTRANSAM-RXN_SGD_ARGSYNBSUB-PWY>
@@ -2477,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2492,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2508,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2523,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2542,7 +2610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2559,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2589,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2602,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2610,19 +2678,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_58228_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_15378_ARGSUCCINSYN-RXN_SGD_ARGSYNBSUB-PWY>
@@ -2630,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2644,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2659,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2672,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2686,19 +2754,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/ARGSUCCINLYA-RXN>
@@ -2718,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2731,7 +2799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2742,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2754,7 +2822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,12 +2842,15 @@
 <http://purl.obolibrary.org/obo/GO_0004056>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLGLUTKIN-RXN_null_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2794,7 +2865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2810,11 +2881,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_57936_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,7 +2893,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57936_N-ACETYLGLUTPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/YHR018C-MONOMER_ARGSUCCINLYA-RXN_controller>
@@ -2832,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2846,7 +2917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2862,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2876,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2891,7 +2962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2902,24 +2973,36 @@
 <http://identifiers.org/sgd/S000005419>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-glutamate + acetyl-CoA &rarr; <i>N</i>-acetyl-L-glutamate + coenzyme A + H<SUP>+</SUP>' 'null' '<i>N</i>-acetyl-L-glutamate + ATP &rarr; <i>N</i>-acetylglutamyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002413_ACETYLGLUTKIN-RXN_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETYLGLUTKIN-RXN>
+          <http://model.geneontology.org/YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2927,7 +3010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2945,7 +3028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2962,7 +3045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2977,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2993,7 +3076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3009,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3020,7 +3103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3031,7 +3114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3039,21 +3122,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-glutamate + <i>N</i>-acetyl-L-ornithine &rarr; <i>N</i>-acetyl-L-glutamate + L-ornithine' 'null' 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000066_reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_null_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
+          <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY>
@@ -3061,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3076,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3096,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3113,7 +3196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3129,7 +3212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3140,7 +3223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3156,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3169,19 +3252,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_15378_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_29985_N-ACETYLTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_N-ACETYLTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_29985_N-ACETYLTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_29985_ACETYLORNTRANSAM-RXN_SGD_ARGSYNBSUB-PWY>
@@ -3189,7 +3272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3204,7 +3287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3217,7 +3300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3232,7 +3315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3259,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3272,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3284,7 +3367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,7 +3393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3330,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3347,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3357,11 +3440,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,7 +3452,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_15378_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -3377,19 +3460,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57805_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_57805_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ORNCARBAMTRANSFER-RXN>
@@ -3401,7 +3484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3415,7 +3498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3431,7 +3514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3449,7 +3532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3459,19 +3542,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002333_YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57805>
@@ -3482,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3496,7 +3579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3512,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3523,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3538,7 +3621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3565,7 +3648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3581,7 +3664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3589,19 +3672,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+          <http://model.geneontology.org/N-ACETYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
+          <http://model.geneontology.org/YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_456216_ACETYLGLUTKIN-RXN_SGD_ARGSYNBSUB-PWY>
@@ -3609,7 +3692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3626,7 +3709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3642,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3653,7 +3736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3665,7 +3748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3681,7 +3764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3696,7 +3779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3706,19 +3789,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000050_ARGSYNBSUB-PWY/ARGSYNBSUB-PWY_SGD_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN>
+          <http://model.geneontology.org/ARGSYNBSUB-PWY/ARGSYNBSUB-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_57743_ARGSUCCINSYN-RXN>
@@ -3730,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3744,7 +3827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3759,20 +3842,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN_SGD_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000066_reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829_null_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN>
+          <http://model.geneontology.org/reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -3787,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3801,7 +3886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3817,7 +3902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3829,7 +3914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3845,7 +3930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3860,7 +3945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ARO-PWY-1-ARO-PWY-1.ttl
+++ b/models/ARO-PWY-1-ARO-PWY-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,24 +134,13 @@
           <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_ARO-PWY-1/ARO-PWY-1_SGD_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,6 +151,17 @@
           <http://model.geneontology.org/ARO-PWY-1/ARO-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36208> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,8 +491,16 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -500,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,16 +519,8 @@
           <http://model.geneontology.org/ARO-PWY-1/ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_145989> ;
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,13 +612,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_ARO-PWY-1/ARO-PWY-1_SGD_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002411_SHIKIMATE-KINASE-RXN_SGD_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,34 +651,12 @@
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_ARO-PWY-1/ARO-PWY-1_SGD_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_ARO-PWY-1/ARO-PWY-1_SGD_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1042,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1056,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1153,7 +1153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1221,7 +1221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,7 +1237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1470,7 +1470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1500,7 +1500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1604,7 +1604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1664,7 +1664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1686,7 +1686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1751,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chorismate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1845,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1908,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,7 +1939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1987,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2051,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2081,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2134,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2152,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2166,7 +2166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2234,7 +2234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,7 +2251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2284,7 +2284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2302,7 +2302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2346,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2361,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2379,7 +2379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2406,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2437,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2476,7 +2476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2492,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2515,7 +2515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2545,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2556,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2567,7 +2567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/ASPARAGINE-BIOSYNTHESIS-1-ASPARAGINE-BIOSYNTHESIS-1.ttl
+++ b/models/ASPARAGINE-BIOSYNTHESIS-1-ASPARAGINE-BIOSYNTHESIS-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-asparagine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,7 +1041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/ASPARAGINE-DEG2-PWY-ASPARAGINE-DEG2-PWY.ttl
+++ b/models/ASPARAGINE-DEG2-PWY-ASPARAGINE-DEG2-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,13 +497,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_58048_ASPARAGHYD-RXN_SGD_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,17 +524,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58048_ASPARAGHYD-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002729>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "asparagine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ASPARTATESYN-PWY-ASPARTATESYN-PWY.ttl
+++ b/models/ASPARTATESYN-PWY-ASPARTATESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ASPBIO-PWY-ASPBIO-PWY.ttl
+++ b/models/ASPBIO-PWY-ASPBIO-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,7 +70,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,7 +87,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -484,6 +484,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_ASPBIO-PWY/ASPBIO-PWY_SGD_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -493,18 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_ASPBIO-PWY/ASPBIO-PWY_SGD_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/BIOTIN-SYNTHESIS-PWY-BIOTIN-SYNTHESIS-PWY.ttl
+++ b/models/BIOTIN-SYNTHESIS-PWY-BIOTIN-SYNTHESIS-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "biotin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1083,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,7 +1243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1268,7 +1268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1285,7 +1285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1321,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,7 +1375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1555,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,7 +1617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1699,7 +1699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1715,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1730,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,7 +1764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1807,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1840,7 +1840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/BRANCHED-CHAIN-AA-SYN-PWY-1-BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
+++ b/models/BRANCHED-CHAIN-AA-SYN-PWY-1-BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
@@ -3,19 +3,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,29 +77,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13163> ;
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-13163_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_2-ISOPROPYLMALATESYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-13158> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17865_RXN-13158>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -107,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -185,19 +200,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+          <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_16763_THREDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -205,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -244,19 +259,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
+          <http://model.geneontology.org/CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_1178>
@@ -271,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,20 +299,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005634> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "alpha-isopropylmalate synthase, minor isozyme" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,13 +320,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,19 +395,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13158> ;
+          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN-13158>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_49072_ACETOLACTREDUCTOISOM-RXN>
@@ -393,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,19 +508,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_2-ISOPROPYLMALATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_11851_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -502,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -570,19 +596,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THREDEHYD-RXN> ;
+          <http://model.geneontology.org/RXN-13163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57926_THREDEHYD-RXN>
+          <http://model.geneontology.org/YGL009C-MONOMER_RXN-13163_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -590,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -601,29 +627,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
@@ -635,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -660,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,23 +842,23 @@
 <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -844,20 +868,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -865,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -923,6 +949,17 @@
 
 <http://model.geneontology.org/reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -933,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -970,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,19 +1051,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_35121_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13163> ;
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35121_RXN-13163>
+          <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-13158> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_RXN-13158>
 ] .
 
 <http://model.geneontology.org/CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN>
@@ -1038,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1097,7 +1151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1146,22 +1200,20 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+          <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_28938_THREDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -1169,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1183,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1210,29 +1262,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate &rarr; 3-methyl-2-oxobutanoate + H<sub>2</sub>O' 'null' '3-methyl-2-oxobutanoate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>S</i>)-2-isopropylmalate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_2-ISOPROPYLMALATESYN-RXN_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
@@ -1246,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1291,12 +1341,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
+        a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_ACETOOHBUTSYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,19 +1386,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-13158> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN-13158>
+          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57427>
@@ -1353,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1364,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1380,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1405,6 +1464,9 @@
           <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000005634>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15378_ACETOLACTREDUCTOISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1414,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,7 +1498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1449,36 +1511,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_2-ISOPROPYLMALATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-13158> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17865_RXN-13158>
+          <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000003909>
@@ -1489,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1545,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1561,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,36 +1648,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002411_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THREDEHYD-RXN> ;
+          <http://model.geneontology.org/RXN-13163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16763_THREDEHYD-RXN>
+          <http://model.geneontology.org/RXN-13158>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOOHBUTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN>
@@ -1625,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1732,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1743,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1776,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1786,19 +1850,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+          <http://model.geneontology.org/CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1807,7 +1871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1823,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1863,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1890,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,7 +1968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1934,27 +1998,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_1178_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13163> ;
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_1178_RXN-13163>
+          <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002411_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-13158> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1972,7 +2056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2003,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2017,7 +2101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2033,18 +2117,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002411_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-13163>
+] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2055,19 +2156,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+          <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_11851_2-ISOPROPYLMALATESYN-RXN>
+          <http://model.geneontology.org/YER086W-MONOMER_THREDEHYD-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2076,7 +2177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2092,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2100,19 +2201,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003777>
@@ -2123,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2134,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2146,7 +2247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2193,7 +2294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2207,11 +2308,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
+] .
+
+<http://identifiers.org/sgd/S000000515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0052656> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2230,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2240,36 +2361,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-13158> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN-13158>
+          <http://model.geneontology.org/CHEBI_35121_RXN-13158>
 ] .
 
 <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
@@ -2281,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2295,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2311,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2326,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2345,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2360,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2373,7 +2477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2381,36 +2485,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_THREDEHYD-RXN>
+          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOOHBUTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -2418,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2430,7 +2534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2469,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2490,7 +2594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2507,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2524,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2537,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2552,7 +2656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,7 +2669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2573,19 +2677,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13158> ;
+          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/YGL009C-MONOMER_RXN-13163_controller>
@@ -2595,7 +2699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2610,7 +2714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2626,7 +2730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2642,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2654,7 +2758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2667,19 +2771,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-13163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL009C-MONOMER_RXN-13163_controller>
+          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -2687,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2698,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2709,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2720,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2732,7 +2836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2748,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2759,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2770,7 +2874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2782,7 +2886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2796,23 +2900,25 @@
 <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://purl.obolibrary.org/obo/CHEBI_35146>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetolactate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component> , <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1Complex55681> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://purl.obolibrary.org/obo/CHEBI_35146>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -2823,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2832,20 +2938,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-threonine &rarr; 2-oxobutanoate + ammonium' 'null' 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+          <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
+          <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2854,7 +2962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2870,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2881,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2892,7 +3000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2903,29 +3011,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -2937,7 +3043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of branched chain amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2954,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2971,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2985,7 +3091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3001,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3012,7 +3118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3023,7 +3129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3034,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3042,19 +3148,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16763_THREDEHYD-RXN>
@@ -3066,24 +3172,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55592> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
@@ -3092,7 +3187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3100,12 +3195,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3121,7 +3227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3138,7 +3244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3155,7 +3261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3168,36 +3274,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002411_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-13158> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
+          <http://model.geneontology.org/CHEBI_57540_RXN-13158>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -3215,7 +3321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,7 +3347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3255,7 +3361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3271,7 +3377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3289,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3309,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3329,7 +3435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3338,20 +3444,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER086W-MONOMER_THREDEHYD-RXN_controller>
+          <http://model.geneontology.org/reaction_THREDEHYD-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3379,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3389,19 +3497,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -3409,7 +3517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3420,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3432,7 +3540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3452,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3469,7 +3577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3486,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3497,26 +3605,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_49256>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_1178_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://identifiers.org/sgd/S000004714>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_1178_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3527,30 +3646,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13158> ;
+          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000515> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003852>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3561,7 +3687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3584,7 +3710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3598,7 +3724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3611,71 +3737,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
+          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58045>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58045>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002411_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-13163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-13158>
+          <http://model.geneontology.org/reaction_RXN-13163_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000002977>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55805> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3683,7 +3794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3694,6 +3805,23 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55805> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -3702,7 +3830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,7 +3862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3751,7 +3879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3764,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3775,7 +3903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3787,7 +3915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3803,7 +3931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3826,7 +3954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3842,7 +3970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3859,27 +3987,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate &rarr; 3-methyl-2-oxobutanoate + H<sub>2</sub>O' 'null' '3-methyl-2-oxobutanoate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>S</i>)-2-isopropylmalate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_2-ISOPROPYLMALATESYN-RXN_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
@@ -3889,7 +4019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3903,7 +4033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3946,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3962,7 +4092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3992,7 +4122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4002,36 +4132,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13163> ;
+          <http://model.geneontology.org/RXN-13158> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_16526_RXN-13158>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002411_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-13163>
+          <http://model.geneontology.org/CHEBI_15378_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -4039,9 +4169,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4054,7 +4195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4073,7 +4214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4090,7 +4231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4108,7 +4249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4121,7 +4262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4134,7 +4275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4143,22 +4284,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-threonine &rarr; 2-oxobutanoate + ammonium' 'null' 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57926_THREDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
@@ -4170,7 +4309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4185,7 +4324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4194,20 +4333,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_49256_ACETOOHBUTREDUCTOISOM-RXN>
@@ -4219,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4233,7 +4374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4253,7 +4394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4272,7 +4413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4280,19 +4421,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13158> ;
+          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35121_RXN-13158>
+          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_17865_RXN-13158>
@@ -4304,7 +4445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4317,7 +4458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4329,7 +4470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4345,7 +4486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4357,7 +4498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4372,20 +4513,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN>
+          <http://model.geneontology.org/reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN>
@@ -4397,7 +4540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4414,7 +4557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4431,7 +4574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4441,19 +4584,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_35121_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THREDEHYD-RXN> ;
+          <http://model.geneontology.org/RXN-13163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_35121_RXN-13163>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
@@ -4461,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4472,7 +4615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4484,7 +4627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4514,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4531,7 +4674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4548,7 +4691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4566,7 +4709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4581,7 +4724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4590,22 +4733,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_null_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_1178_RXN-13163_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THREDEHYD-RXN> ;
+          <http://model.geneontology.org/RXN-13163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THREDEHYD-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_1178_RXN-13163>
 ] .
 
 <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
@@ -4617,7 +4758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4630,19 +4771,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAIN-AA-SYN-PWY-1/BRANCHED-CHAIN-AA-SYN-PWY-1>
+          <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -4654,7 +4795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4670,7 +4811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4682,7 +4823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4697,10 +4838,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetolactate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component> , <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4713,7 +4856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4728,7 +4871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4745,7 +4888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/BSUBPOLYAMSYN-PWY-BSUBPOLYAMSYN-PWY.ttl
+++ b/models/BSUBPOLYAMSYN-PWY-BSUBPOLYAMSYN-PWY.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermidine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/CITRUL-BIO2-PWY-CITRUL-BIO2-PWY.ttl
+++ b/models/CITRUL-BIO2-PWY-CITRUL-BIO2-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -51,19 +51,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_CITRUL-BIO2-PWY/CITRUL-BIO2-PWY_SGD_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CITRUL-BIO2-PWY/CITRUL-BIO2-PWY>
+          <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -130,6 +130,9 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58228>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CITRUL-BIO2-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -140,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "citrulline biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -150,19 +153,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN>
@@ -182,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -229,11 +232,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -243,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -375,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -413,11 +419,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +431,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_15378_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
@@ -437,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,19 +473,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_46911_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -491,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,10 +512,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "carbamoyl phosphate synthetase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component> , <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,13 +559,24 @@
           <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -587,19 +606,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/CHEBI_58228_ORNCARBAMTRANSFER-RXN>
 ] .
 
 <http://model.geneontology.org/YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller>
@@ -609,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -638,20 +657,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_null_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58228_ORNCARBAMTRANSFER-RXN>
+          <http://model.geneontology.org/reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829>
@@ -663,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -719,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -797,9 +818,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -812,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,29 +879,12 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46911_ORNCARBAMTRANSFER-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_CITRUL-BIO2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -879,11 +892,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_CITRUL-BIO2-PWY/CITRUL-BIO2-PWY_SGD_CITRUL-BIO2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CITRUL-BIO2-PWY/CITRUL-BIO2-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,17 +930,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -920,13 +939,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CITRUL-BIO2-PWYSmallMolecule22806> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -937,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,11 +980,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -962,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,8 +1023,34 @@
           <http://model.geneontology.org/CITRUL-BIO2-PWY/CITRUL-BIO2-PWY>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_CITRUL-BIO2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller>
+] .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1004,9 +1063,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1025,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,22 +1107,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_null_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1061,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1078,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,11 +1165,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_CITRUL-BIO2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/COMPLETE-ARO-PWY-1-COMPLETE-ARO-PWY-1.ttl
+++ b/models/COMPLETE-ARO-PWY-1-COMPLETE-ARO-PWY-1.ttl
@@ -1,18 +1,20 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
+          <http://model.geneontology.org/PRAISOM-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001694>
@@ -27,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -65,19 +67,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
@@ -89,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -119,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,19 +170,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
 ] .
 
 <http://geneontology.org/lego/evidence>
@@ -191,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -210,36 +212,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
 <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN>
@@ -261,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,20 +292,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -311,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,22 +366,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
@@ -387,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,36 +402,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -441,7 +443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,49 +458,62 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
+          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -509,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,23 +532,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -555,38 +559,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58095>
@@ -603,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -613,10 +615,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -670,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -687,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,22 +700,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
 ] .
 
 <http://model.geneontology.org/CHEBI_29748_ANTHRANSYN-RXN>
@@ -723,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,45 +751,60 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' '(1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + L-serine &rarr; L-tryptophan + D-glyceraldehyde 3-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
+          <http://model.geneontology.org/TRYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
+          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +815,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
+        a       <http://identifiers.org/sgd/S000000892> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,34 +860,21 @@
           <http://model.geneontology.org/CHORISMATEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.5.1.19-RXN>
+          <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -858,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -884,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -914,75 +938,75 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1007,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,7 +1044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1031,9 +1055,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1046,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,12 +1089,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1070,19 +1105,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -1090,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1117,10 +1152,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,44 +1187,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002411_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
@@ -1195,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1210,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1223,46 +1262,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' 'null' '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004765>
@@ -1270,19 +1307,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000453>
@@ -1293,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1329,19 +1366,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
@@ -1353,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,41 +1398,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1406,19 +1456,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -1426,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1454,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1482,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,17 +1543,6 @@
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YPR060C-MONOMER_CHORISMATEMUT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006264> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1511,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1519,12 +1558,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1538,19 +1588,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002411_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1561,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,44 +1624,49 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_16567_PRTRANS-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' 'null' '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_null_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+] .
+
+<http://identifiers.org/sgd/S000005260>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1635,39 +1690,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_145989_2.5.1.19-RXN>
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000002534>
@@ -1682,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1695,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1706,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1717,34 +1770,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
-] .
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10814> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
+] .
 
 <http://purl.obolibrary.org/obo/GO_0003855>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1761,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1771,36 +1824,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
@@ -1808,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1822,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1830,17 +1883,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/CHORISMATEMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
@@ -1852,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1865,28 +1918,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CHORISMATEMUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
-] .
 
 <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -1897,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1907,19 +1943,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-KINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10814> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
@@ -1931,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1948,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1969,21 +2022,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IGPSYN-RXN>
+          <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
@@ -1995,7 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2022,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2035,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2084,29 +2137,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005260> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "prephenate dehydratase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2119,7 +2172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2133,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2144,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2159,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,36 +2222,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
@@ -2206,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2217,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2232,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2241,22 +2294,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
@@ -2264,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2276,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,33 +2341,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58394> ;
@@ -2327,13 +2378,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57145> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2344,7 +2412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2359,7 +2427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2379,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2392,19 +2460,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_43474_2.5.1.19-RXN>
 ] .
 
 <http://model.geneontology.org/2.5.1.19-RXN>
@@ -2426,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2439,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2454,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2474,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2489,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2498,20 +2566,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
+          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
@@ -2519,7 +2589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2530,9 +2600,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001694> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2541,7 +2620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2552,11 +2631,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IGPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
+] .
 
 <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
@@ -2565,32 +2661,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Protein57047> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' '(1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + L-serine &rarr; L-tryptophan + D-glyceraldehyde 3-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_null_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPSYN-RXN>
-] .
 
 <http://purl.obolibrary.org/obo/GO_0004640>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2614,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2628,7 +2705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2640,20 +2717,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
+          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
@@ -2661,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2679,7 +2758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2695,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2710,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2723,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2734,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2742,46 +2821,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
-] .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2792,7 +2872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2819,71 +2899,73 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -2891,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2907,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2920,7 +3002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2931,19 +3013,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2952,7 +3034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2972,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2984,39 +3066,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRAISOM-RXN>
+          <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -3024,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3038,7 +3118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3046,36 +3126,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
+          <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
+          <http://model.geneontology.org/RXN3O-4157>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
@@ -3083,7 +3163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3103,7 +3183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3118,7 +3198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3134,7 +3214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3142,19 +3222,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_ANTHRANSYN-RXN_location_lociGO_0005829>
@@ -3165,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3176,46 +3256,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -3223,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3238,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3248,19 +3326,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58315>
@@ -3271,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3282,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3294,7 +3372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3306,7 +3384,7 @@
 ] .
 
 <http://model.geneontology.org/RXN3O-4157>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016212> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3324,7 +3402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3333,20 +3411,22 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
+          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
@@ -3358,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3385,7 +3465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3398,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3409,44 +3489,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002411_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16567>
@@ -3457,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3468,7 +3550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3479,7 +3561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3487,19 +3569,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16567_PRTRANS-RXN>
+          <http://model.geneontology.org/RXN-10814>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
@@ -3507,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3519,7 +3601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3532,19 +3614,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
@@ -3556,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3576,7 +3675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3589,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3599,22 +3698,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
 ] .
 
 <http://model.geneontology.org/YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller>
@@ -3624,7 +3721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3641,7 +3738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3654,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3668,7 +3765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3676,19 +3773,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
+          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
 ] .
 
 <http://model.geneontology.org/CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
@@ -3700,7 +3797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3713,7 +3810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3724,51 +3821,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "tyr" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56717> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_145989> ;
@@ -3779,13 +3848,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57026> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "tyr" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56717> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
@@ -3794,7 +3891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3810,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3833,7 +3930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3847,7 +3944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3886,7 +3983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3903,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3916,7 +4013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3924,19 +4021,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
 ] .
 
 <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
@@ -3946,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3965,75 +4062,73 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -4041,7 +4136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4052,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4067,7 +4162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4080,27 +4175,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
@@ -4112,7 +4209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4125,39 +4222,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004665>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
@@ -4165,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4179,7 +4278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4190,7 +4289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4200,37 +4299,39 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_2.5.1.19-RXN>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
@@ -4238,7 +4339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4249,29 +4350,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
@@ -4279,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4298,7 +4397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4315,7 +4414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4325,19 +4424,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_null_COMPLETE-ARO-PWY-1>
@@ -4345,7 +4444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4359,7 +4458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4371,22 +4470,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
@@ -4398,7 +4495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4411,7 +4508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4426,7 +4523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4443,7 +4540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4456,7 +4553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4467,7 +4564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4478,36 +4575,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
+          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
+          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
@@ -4519,7 +4618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4539,7 +4638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4556,7 +4655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4573,7 +4672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of aromatic amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -4590,7 +4689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4602,22 +4701,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
@@ -4632,7 +4729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4645,7 +4742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4660,7 +4757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4672,22 +4769,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' 'null' '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
@@ -4698,7 +4793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4709,7 +4804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4717,36 +4812,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4757,7 +4852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4782,7 +4877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4799,7 +4894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4819,7 +4914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4829,27 +4924,30 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
+          <http://model.geneontology.org/2.6.1.58-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4860,7 +4958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4875,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4885,19 +4983,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller>
@@ -4907,13 +5005,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Protein57047> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
+] .
 
 <http://identifiers.org/sgd/S000001179>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4927,7 +5042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4944,7 +5059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4957,30 +5072,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
+          <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4988,20 +5100,57 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002411_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-4157>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
+          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
 ] .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32364> ;
@@ -5012,7 +5161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5029,7 +5178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5038,22 +5187,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_COMPLETE-ARO-PWY-1>
@@ -5061,27 +5208,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' 'null' '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
+          <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/PRAISOM-RXN>
@@ -5103,7 +5252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5116,7 +5265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5128,7 +5277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5141,19 +5290,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_30616_SHIKIMATE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
@@ -5161,7 +5310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5172,7 +5321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5180,19 +5329,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
@@ -5204,7 +5353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5231,7 +5380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5241,38 +5390,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29934_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
@@ -5284,7 +5431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5301,7 +5448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5318,7 +5465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5334,7 +5481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5345,46 +5492,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -5392,7 +5537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5407,7 +5552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5420,7 +5565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5431,7 +5576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5446,7 +5591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5460,7 +5605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5476,7 +5621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5487,7 +5632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5503,7 +5648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5516,7 +5661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5524,19 +5669,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
@@ -5548,7 +5693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5564,27 +5709,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
+          <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004425>
@@ -5598,19 +5745,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
+          <http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
@@ -5622,7 +5769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5635,7 +5782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5653,7 +5800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5669,11 +5816,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IGPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29934> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5684,30 +5850,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56665> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5718,7 +5867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5738,7 +5887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5766,7 +5915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5776,19 +5925,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -5796,44 +5945,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_null_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.5.1.19-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
+          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
@@ -5841,7 +5992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5859,7 +6010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5872,7 +6023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5887,7 +6038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5900,19 +6051,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
 ] .
 
 <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
@@ -5922,7 +6073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5936,7 +6087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5949,19 +6100,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58866>
@@ -5976,7 +6127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5986,38 +6137,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
@@ -6028,18 +6177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6047,27 +6185,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6078,29 +6227,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DAHPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
@@ -6108,7 +6255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6122,7 +6269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6133,7 +6280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6144,7 +6291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6159,7 +6306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6172,7 +6319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6185,7 +6332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6202,7 +6349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6218,7 +6365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6236,7 +6383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6246,19 +6393,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
 ] .
 
 <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
@@ -6268,7 +6415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6279,12 +6426,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IGPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6292,36 +6456,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_18005>
@@ -6336,7 +6483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6355,7 +6502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6368,20 +6515,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-KINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHORISMATEMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004106> ;
@@ -6402,24 +6560,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1BiochemicalReaction56776> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_SHIKIMATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -6430,7 +6577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6443,33 +6590,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0016212>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004106>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1>
@@ -6477,7 +6621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6485,40 +6629,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_RXN-10814_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-10814>
+          <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58394_3-DEHYDROQUINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/2.6.1.58-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0016212> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -6534,7 +6678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6549,7 +6693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6562,7 +6706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6573,7 +6717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6584,20 +6728,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "anthranilate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component> , <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6610,7 +6756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6618,19 +6764,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1>
@@ -6638,7 +6784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6649,7 +6795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6657,36 +6803,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16630_SHIKIMATE-5-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_null_COMPLETE-ARO-PWY-1>
@@ -6694,7 +6842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6709,7 +6857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6717,12 +6865,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000000892>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6733,7 +6884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6741,19 +6892,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_2.6.1.58-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.6.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -6778,7 +6929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6792,7 +6943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6808,7 +6959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6822,18 +6973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6858,7 +6998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6866,38 +7006,49 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002442>
@@ -6912,7 +7063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6922,17 +7073,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.5.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
+          <http://model.geneontology.org/CHEBI_145989_2.5.1.19-RXN>
 ] .

--- a/models/CYSTEINE-SYN2-PWY-CYSTEINE-SYN2-PWY.ttl
+++ b/models/CYSTEINE-SYN2-PWY-CYSTEINE-SYN2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "cysteine biosynthesis from homocysteine - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/DENOVOPURINE2-PWY-DENOVOPURINE2-PWY.ttl
+++ b/models/DENOVOPURINE2-PWY-DENOVOPURINE2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -158,19 +158,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58564>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,22 +192,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -216,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,36 +230,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
@@ -273,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,36 +281,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -321,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,19 +375,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
@@ -401,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,13 +499,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57378> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004643>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -527,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,12 +542,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -587,36 +614,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -627,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,20 +694,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -689,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,20 +730,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58457>
@@ -726,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,19 +770,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
+          <http://model.geneontology.org/a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
@@ -763,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -776,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -848,27 +879,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_DENOVOPURINE2-PWY>
@@ -876,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,41 +971,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
@@ -984,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,20 +1025,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-746>
@@ -1021,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,6 +1077,23 @@
           <http://model.geneontology.org/AIRCARBOXY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
@@ -1057,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,38 +1115,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
@@ -1106,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1118,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,19 +1160,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
@@ -1153,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1183,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1211,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1278,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1304,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1348,29 +1377,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1379,7 +1406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1406,19 +1433,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1427,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1462,36 +1489,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
@@ -1499,29 +1526,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FGAMSYN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
@@ -1533,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1543,28 +1568,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_8f0d3ceb-8efb-471f-becf-275c6d0f76ea_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1597,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8f0d3ceb-8efb-471f-becf-275c6d0f76ea_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY>
@@ -1580,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1595,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1612,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1625,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1675,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1683,19 +1708,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
@@ -1706,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1715,12 +1740,29 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1742,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1753,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1763,19 +1805,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
@@ -1787,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1800,44 +1842,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
+          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_DENOVOPURINE2-PWY>
@@ -1845,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1853,19 +1897,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1876,7 +1920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,17 +1931,6 @@
           <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_8f0d3ceb-8efb-471f-becf-275c6d0f76ea_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1907,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1924,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1933,20 +1966,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
+          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000003293>
@@ -1958,7 +1993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1975,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,9 +2030,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/fbc4232f-4a5c-4716-8da2-d3375d377062_GART-RXN> ;
+                <http://model.geneontology.org/edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/9bed507e-6d62-47fa-bb53-2f61ab2daaf0_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2005,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2013,21 +2048,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_fbc4232f-4a5c-4716-8da2-d3375d377062_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fbc4232f-4a5c-4716-8da2-d3375d377062_GART-RXN>
+          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
@@ -2037,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2052,7 +2090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2063,12 +2101,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_58681>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2103,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2120,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,11 +2192,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57913> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2154,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2171,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2184,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2192,19 +2264,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
@@ -2216,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2231,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2241,32 +2313,34 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
+          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2278,20 +2352,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2300,7 +2376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,68 +2392,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/36ec576b-ae74-41a1-a736-1496239b24cf_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_33695>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58681> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "5-phospho-&beta;-D-ribosylamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule58002> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2387,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2398,24 +2440,50 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58681> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "5-phospho-&beta;-D-ribosylamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule58002> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
+          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_DENOVOPURINE2-PWY>
@@ -2423,7 +2491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2431,38 +2499,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-746>
+          <http://model.geneontology.org/FGAMSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004424>
@@ -2477,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2492,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2505,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2520,7 +2588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2540,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2553,7 +2621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2566,7 +2634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2586,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2599,11 +2667,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004637> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2624,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2637,7 +2722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2648,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2663,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2686,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2713,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2723,19 +2808,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY>
@@ -2743,7 +2828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2755,7 +2840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2767,13 +2852,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanylate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2783,36 +2868,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2821,7 +2906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2848,37 +2933,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
-
-<http://model.geneontology.org/8f0d3ceb-8efb-471f-becf-275c6d0f76ea_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2888,7 +2956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2908,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,44 +2989,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/fbc4232f-4a5c-4716-8da2-d3375d377062_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2969,7 +3020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2999,7 +3050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3022,7 +3073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3035,18 +3086,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3060,20 +3114,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_fbc4232f-4a5c-4716-8da2-d3375d377062_GART-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3089,7 +3132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3106,7 +3149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3119,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3134,7 +3177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3154,7 +3197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3170,19 +3213,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3191,7 +3234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3204,19 +3247,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002411_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -3224,7 +3267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3232,19 +3275,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_GART-RXN>
@@ -3256,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3271,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3280,22 +3323,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_null_DENOVOPURINE2-PWY>
@@ -3303,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3314,19 +3355,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
+          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58467>
@@ -3338,7 +3379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3368,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3377,20 +3418,22 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
+          <http://model.geneontology.org/RXN0-746>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3399,7 +3442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3415,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3426,7 +3469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3434,19 +3477,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
 <http://geneontology.org/lego/evidence>
@@ -3457,7 +3500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3466,12 +3509,23 @@
 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3479,29 +3533,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
 <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3514,7 +3570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3529,7 +3585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3539,19 +3595,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -3559,18 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_9bed507e-6d62-47fa-bb53-2f61ab2daaf0_GART-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3585,7 +3630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3595,19 +3640,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -3622,7 +3667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3635,19 +3680,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY>
@@ -3655,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3667,7 +3712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3687,7 +3732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3704,7 +3749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3714,19 +3759,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
@@ -3749,7 +3794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3759,36 +3804,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -3800,7 +3845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3813,7 +3858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3824,7 +3869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3835,7 +3880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3850,7 +3895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3863,7 +3908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3876,7 +3921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3895,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3903,17 +3948,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
@@ -3927,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3944,7 +3989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3954,19 +3999,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004748>
@@ -3980,7 +4025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3999,19 +4044,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4022,7 +4067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4035,55 +4080,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DADPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -4091,7 +4136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4102,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4116,7 +4161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4124,19 +4169,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58475>
@@ -4148,7 +4193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4162,6 +4207,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58443>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4169,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4183,7 +4239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4199,7 +4255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4214,7 +4270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4227,7 +4283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4241,7 +4297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4250,12 +4306,29 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4270,7 +4343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4287,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4300,7 +4373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4325,7 +4398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4341,7 +4414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4366,7 +4439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4381,7 +4454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4394,7 +4467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4405,46 +4478,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AIRS-RXN>
+          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
@@ -4456,7 +4527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4470,7 +4541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4486,7 +4557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4501,7 +4572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4511,19 +4582,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4534,7 +4605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4554,7 +4625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4564,19 +4635,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
@@ -4588,7 +4659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4604,7 +4675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4612,19 +4683,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY>
@@ -4632,7 +4703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4647,7 +4718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4660,7 +4731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4675,7 +4746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4690,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4706,7 +4777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4727,7 +4798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4740,7 +4811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4751,7 +4822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4759,19 +4830,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_AICARSYN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -4779,7 +4850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4790,7 +4861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4798,53 +4869,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GART-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
@@ -4856,7 +4927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4869,7 +4940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4880,7 +4951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4890,22 +4961,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPKIN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_DENOVOPURINE2-PWY>
@@ -4913,7 +4982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4928,7 +4997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4942,7 +5011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4955,19 +5024,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
+          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
@@ -4979,7 +5048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4988,20 +5057,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
@@ -5009,7 +5080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5021,7 +5092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5037,7 +5108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5054,7 +5125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5065,7 +5136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5090,7 +5161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5107,7 +5178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5120,7 +5191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5135,7 +5206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5154,7 +5225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5168,7 +5239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5182,7 +5253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5200,7 +5271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5213,7 +5284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5227,7 +5298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5242,7 +5313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5258,19 +5329,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5279,7 +5350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5295,7 +5366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5306,7 +5377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5314,19 +5385,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -5334,7 +5405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5346,7 +5417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5359,36 +5430,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_DENOVOPURINE2-PWY>
@@ -5396,27 +5467,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
+          <http://model.geneontology.org/AIRS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY>
@@ -5424,7 +5497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5432,19 +5505,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
@@ -5456,7 +5529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5474,7 +5547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5501,7 +5574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5514,7 +5587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5525,7 +5598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5539,7 +5612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5550,7 +5623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5561,7 +5634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5569,19 +5642,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
 <http://model.geneontology.org/YLR359W-MONOMER_AMPSYN-RXN_controller>
@@ -5591,7 +5664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5611,7 +5684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5624,28 +5697,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_36ec576b-ae74-41a1-a736-1496239b24cf_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5653,43 +5726,41 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36ec576b-ae74-41a1-a736-1496239b24cf_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -5701,7 +5772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5711,36 +5782,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5749,7 +5822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5765,19 +5838,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5788,7 +5861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5805,7 +5878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5821,7 +5894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5832,7 +5905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5847,7 +5920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5860,11 +5933,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004644>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5874,7 +5964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5895,7 +5985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5908,7 +5998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5917,12 +6007,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5937,7 +6044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5953,7 +6060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5964,7 +6071,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5975,19 +6093,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -5995,7 +6113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6006,46 +6124,53 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6054,7 +6179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6070,7 +6195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6078,19 +6203,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6099,7 +6224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6119,7 +6244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6136,7 +6261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6146,19 +6271,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
+          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_137981>
@@ -6169,7 +6294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6177,19 +6302,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58426>
@@ -6197,19 +6322,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
+          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN>
@@ -6221,7 +6346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6234,7 +6359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6252,7 +6377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6265,7 +6390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6276,7 +6401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6287,7 +6412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6304,7 +6429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6320,7 +6445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6334,7 +6459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6345,7 +6470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6356,7 +6481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6371,7 +6496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6379,26 +6504,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
@@ -6410,7 +6544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6423,7 +6557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6437,7 +6571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6445,36 +6579,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
+          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
+          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_DENOVOPURINE2-PWY>
@@ -6482,40 +6618,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003563>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6524,7 +6661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6543,7 +6680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6554,44 +6691,49 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
+          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6606,7 +6748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6619,7 +6761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6631,7 +6773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6649,7 +6791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6666,7 +6808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6676,19 +6818,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY>
@@ -6696,7 +6838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6708,7 +6850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6728,7 +6870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6745,7 +6887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6758,7 +6900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6773,7 +6915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6781,12 +6923,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6799,7 +6952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6812,7 +6965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6823,7 +6976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6840,7 +6993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6854,7 +7007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6865,9 +7018,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -6880,7 +7042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6895,7 +7057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6908,7 +7070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6919,7 +7081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6930,7 +7092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6938,19 +7100,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6959,7 +7121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6975,7 +7137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6986,7 +7148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7001,7 +7163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7011,19 +7173,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -7045,7 +7207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7054,37 +7216,39 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
+          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 <http://identifiers.org/sgd/S000004915>
@@ -7095,7 +7259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7103,6 +7267,17 @@
 
 <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -7112,7 +7287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7120,19 +7295,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7141,7 +7316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7157,7 +7332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7171,19 +7346,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7194,7 +7369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7205,6 +7380,23 @@
           <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7214,7 +7406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7235,7 +7427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7248,7 +7440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7259,7 +7451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7274,7 +7466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7289,7 +7481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7302,7 +7494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7317,7 +7509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7330,7 +7522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7338,19 +7530,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
 ] .
 
 <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
@@ -7362,7 +7554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7378,7 +7570,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/AICARSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7389,7 +7611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7400,7 +7622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7408,19 +7630,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_DENOVOPURINE2-PWY>
@@ -7428,7 +7650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7439,19 +7661,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_15377_ADPREDUCT-RXN_SGD_DENOVOPURINE2-PWY>
@@ -7459,7 +7681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7467,19 +7689,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58426_GART-RXN>
@@ -7491,7 +7713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7508,7 +7730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7525,7 +7747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7534,20 +7756,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7556,7 +7780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7576,7 +7800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7589,29 +7813,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GART-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7620,7 +7842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7637,7 +7859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7657,7 +7879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7667,19 +7889,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
@@ -7687,7 +7909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7702,7 +7924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7722,7 +7944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7735,7 +7957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7746,7 +7968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7764,13 +7986,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57411> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004643> ;
@@ -7781,9 +8006,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> , <http://model.geneontology.org/36ec576b-ae74-41a1-a736-1496239b24cf_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/8f0d3ceb-8efb-471f-becf-275c6d0f76ea_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -7791,7 +8016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7799,15 +8024,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7822,7 +8044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7847,13 +8069,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYBiochemicalReaction57382> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003922> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7874,7 +8107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7884,19 +8117,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
 <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
@@ -7906,22 +8139,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY>
@@ -7929,7 +8160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7941,7 +8172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7956,22 +8187,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7980,7 +8209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7996,7 +8225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8004,36 +8233,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -8041,7 +8270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8049,27 +8278,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8077,19 +8317,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8098,7 +8338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8118,7 +8358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8131,7 +8371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8144,7 +8384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8161,7 +8401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8175,7 +8415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8191,7 +8431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8202,7 +8442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8217,7 +8457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8244,7 +8484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8257,18 +8497,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8279,7 +8536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8296,18 +8553,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8321,7 +8595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8339,7 +8613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8352,7 +8626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8360,19 +8634,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8381,7 +8655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8397,7 +8671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8408,19 +8682,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -8428,7 +8719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8436,28 +8727,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8470,19 +8744,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8491,7 +8765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8507,7 +8781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8522,7 +8796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8531,21 +8805,34 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/GART-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -8553,7 +8840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8569,7 +8856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8580,28 +8867,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/9bed507e-6d62-47fa-bb53-2f61ab2daaf0_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8612,7 +8882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8625,7 +8895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8636,7 +8906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8651,7 +8921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8664,7 +8934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8691,7 +8961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8718,7 +8988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8735,7 +9005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8748,7 +9018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8769,7 +9039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8782,7 +9052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8793,7 +9063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8804,7 +9074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8812,19 +9082,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
 
 <http://identifiers.org/sgd/S000002816>
@@ -8835,7 +9105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8850,7 +9120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8858,55 +9128,60 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000002862>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
+          <http://model.geneontology.org/edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -8914,27 +9189,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPREDUCT-RXN>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8943,7 +9220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8956,19 +9233,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY>
@@ -8976,7 +9253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8984,19 +9261,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_DENOVOPURINE2-PWY/DENOVOPURINE2-PWY_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DGDPKIN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE2-PWY>
@@ -9004,7 +9281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9016,7 +9293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9034,7 +9311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9047,7 +9324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9063,7 +9340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9076,46 +9353,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_36ec576b-ae74-41a1-a736-1496239b24cf_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9126,7 +9403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9144,7 +9421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9157,7 +9434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9165,36 +9442,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
@@ -9206,7 +9483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9224,23 +9501,32 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -9248,7 +9534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9278,7 +9564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9298,7 +9584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9311,29 +9597,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9342,7 +9626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9355,55 +9639,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_9bed507e-6d62-47fa-bb53-2f61ab2daaf0_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9bed507e-6d62-47fa-bb53-2f61ab2daaf0_GART-RXN>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_DENOVOPURINE2-PWY>
@@ -9411,7 +9693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9422,7 +9704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/DENOVOPURINE3-PWY-DENOVOPURINE3-PWY.ttl
+++ b/models/DENOVOPURINE3-PWY-DENOVOPURINE3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,19 +145,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58564>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,29 +205,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -236,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,19 +250,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_null_DENOVOPURINE3-PWY>
@@ -272,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -280,19 +278,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
@@ -304,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,36 +312,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002411_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/AIRCARBOXY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
@@ -355,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,29 +378,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002411_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/AIRCARBOXY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SAICARSYN-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -436,19 +434,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
@@ -460,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -556,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -571,13 +569,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45593> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004643>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -599,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,21 +614,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY>
@@ -629,18 +639,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -666,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,36 +703,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -716,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,20 +783,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -778,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,27 +823,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58457>
@@ -826,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,19 +870,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
+          <http://model.geneontology.org/14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
@@ -863,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -876,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,12 +933,29 @@
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
+<http://model.geneontology.org/14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -932,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -956,19 +1004,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
 ] .
 
 <http://model.geneontology.org/AICARSYN-RXN>
@@ -990,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,57 +1063,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/e45f2d3a-5e14-4608-a81d-4f6212f833a7_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DADPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -1073,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1088,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1101,21 +1132,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-746>
@@ -1127,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,17 +1185,6 @@
           <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_47a2a257-3606-4d22-9873-ab47b7409422_GART-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1174,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,38 +1204,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1224,7 +1242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,19 +1255,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
@@ -1259,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1273,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,6 +1302,23 @@
           <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
 ] .
 
+<http://model.geneontology.org/2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_456216_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1293,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,29 +1375,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -1374,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,21 +1446,32 @@
 <http://purl.obolibrary.org/obo/GO_0004019>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1425,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1444,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1452,20 +1507,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1473,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,23 +1550,12 @@
           <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1508,19 +1563,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
@@ -1528,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1536,38 +1591,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FGAMSYN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_AICARSYN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -1575,7 +1628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1611,28 +1664,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_42aa14f8-1d13-4793-894f-ce5b6786736d_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,7 +1693,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/42aa14f8-1d13-4793-894f-ce5b6786736d_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-745>
@@ -1652,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1665,7 +1718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1680,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1693,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1704,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1715,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1726,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1752,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,19 +1815,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DADPKIN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
@@ -1785,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1804,19 +1857,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
 <http://www.w3.org/2004/02/skos/core#note>
@@ -1827,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1849,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1857,19 +1910,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
@@ -1881,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1890,54 +1943,58 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
+          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPREDUCT-RXN>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1948,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1964,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1979,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1992,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2007,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,20 +2073,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
+          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000003293>
@@ -2041,7 +2100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2058,7 +2117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,6 +2128,9 @@
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/GART-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004644> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2078,9 +2140,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/dc9067e7-5957-4370-9eb5-87535592b5b3_GART-RXN> ;
+                <http://model.geneontology.org/2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/47a2a257-3606-4d22-9873-ab47b7409422_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2088,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2096,33 +2158,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_dc9067e7-5957-4370-9eb5-87535592b5b3_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dc9067e7-5957-4370-9eb5-87535592b5b3_GART-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
+] .
 
 <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001259> ;
@@ -2131,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2162,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2170,19 +2232,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY>
@@ -2190,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2225,7 +2287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2238,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2264,13 +2326,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45918> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/AICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58443_AICARSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58443> ;
@@ -2281,7 +2362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2294,7 +2375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2309,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2326,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2336,19 +2417,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
+          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
@@ -2360,7 +2441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2375,7 +2456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2385,19 +2466,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
+          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY>
@@ -2405,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2415,32 +2496,32 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2456,7 +2537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2468,7 +2549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2479,45 +2560,28 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_33695>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58681> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "5-phospho-&beta;-D-ribosylamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule46090> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2527,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2538,60 +2602,86 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58681> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "5-phospho-&beta;-D-ribosylamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule46090> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DADPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-746>
+          <http://model.geneontology.org/FGAMSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004424>
@@ -2606,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2621,7 +2711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,29 +2719,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/42aa14f8-1d13-4793-894f-ce5b6786736d_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2666,7 +2739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2686,7 +2759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2699,7 +2772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2710,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2723,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2743,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2756,35 +2829,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/47a2a257-3606-4d22-9873-ab47b7409422_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2795,7 +2851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2806,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2814,19 +2870,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+          <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
@@ -2848,7 +2904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2868,7 +2924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2881,7 +2937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2899,7 +2955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2926,7 +2982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2935,22 +2991,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2959,7 +3013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2971,13 +3025,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanylate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2987,36 +3041,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3025,7 +3079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3041,19 +3095,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_DENOVOPURINE3-PWY>
@@ -3061,7 +3115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3075,7 +3129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3095,7 +3149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3108,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3127,20 +3181,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3150,7 +3215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3160,17 +3225,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004639> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3191,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3214,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3227,18 +3281,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3249,7 +3306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3263,11 +3320,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -3281,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3298,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3311,7 +3385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3326,7 +3400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3346,7 +3420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3362,19 +3436,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3383,7 +3457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3395,37 +3469,39 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE3-PWY>
@@ -3433,7 +3509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3448,7 +3524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3463,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3472,22 +3548,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -3495,19 +3569,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_DENOVOPURINE3-PWY>
@@ -3515,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3530,7 +3604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3560,7 +3634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3573,7 +3647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3584,27 +3658,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
+          <http://model.geneontology.org/RXN0-746>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3613,7 +3689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3629,7 +3705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3640,7 +3716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3651,7 +3727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3662,29 +3738,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -3692,7 +3766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3701,21 +3775,38 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
 
 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
@@ -3726,7 +3817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3734,29 +3825,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3769,7 +3862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3784,7 +3877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3794,19 +3887,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
@@ -3818,7 +3911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3827,20 +3920,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -3855,7 +3950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3871,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3882,7 +3977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3890,19 +3985,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3911,7 +4006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3931,7 +4026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3948,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3960,22 +4055,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
@@ -3995,7 +4088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4008,7 +4101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4016,36 +4109,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -4057,7 +4150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4074,7 +4167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4087,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4098,7 +4191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4111,7 +4204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4124,7 +4217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4138,19 +4231,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
@@ -4162,7 +4255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4179,7 +4272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4196,7 +4289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4206,19 +4299,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004748>
@@ -4229,7 +4322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4243,7 +4336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4262,19 +4355,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4285,7 +4378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4298,55 +4391,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DADPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -4354,7 +4447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4365,7 +4458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4379,7 +4472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4390,7 +4483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4398,19 +4491,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-NH3-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58475>
@@ -4422,7 +4515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4438,7 +4531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4453,7 +4546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4464,12 +4557,23 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4480,7 +4584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4495,7 +4599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4508,7 +4612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4519,7 +4623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4535,19 +4639,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
@@ -4559,7 +4663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4576,7 +4680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4593,7 +4697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4606,7 +4710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4631,7 +4735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4639,12 +4743,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4658,7 +4779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4683,7 +4804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4698,7 +4819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4706,12 +4827,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4726,7 +4864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4739,46 +4877,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AIRS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
@@ -4790,7 +4909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4804,7 +4923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4824,7 +4943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4834,19 +4953,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4857,7 +4976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4877,7 +4996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4887,19 +5006,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4908,7 +5027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4927,7 +5046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4938,7 +5057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4946,19 +5065,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY>
@@ -4966,7 +5085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4981,7 +5100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4998,7 +5117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5013,7 +5132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5027,11 +5146,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_58115>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58115>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5042,7 +5178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5055,7 +5191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5066,7 +5202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5077,7 +5213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5088,7 +5224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5099,7 +5235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5107,20 +5243,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5139,7 +5286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5149,36 +5296,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -5186,7 +5333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5194,19 +5341,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
@@ -5218,7 +5365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5231,7 +5378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5242,19 +5389,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
@@ -5266,7 +5413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5280,7 +5427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5293,19 +5440,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
+          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
@@ -5317,7 +5464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5326,20 +5473,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY>
@@ -5347,7 +5496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5359,7 +5508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5381,7 +5530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5406,7 +5555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5419,7 +5568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5434,7 +5583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5451,7 +5600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5470,7 +5619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5481,7 +5630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5498,7 +5647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5509,7 +5658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5519,20 +5668,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000000070>
@@ -5543,7 +5694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5558,7 +5709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5574,7 +5725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5585,7 +5736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5599,7 +5750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5607,19 +5758,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_DENOVOPURINE3-PWY>
@@ -5627,7 +5778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5638,7 +5789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5650,7 +5801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5663,19 +5814,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
@@ -5683,7 +5834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5694,7 +5845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5706,7 +5857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5722,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5733,7 +5884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5741,81 +5892,72 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_dc9067e7-5957-4370-9eb5-87535592b5b3_GART-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
+          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/AIRS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
@@ -5826,7 +5968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5838,7 +5980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5856,7 +5998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5883,7 +6025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5899,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5910,9 +6052,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5921,7 +6074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5929,19 +6082,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
@@ -5952,7 +6105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5965,7 +6118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5985,7 +6138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5998,7 +6151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6009,7 +6162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6020,7 +6173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6031,28 +6184,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_e45f2d3a-5e14-4608-a81d-4f6212f833a7_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6060,43 +6213,41 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e45f2d3a-5e14-4608-a81d-4f6212f833a7_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -6108,7 +6259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6118,19 +6269,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -6138,7 +6289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6146,19 +6297,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6167,7 +6318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6186,7 +6337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6194,19 +6345,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6217,7 +6368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6237,7 +6388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of purine nucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6251,7 +6402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6267,7 +6418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6282,7 +6433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6295,7 +6446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6306,7 +6457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6330,7 +6481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6346,7 +6497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6354,19 +6505,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_DENOVOPURINE3-PWY>
@@ -6374,7 +6525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6385,7 +6536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6400,7 +6551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6413,11 +6564,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_61429>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6431,7 +6599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6444,19 +6612,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
+          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY>
@@ -6464,37 +6632,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6502,19 +6677,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6523,7 +6698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6539,7 +6714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6550,7 +6725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6558,19 +6733,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6579,7 +6754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6599,7 +6774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6616,7 +6791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6626,19 +6801,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_137981>
@@ -6649,7 +6824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6657,19 +6832,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58426>
@@ -6677,19 +6852,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
+          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN>
@@ -6701,7 +6876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6721,7 +6896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6734,7 +6909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6748,7 +6923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6770,7 +6945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6785,7 +6960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6805,7 +6980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6815,19 +6990,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
+          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
 <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
@@ -6839,7 +7014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6851,22 +7026,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_DENOVOPURINE3-PWY>
@@ -6874,57 +7047,51 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
+          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_42aa14f8-1d13-4793-894f-ce5b6786736d_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003563>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6932,19 +7099,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6953,7 +7120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6967,39 +7134,55 @@
 <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
+          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -7013,7 +7196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7026,7 +7209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7038,7 +7221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7056,7 +7239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7073,7 +7256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7083,19 +7266,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7104,7 +7287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7115,23 +7298,6 @@
           <http://model.geneontology.org/YGL234W-MONOMER_AIRS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/dc9067e7-5957-4370-9eb5-87535592b5b3_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7141,7 +7307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7158,7 +7324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7175,7 +7341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7192,7 +7358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -7205,7 +7371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7218,7 +7384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7231,7 +7397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7246,6 +7412,49 @@
 <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
+] .
+
+<http://model.geneontology.org/4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7255,7 +7464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7270,7 +7479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7283,7 +7492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7294,7 +7503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7305,7 +7514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7316,7 +7525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7327,7 +7536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7335,19 +7544,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7356,7 +7565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7372,7 +7581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7387,7 +7596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7397,19 +7606,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -7431,7 +7640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7441,39 +7650,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 <http://identifiers.org/sgd/S000004915>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
@@ -7484,7 +7695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7495,19 +7706,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_DENOVOPURINE3-PWY>
@@ -7515,7 +7726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7527,7 +7738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7543,7 +7754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7555,21 +7766,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_18413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7580,7 +7802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7600,7 +7822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7621,7 +7843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7634,7 +7856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7645,7 +7867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7660,7 +7882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7675,7 +7897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7688,7 +7910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7703,7 +7925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7716,27 +7938,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
+          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY>
@@ -7744,7 +7968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7759,7 +7983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7776,7 +8000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7789,19 +8013,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -7809,27 +8033,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_DENOVOPURINE3-PWY>
@@ -7837,7 +8074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7848,19 +8085,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_DENOVOPURINE3-PWY>
@@ -7868,7 +8105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7876,19 +8113,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
@@ -7900,7 +8137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7913,7 +8150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7928,7 +8165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7941,7 +8178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7956,7 +8193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7965,22 +8202,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPKIN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7989,7 +8224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8005,7 +8240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8020,7 +8255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8033,7 +8268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8044,29 +8279,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GART-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8075,7 +8308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8092,7 +8325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8112,7 +8345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8125,7 +8358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8133,19 +8366,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
@@ -8153,7 +8386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8168,7 +8401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8188,7 +8421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8201,7 +8434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8212,7 +8445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8223,7 +8456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8241,7 +8474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8261,9 +8494,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e45f2d3a-5e14-4608-a81d-4f6212f833a7_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/42aa14f8-1d13-4793-894f-ce5b6786736d_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -8271,7 +8504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8284,7 +8517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8295,7 +8528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8310,7 +8543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8335,7 +8568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8348,7 +8581,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8359,7 +8603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8370,7 +8614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8395,7 +8639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8408,7 +8652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8416,19 +8660,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
+          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
@@ -8439,7 +8683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8449,22 +8693,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8473,7 +8715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8489,7 +8731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8503,29 +8745,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8534,7 +8774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8550,7 +8790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8558,36 +8798,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_DENOVOPURINE3-PWY>
@@ -8595,7 +8835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8603,17 +8843,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
@@ -8623,7 +8863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8631,19 +8871,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -8651,18 +8891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_e45f2d3a-5e14-4608-a81d-4f6212f833a7_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8674,7 +8903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8694,7 +8923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8709,7 +8938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8726,7 +8955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8740,7 +8969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8751,6 +8980,17 @@
           <http://model.geneontology.org/CHEBI_456215_ADENYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8760,7 +9000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8787,7 +9027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8800,7 +9040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8814,17 +9054,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
@@ -8834,7 +9074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8855,7 +9095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8868,7 +9108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8876,19 +9116,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-NH3-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8897,7 +9137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8913,36 +9153,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8951,7 +9191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8963,20 +9203,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8985,7 +9227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9001,7 +9243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9016,7 +9258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9029,27 +9271,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_DENOVOPURINE3-PWY>
@@ -9057,7 +9301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9069,7 +9313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9080,6 +9324,17 @@
           <http://model.geneontology.org/CHEBI_58443_AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9089,7 +9344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9102,7 +9357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9117,13 +9372,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule46090> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004385> ;
@@ -9146,7 +9418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9173,7 +9445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9190,7 +9462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9213,7 +9485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9226,7 +9498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9237,7 +9509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9248,7 +9520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9256,19 +9528,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
+          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
 <http://identifiers.org/sgd/S000002816>
@@ -9283,7 +9555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9291,21 +9563,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000002862>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_DENOVOPURINE3-PWY>
@@ -9313,7 +9590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9321,36 +9598,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
+          <http://model.geneontology.org/2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY>
@@ -9358,7 +9635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9369,27 +9646,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9398,7 +9677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9414,7 +9693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9425,7 +9704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9433,36 +9712,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DGDPKIN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9471,7 +9750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9489,7 +9768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9502,7 +9781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9516,7 +9795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9529,7 +9808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9542,7 +9821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9553,7 +9832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9564,7 +9843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9572,19 +9851,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -9592,7 +9871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9603,7 +9882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9611,23 +9890,34 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+          <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
 <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -9638,7 +9928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9647,22 +9937,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
@@ -9670,7 +9958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9678,19 +9966,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
@@ -9702,7 +9990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9720,22 +10008,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ADENYL-KIN-RXN>
@@ -9757,7 +10043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9771,7 +10057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9787,7 +10073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9805,7 +10091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9814,22 +10100,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_DENOVOPURINE3-PWY>
@@ -9837,7 +10121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9849,7 +10133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9862,19 +10146,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_DENOVOPURINE3-PWY>
@@ -9882,44 +10183,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_47a2a257-3606-4d22-9873-ab47b7409422_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/47a2a257-3606-4d22-9873-ab47b7409422_GART-RXN>
+          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .

--- a/models/DETOX1-PWY-DETOX1-PWY.ttl
+++ b/models/DETOX1-PWY-DETOX1-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,20 +14,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-1642_SUPEROX-DISMUT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001050> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "mitochondrial superoxide dismutase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -136,6 +136,9 @@
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://identifiers.org/sgd/S000001050>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -149,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -288,20 +291,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000003865>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/MONOMER3O-1629_SUPEROX-DISMUT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003865> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "cytoplasmic superoxide dismutase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -361,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,9 +613,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -619,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -662,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -740,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superoxide radicals degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ERGOSTEROL-SYN-PWY-1-ERGOSTEROL-SYN-PWY-1.ttl
+++ b/models/ERGOSTEROL-SYN-PWY-1-ERGOSTEROL-SYN-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -53,26 +53,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59199> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/MONOMER3O-232_RXN3O-9828_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-22 sterol desaturase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59180> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -81,11 +66,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/MONOMER3O-232_RXN3O-9828_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004617> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "C-22 sterol desaturase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59180> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_87287_RXN3O-9822>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_87287> ;
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +137,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_1949_RXN66-314_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -148,20 +159,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_1949_RXN66-314_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,6 +444,23 @@
           <http://model.geneontology.org/RXN3O-9828> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57783_RXN3O-9828>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-178> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59789_RXN3O-178>
 ] .
 
 <http://model.geneontology.org/CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN>
@@ -455,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -466,29 +483,12 @@
 <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-178> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN3O-178>
-] .
-
 <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_IPPISOM-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,11 +513,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_d074e19c-8795-4044-a32f-b48795e82aa6_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +525,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d074e19c-8795-4044-a32f-b48795e82aa6_RXN3O-9825>
+          <http://model.geneontology.org/a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -536,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,28 +909,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/298bd7c7-0f47-4a64-a77d-682ff83b4fa0_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -938,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -976,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,9 +989,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> , <http://model.geneontology.org/d074e19c-8795-4044-a32f-b48795e82aa6_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/eb3515bd-1973-4f79-8b0a-309b0e71c4e7_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1016,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,7 +1037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,24 +1079,13 @@
           <http://model.geneontology.org/ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_null_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_298bd7c7-0f47-4a64-a77d-682ff83b4fa0_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,8 +1093,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/298bd7c7-0f47-4a64-a77d-682ff83b4fa0_RXN3O-9826>
+          <http://model.geneontology.org/3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_null_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1132,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1201,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1215,7 +1198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1241,13 +1224,13 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/MONOMER3O-188_RXN3O-178_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004467> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "SAM:C-24 sterol methyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,24 +1247,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_1ee99255-1bb8-4f31-884a-ddd69c02683f_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_136486_RXN66-313>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_136486> ;
@@ -1292,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,28 +1277,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/b4a569bf-68a5-4364-b74a-0199d4d76c59_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1334,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1374,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1503,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1514,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1531,7 +1486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1565,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1582,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1612,15 +1567,32 @@
           <http://model.geneontology.org/reaction_IPPISOM-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57288>
+<http://identifiers.org/sgd/S000004467>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-203_SGD_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-203> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17038_RXN3O-203>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN3O-9816_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1645,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1653,22 +1625,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-203_SGD_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-203> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17038_RXN3O-203>
-] .
+<http://purl.obolibrary.org/obo/CHEBI_57288>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1676,7 +1634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,6 +1643,23 @@
           <http://model.geneontology.org/RXN3O-9821> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9821>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58146_PHOSPHOMEVALONATE-KINASE-RXN>
@@ -1696,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,28 +1684,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9825>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
@@ -1741,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1755,7 +1713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1775,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,7 +1747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1822,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1837,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1850,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1906,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1925,18 +1883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_eb3515bd-1973-4f79-8b0a-309b0e71c4e7_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1947,7 +1894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1958,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1972,7 +1919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2000,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +1959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +1976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2049,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2062,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2096,7 +2043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,7 +2062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2132,7 +2079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2163,7 +2110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2193,7 +2140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2209,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2223,7 +2170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2240,7 +2187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,7 +2204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2277,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2296,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2258,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/643302e0-0228-4245-b8b5-0ed10f4e6681_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
+                <http://model.geneontology.org/feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2321,7 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2341,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2358,7 +2305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2377,7 +2324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,7 +2341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2417,7 +2364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2433,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2447,7 +2394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2473,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2486,7 +2433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2498,7 +2445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2521,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2535,7 +2482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2552,7 +2499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,7 +2515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2580,7 +2527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2600,7 +2547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2617,7 +2564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2634,7 +2581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2651,7 +2598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2667,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2679,7 +2626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2695,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2709,7 +2656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2724,7 +2671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2751,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2768,7 +2715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2794,7 +2741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2830,7 +2777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2842,7 +2789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,7 +2805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2869,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2889,7 +2836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2903,12 +2850,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_18249>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_15378_RXN66-319_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2933,7 +2897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2947,7 +2911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2967,7 +2931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2994,7 +2958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3013,7 +2977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3024,8 +2988,27 @@
           <http://model.geneontology.org/reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002411_RXN66-319_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002413_LANOSTEROL-SYNTHASE-RXN_null_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43074_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43074> ;
@@ -3036,35 +3019,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58634> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002413_LANOSTEROL-SYNTHASE-RXN_null_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002411_RXN66-319_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3078,7 +3039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3092,7 +3053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3110,7 +3071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3127,7 +3088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3141,7 +3102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3161,7 +3122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3169,12 +3130,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3186,7 +3158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,27 +3169,22 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9828>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_null_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ERGOSTEROL-SYN-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3225,7 +3192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3236,13 +3203,24 @@
           <http://model.geneontology.org/ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_null_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3258,7 +3236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3273,7 +3251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3286,7 +3264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3301,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3318,7 +3296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3334,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3363,7 +3341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3400,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3413,7 +3391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3421,6 +3399,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57623>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -3431,7 +3426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3445,7 +3440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3465,7 +3460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3481,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3495,7 +3490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3507,7 +3502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3524,7 +3519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3560,7 +3555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3574,7 +3569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3594,7 +3589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3610,7 +3605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3621,7 +3616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3633,7 +3628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3649,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3657,11 +3652,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_1ee99255-1bb8-4f31-884a-ddd69c02683f_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3669,7 +3664,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1ee99255-1bb8-4f31-884a-ddd69c02683f_RXN3O-9826>
+          <http://model.geneontology.org/fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3678,7 +3673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3697,7 +3692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3711,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3723,7 +3718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3739,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3754,7 +3749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,7 +3765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3788,7 +3783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3805,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3821,7 +3816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3832,7 +3827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3844,7 +3839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,7 +3862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3883,7 +3878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3894,7 +3889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +3904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +3921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3942,7 +3937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3963,7 +3958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3990,7 +3985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4006,7 +4001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,7 +4017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4034,7 +4029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4051,7 +4046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4070,7 +4065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4089,7 +4084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4106,7 +4101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4126,7 +4121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4143,7 +4138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4161,7 +4156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4176,7 +4171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4190,7 +4185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4201,30 +4196,13 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9821>
 ] .
 
-<http://model.geneontology.org/d074e19c-8795-4044-a32f-b48795e82aa6_RXN3O-9825>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4244,7 +4222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4261,7 +4239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4278,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4305,7 +4283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4318,7 +4296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4332,7 +4310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4347,7 +4325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4361,7 +4339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4378,7 +4356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4401,7 +4379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4417,7 +4395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4428,20 +4406,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4451,7 +4418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4462,22 +4429,16 @@
           <http://model.geneontology.org/MONOMER3O-232_RXN3O-9828_controller>
 ] .
 
-<http://model.geneontology.org/643302e0-0228-4245-b8b5-0ed10f4e6681_RXN66-318>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9816>
         a       <http://purl.obolibrary.org/obo/GO_0004506> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4498,7 +4459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4512,7 +4473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4529,7 +4490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4551,7 +4512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4571,7 +4532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4587,7 +4548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4599,7 +4560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4616,7 +4577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4633,7 +4594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4653,7 +4614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4666,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4678,7 +4639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4694,7 +4655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4705,7 +4666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4716,7 +4677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4739,7 +4700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4752,26 +4713,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-4 sterol methyl oxidase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58955> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN3O-9827>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -4782,13 +4728,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58591> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "C-4 sterol methyl oxidase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58955> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller>
         a       <http://identifiers.org/sgd/S000003292> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4797,7 +4758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4824,7 +4785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4839,7 +4800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4852,7 +4813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4863,18 +4824,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_PHOSPHOMEVALONATE-KINASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4889,7 +4850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4897,23 +4858,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_PHOSPHOMEVALONATE-KINASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4927,7 +4888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4948,7 +4909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4962,7 +4923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4978,7 +4939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4993,7 +4954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5013,7 +4974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5026,7 +4987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5040,7 +5001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5057,7 +5018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5080,7 +5041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5096,7 +5057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5107,6 +5068,17 @@
           <http://model.geneontology.org/RXN66-313>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0008398>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5116,7 +5088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5146,7 +5118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5163,7 +5135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5177,7 +5149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5194,7 +5166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5210,7 +5182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5222,7 +5194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5252,7 +5224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5269,7 +5241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5283,7 +5255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5299,7 +5271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5311,7 +5283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5331,7 +5303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5339,23 +5311,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_b4a569bf-68a5-4364-b74a-0199d4d76c59_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5366,7 +5327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5378,7 +5339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5389,6 +5350,17 @@
           <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5398,7 +5370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5411,7 +5383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5429,7 +5401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5445,7 +5417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5460,7 +5432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5477,7 +5449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5493,7 +5465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5505,7 +5477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5521,7 +5493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5532,7 +5504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5547,7 +5519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5561,7 +5533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5583,7 +5555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5595,7 +5567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5611,7 +5583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5628,7 +5600,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b4a569bf-68a5-4364-b74a-0199d4d76c59_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5636,7 +5608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5650,7 +5622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5666,7 +5638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5677,7 +5649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5691,7 +5663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5702,13 +5674,24 @@
           <http://model.geneontology.org/IPPISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5725,7 +5708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5742,7 +5725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5758,7 +5741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5770,7 +5753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5790,7 +5773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5803,7 +5786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5818,7 +5801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5838,7 +5821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5851,7 +5834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5866,7 +5849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5879,7 +5862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5903,7 +5886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5916,7 +5899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5929,7 +5912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5942,7 +5925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5959,7 +5942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5992,7 +5975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6005,7 +5988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6016,7 +5999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6028,7 +6011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6044,7 +6027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6055,7 +6038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6069,7 +6052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6085,7 +6068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6096,7 +6079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6107,7 +6090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6132,7 +6115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6146,7 +6129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6162,7 +6145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6174,7 +6157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6191,7 +6174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6207,7 +6190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6218,7 +6201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6226,11 +6209,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_b4a569bf-68a5-4364-b74a-0199d4d76c59_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6238,7 +6221,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b4a569bf-68a5-4364-b74a-0199d4d76c59_RXN3O-9824>
+          <http://model.geneontology.org/94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -6250,7 +6233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6270,7 +6253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6289,7 +6272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6306,7 +6289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6323,7 +6306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6343,24 +6326,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58886> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_d074e19c-8795-4044-a32f-b48795e82aa6_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9824>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6371,7 +6343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6384,7 +6356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6395,7 +6367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6409,7 +6381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6420,7 +6392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6433,7 +6405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6449,7 +6421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6470,7 +6442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6486,7 +6458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6500,7 +6472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6518,7 +6490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6535,7 +6507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6548,7 +6520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6563,7 +6535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6580,7 +6552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6588,39 +6560,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YMR202W-MONOMER_RXN3O-203_controller>
-        a       <http://identifiers.org/sgd/S000004815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-8 sterol isomerase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59245> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6631,12 +6577,38 @@
           <http://model.geneontology.org/CHEBI_136486_RXN66-313>
 ] .
 
+<http://model.geneontology.org/YMR202W-MONOMER_RXN3O-203_controller>
+        a       <http://identifiers.org/sgd/S000004815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "C-8 sterol isomerase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59245> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6648,7 +6620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6664,7 +6636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6675,7 +6647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6686,7 +6658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6697,7 +6669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6708,7 +6680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6720,7 +6692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6736,7 +6708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6750,7 +6722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6766,7 +6738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6777,7 +6749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6792,7 +6764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6806,7 +6778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6822,7 +6794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6836,7 +6808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6853,7 +6825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6870,7 +6842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6887,7 +6859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6905,7 +6877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6919,7 +6891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6939,7 +6911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6953,7 +6925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6976,7 +6948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6989,7 +6961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7004,7 +6976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7017,7 +6989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7028,7 +7000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7039,7 +7011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7051,7 +7023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7071,7 +7043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7087,7 +7059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7098,7 +7070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7110,7 +7082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7128,7 +7100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7145,7 +7117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7165,7 +7137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7178,7 +7150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7189,7 +7161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7201,7 +7173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7217,28 +7189,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/1ee99255-1bb8-4f31-884a-ddd69c02683f_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7248,7 +7203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7267,7 +7222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7279,7 +7234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7299,7 +7254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7313,7 +7268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7330,7 +7285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7349,7 +7304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7366,7 +7321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7382,7 +7337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7394,7 +7349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7414,7 +7369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7431,7 +7386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7445,7 +7400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7461,7 +7416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7476,7 +7431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7498,7 +7453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7509,12 +7464,15 @@
           <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000004617>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7525,18 +7483,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7551,7 +7526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7564,7 +7539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7575,7 +7550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7586,7 +7561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7597,7 +7572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7608,7 +7583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7619,7 +7594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7634,7 +7609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7651,7 +7626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7671,28 +7646,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule59124> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/eb3515bd-1973-4f79-8b0a-309b0e71c4e7_RXN3O-9825>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -7702,7 +7660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7718,7 +7676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7729,7 +7687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7744,7 +7702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7757,7 +7715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7768,7 +7726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7779,7 +7737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7790,7 +7748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7802,7 +7760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7818,7 +7776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7833,9 +7791,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1ee99255-1bb8-4f31-884a-ddd69c02683f_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/298bd7c7-0f47-4a64-a77d-682ff83b4fa0_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
+                <http://model.geneontology.org/3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7843,7 +7801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7857,7 +7815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7874,7 +7832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7891,7 +7849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7907,7 +7865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7920,7 +7878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7934,7 +7892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7953,7 +7911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7973,7 +7931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7989,7 +7947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8005,7 +7963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8019,7 +7977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8036,7 +7994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8056,7 +8014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8073,7 +8031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8086,7 +8044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8101,7 +8059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8117,7 +8075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8137,7 +8095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8150,7 +8108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8168,7 +8126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8185,7 +8143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8212,7 +8170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8225,7 +8183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8236,7 +8194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8248,7 +8206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8267,7 +8225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8285,7 +8243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8299,7 +8257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8315,7 +8273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8327,7 +8285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8344,7 +8302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8364,7 +8322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8377,7 +8335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8391,7 +8349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8402,13 +8360,16 @@
           <http://model.geneontology.org/RXN3O-9825>
 ] .
 
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_IPPISOM-RXN_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8419,9 +8380,6 @@
           <http://model.geneontology.org/CHEBI_128769_IPPISOM-RXN>
 ] .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004821> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -8429,13 +8387,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
         a       <http://identifiers.org/sgd/S000002969> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8444,7 +8413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8457,7 +8426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8472,7 +8441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8499,7 +8468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8513,7 +8482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8530,7 +8499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8550,7 +8519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8564,7 +8533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8584,7 +8553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8597,7 +8566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8612,7 +8581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8632,7 +8601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8645,7 +8614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8657,7 +8626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8673,7 +8642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8688,7 +8657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8715,7 +8684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8728,7 +8697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8743,7 +8712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8759,7 +8728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8770,7 +8739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8781,7 +8750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8792,7 +8761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8803,7 +8772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8818,7 +8787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8832,7 +8801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8851,7 +8820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8863,7 +8832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8879,7 +8848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8892,7 +8861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8902,11 +8871,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_643302e0-0228-4245-b8b5-0ed10f4e6681_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8914,7 +8883,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/643302e0-0228-4245-b8b5-0ed10f4e6681_RXN66-318>
+          <http://model.geneontology.org/feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
@@ -8922,7 +8891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8933,18 +8902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8959,7 +8917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8976,7 +8934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8984,13 +8942,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9009,7 +8978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9029,7 +8998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9046,7 +9015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9060,7 +9029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9077,7 +9046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9097,7 +9066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9111,7 +9080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9128,7 +9097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9145,7 +9114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9168,7 +9137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9181,7 +9150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9192,7 +9161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9204,7 +9173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9224,7 +9193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9238,7 +9207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9258,7 +9227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9271,7 +9240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9282,7 +9251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9297,7 +9266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9324,7 +9293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9341,7 +9310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9358,7 +9327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9372,7 +9341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9388,7 +9357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9403,7 +9372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9416,7 +9385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9427,7 +9396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9439,7 +9408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9450,23 +9419,23 @@
           <http://model.geneontology.org/CHEBI_29888_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9481,7 +9450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9494,7 +9463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9506,7 +9475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9536,7 +9505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9549,7 +9518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9561,7 +9530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9577,7 +9546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9593,7 +9562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9607,7 +9576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9624,7 +9593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9635,17 +9604,6 @@
           <http://model.geneontology.org/CHEBI_57856_RXN3O-178>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_298bd7c7-0f47-4a64-a77d-682ff83b4fa0_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -9654,7 +9612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9670,7 +9628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9688,7 +9646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9701,7 +9659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9709,11 +9667,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_eb3515bd-1973-4f79-8b0a-309b0e71c4e7_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9721,7 +9679,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eb3515bd-1973-4f79-8b0a-309b0e71c4e7_RXN3O-9825>
+          <http://model.geneontology.org/0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9730,7 +9688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9746,7 +9704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9761,7 +9719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9778,7 +9736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9792,7 +9750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9809,7 +9767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9829,7 +9787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9846,7 +9804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9862,7 +9820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9885,7 +9843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9899,7 +9857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9918,7 +9876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9932,7 +9890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9943,7 +9901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9954,7 +9912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9969,7 +9927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9996,7 +9954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10023,7 +9981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10036,7 +9994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10052,7 +10010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10066,7 +10024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10084,7 +10042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10099,7 +10057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10116,7 +10074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10134,7 +10092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10148,7 +10106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10164,7 +10122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10179,7 +10137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -10192,7 +10150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10203,7 +10161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10228,7 +10186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10241,7 +10199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10256,7 +10214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10276,7 +10234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10290,7 +10248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10309,7 +10267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10321,7 +10279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10343,7 +10301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10363,11 +10321,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58832> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -10377,7 +10352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10388,6 +10363,17 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9828>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_null_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -10396,7 +10382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10407,24 +10393,13 @@
           <http://model.geneontology.org/reaction_RXN3O-178_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_null_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10440,7 +10415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10455,7 +10430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10474,7 +10449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10484,23 +10459,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GPPSYN-RXN>
 ] .
-
-<http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004337> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10521,13 +10479,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction58739> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN66-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -10538,7 +10513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10551,7 +10526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10566,7 +10541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10580,7 +10555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10599,7 +10574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10611,6 +10586,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15441_LANOSTEROL-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15441> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10620,7 +10606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10636,7 +10622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10656,7 +10642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10672,7 +10658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10687,7 +10673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10703,7 +10689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10715,7 +10701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10737,7 +10723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10751,7 +10737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10765,7 +10751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10783,7 +10769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10797,7 +10783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10813,7 +10799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10841,7 +10827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10857,7 +10843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10876,7 +10862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10892,7 +10878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10906,7 +10892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10923,7 +10909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10940,7 +10926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10956,7 +10942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10967,7 +10953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10978,7 +10964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10993,7 +10979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11007,7 +10993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11024,7 +11010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11040,7 +11026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11051,7 +11037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11062,7 +11048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11076,7 +11062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11087,7 +11073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11098,7 +11084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11113,7 +11099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11126,7 +11112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11141,7 +11127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11156,7 +11142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11173,7 +11159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11189,7 +11175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11204,7 +11190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11221,7 +11207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11235,7 +11221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11251,7 +11237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11268,7 +11254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11280,7 +11266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11310,7 +11296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11327,7 +11313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11344,7 +11330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11360,7 +11346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11371,7 +11357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11382,7 +11368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11394,7 +11380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11411,7 +11397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11428,7 +11414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11448,7 +11434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11467,7 +11453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11487,7 +11473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11504,7 +11490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11523,7 +11509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11535,7 +11521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11555,7 +11541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11568,7 +11554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11583,7 +11569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11599,18 +11585,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_null_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11624,7 +11627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11638,7 +11641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11657,7 +11660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11668,7 +11671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11683,7 +11686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11700,7 +11703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11717,7 +11720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11733,7 +11736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11748,7 +11751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11761,7 +11764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11772,7 +11775,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11786,7 +11800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11805,7 +11819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11825,7 +11839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11841,7 +11855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11861,7 +11875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11875,7 +11889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11896,7 +11910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11909,7 +11923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11921,7 +11935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11937,7 +11951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11949,7 +11963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11969,7 +11983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11982,7 +11996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11994,7 +12008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12005,24 +12019,13 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9827>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_643302e0-0228-4245-b8b5-0ed10f4e6681_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12039,7 +12042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12055,7 +12058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/FASYN-ELONG2-PWY-FASYN-ELONG2-PWY.ttl
+++ b/models/FASYN-ELONG2-PWY-FASYN-ELONG2-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -173,15 +173,12 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004321>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -563,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -583,7 +580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid elongation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -617,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -656,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -769,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -817,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -892,14 +889,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004321> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004315> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 2,3,4-saturated fatty acyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; acyl-carrier protein + a 3-oxoacyl-[acp] + CO<SUB>2</SUB>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -917,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1043,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1058,7 +1055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1075,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1095,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1206,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1245,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1276,7 +1273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1303,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1329,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1356,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,17 +1378,6 @@
           <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1400,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,6 +1397,17 @@
           <http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1418,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,14 +1476,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 2,3,4-saturated fatty acyl-[acp] + NADP<sup>+</sup> &larr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1504,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1512,11 +1509,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://purl.obolibrary.org/obo/GO_0008659>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1527,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1585,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1603,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1612,7 +1609,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1630,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1644,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1679,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1692,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1707,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,7 +1718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1764,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1808,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1820,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1851,13 +1848,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FASYN-ELONG2-PWYSmallMolecule21187> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004315>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1920,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1929,7 +1929,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-9780>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1947,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,7 +1961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +1978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2011,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2027,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2058,7 +2058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2094,7 +2094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,7 +2110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2122,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2153,7 +2153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2170,7 +2170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,7 +2192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2226,7 +2226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2263,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2277,7 +2277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2293,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/FOLSYN-PWY-1-FOLSYN-PWY-1.ttl
+++ b/models/FOLSYN-PWY-1-FOLSYN-PWY-1.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,25 +72,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/GO_0046820>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_5c89f5cb-6bda-4538-9b3c-786c3ff58a47_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5c89f5cb-6bda-4538-9b3c-786c3ff58a47_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0046820>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -104,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,56 +129,56 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_731be01c-7291-47d4-b9c0-52f33851d0e3_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/731be01c-7291-47d4-b9c0-52f33851d0e3_DIHYDROFOLATEREDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
-] .
-
-<http://model.geneontology.org/79a898b6-b881-4673-832e-9a5291c4d2b0_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+                "a 7,8-dihydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1.5.1.15-RXN>
+] .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -171,44 +188,49 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
+          <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -216,19 +238,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
@@ -240,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,15 +270,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -275,36 +311,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GCVMULTI-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
@@ -315,44 +351,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -367,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,50 +438,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_403b0286-4b00-4353-add1-cb4c6eeda386_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/403b0286-4b00-4353-add1-cb4c6eeda386_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9789> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789>
+] .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003848> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -464,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,12 +508,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -499,36 +535,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
@@ -540,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,13 +593,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000004801>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -573,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -595,58 +634,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_77625292-c91e-4cd0-a8e5-e1e37c0ed5ba_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/77625292-c91e-4cd0-a8e5-e1e37c0ed5ba_1.5.1.15-RXN>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_10fc02e2-a72c-4a37-92aa-8927bc46254a_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -657,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,37 +693,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -707,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -715,38 +752,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GCVMULTI-RXN>
+          <http://model.geneontology.org/d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
@@ -754,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -765,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -796,12 +831,54 @@
 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
+        a       <http://identifiers.org/sgd/S000001788> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -809,19 +886,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_a779bd8f-a290-40a1-b670-dad2492c3ebd_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a779bd8f-a290-40a1-b670-dad2492c3ebd_RXN3O-9789>
+          <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
@@ -831,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,36 +924,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
@@ -884,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -895,44 +974,76 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_33384>
+<http://purl.obolibrary.org/obo/GO_0004150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0004487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_33384>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -941,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -955,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,22 +1077,59 @@
           <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0004487>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -990,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,51 +1148,62 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
-] .
 
 <http://model.geneontology.org/ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008696> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1065,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,23 +1232,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_403b0286-4b00-4353-add1-cb4c6eeda386_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1103,19 +1251,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_10fc02e2-a72c-4a37-92aa-8927bc46254a_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/10fc02e2-a72c-4a37-92aa-8927bc46254a_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -1127,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,19 +1302,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
@@ -1174,44 +1322,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/10fc02e2-a72c-4a37-92aa-8927bc46254a_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_246422>
@@ -1219,19 +1355,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_FOLSYN-PWY-1>
@@ -1239,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1250,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1258,30 +1411,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1296,9 +1446,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> , <http://model.geneontology.org/5c89f5cb-6bda-4538-9b3c-786c3ff58a47_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/79a898b6-b881-4673-832e-9a5291c4d2b0_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1306,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1319,29 +1469,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_1882331c-ca66-4ef0-8ad2-fd4c37f32fc5_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,39 +1507,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1408,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1433,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1444,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1452,19 +1594,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -1476,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1510,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1523,20 +1665,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1549,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1560,19 +1730,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1583,7 +1753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1607,44 +1777,57 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1666,17 +1849,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004329> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1684,9 +1884,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/97ab9c65-84e3-4583-b85b-70b363dd58a2_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/10fc02e2-a72c-4a37-92aa-8927bc46254a_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1694,7 +1894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1706,22 +1906,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
@@ -1729,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1737,19 +1935,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/THYMIDYLATESYN-RXN>
@@ -1761,9 +1959,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/64f2729e-af89-41c9-b968-a800b8d0d378_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bdb69692-6a89-4769-8978-eef46b2be8f4_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1771,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1787,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1813,13 +2011,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60143> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005200>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1843,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1851,32 +2060,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/a779bd8f-a290-40a1-b670-dad2492c3ebd_RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,36 +2107,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
@@ -1945,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,46 +2164,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2015,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,18 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_52f7eca5-0d90-450d-926a-07f8a11b109c_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2047,91 +2248,61 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/731be01c-7291-47d4-b9c0-52f33851d0e3_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_64f2729e-af89-41c9-b968-a800b8d0d378_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2142,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2153,47 +2324,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
-
-<http://model.geneontology.org/97ab9c65-84e3-4583-b85b-70b363dd58a2_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0008696>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2218,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2231,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2259,378 +2411,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_b7ebe3dc-387e-46fb-b572-bd23be8484a5_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
-] .
-
-<http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59789> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_52f7eca5-0d90-450d-926a-07f8a11b109c_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/52f7eca5-0d90-450d-926a-07f8a11b109c_METHENYLTHFCYCLOHYDRO-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-] .
-
-<http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/52f7eca5-0d90-450d-926a-07f8a11b109c_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/69bdb889-9804-46fd-9fde-180daa71563c_METHENYLTHFCYCLOHYDRO-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction60086> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/5c89f5cb-6bda-4538-9b3c-786c3ff58a47_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADCLY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58762> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "7,8-dihydroneopterin 3'-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60427> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0003934>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59789> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_63528>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17001>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2638,7 +2423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2657,7 +2442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2668,91 +2453,63 @@
           <http://model.geneontology.org/ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_79a898b6-b881-4673-832e-9a5291c4d2b0_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "thymidylate synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Complex60078> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59884> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59789> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1>
+<http://model.geneontology.org/ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2781,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2792,30 +2549,32 @@
           <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_77625292-c91e-4cd0-a8e5-e1e37c0ed5ba_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002411>
+                <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000003499>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction60086> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2823,7 +2582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2835,43 +2594,57 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/ADCLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58762> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "7,8-dihydroneopterin 3'-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60427> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2879,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2892,19 +2665,441 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0003934>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59789> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_63528>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_17001>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PABASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "thymidylate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Complex60078> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
+] .
+
+<http://identifiers.org/sgd/S000003499>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PABASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29748_PABASYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
@@ -2912,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2920,6 +3115,23 @@
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2929,28 +3141,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
-] .
 
 <http://purl.obolibrary.org/obo/CHEBI_73083>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2964,7 +3159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2972,12 +3167,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2989,7 +3201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2999,23 +3211,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
 ] .
-
-<http://model.geneontology.org/64f2729e-af89-41c9-b968-a800b8d0d378_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17839>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3027,7 +3222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3037,53 +3232,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_64f2729e-af89-41c9-b968-a800b8d0d378_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/64f2729e-af89-41c9-b968-a800b8d0d378_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/52f7eca5-0d90-450d-926a-07f8a11b109c_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
@@ -3091,63 +3269,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ea77d7fb-f95e-4ff9-8a52-d79c7343e57d_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_null_FOLSYN-PWY-1>
@@ -3155,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3170,7 +3331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3178,19 +3339,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_731be01c-7291-47d4-b9c0-52f33851d0e3_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58462> ;
@@ -3201,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3212,12 +3373,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3231,7 +3403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3242,43 +3414,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/83d77982-3c29-4143-8670-6885b03f2199_RXN3O-9789>
+<http://model.geneontology.org/61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3287,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3302,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3310,67 +3484,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29748_PABASYN-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/bdb69692-6a89-4769-8978-eef46b2be8f4_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+] .
 
-<http://model.geneontology.org/0c5feed5-6e3e-4b46-9e0a-e200514422c2_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
         a       <http://identifiers.org/sgd/S000004719> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3379,7 +3530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3392,7 +3543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3407,7 +3558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of tetrahydrofolate biosynthesis and salvage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3424,7 +3575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3433,22 +3584,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
@@ -3456,7 +3605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3464,19 +3613,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17001_H2NEOPTERINALDOL-RXN>
+          <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
@@ -3486,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3503,7 +3652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3511,12 +3660,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3524,27 +3673,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
+          <http://model.geneontology.org/33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3552,17 +3701,6 @@
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0c5feed5-6e3e-4b46-9e0a-e200514422c2_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3575,7 +3713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3585,60 +3723,56 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_83d77982-3c29-4143-8670-6885b03f2199_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/83d77982-3c29-4143-8670-6885b03f2199_RXN3O-9789>
+          <http://model.geneontology.org/71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_46b3f22b-6f21-4d3d-893c-550f2581200c_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9789> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000004801> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3647,11 +3781,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17071> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3662,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3672,38 +3823,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/GLYOHMETRANS-RXN>
@@ -3715,9 +3866,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/46b3f22b-6f21-4d3d-893c-550f2581200c_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/403b0286-4b00-4353-add1-cb4c6eeda386_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3725,13 +3876,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction59994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3742,7 +3904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3752,69 +3914,58 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_46b3f22b-6f21-4d3d-893c-550f2581200c_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/46b3f22b-6f21-4d3d-893c-550f2581200c_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0004489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004489>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_69bdb889-9804-46fd-9fde-180daa71563c_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3822,19 +3973,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
@@ -3842,47 +3993,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN>
 ] .
-
-<http://model.geneontology.org/69bdb889-9804-46fd-9fde-180daa71563c_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3892,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3907,7 +4039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3919,30 +4051,49 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "aminodeoxychorismate lyase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3951,48 +4102,69 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-I-RXN>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
+
+<http://model.geneontology.org/71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_79a898b6-b881-4673-832e-9a5291c4d2b0_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/79a898b6-b881-4673-832e-9a5291c4d2b0_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58762>
@@ -4007,7 +4179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4017,19 +4189,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0c5feed5-6e3e-4b46-9e0a-e200514422c2_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0c5feed5-6e3e-4b46-9e0a-e200514422c2_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
@@ -4041,7 +4213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4049,24 +4221,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000005600>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_17001_H2NEOPTERINALDOL-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4077,7 +4272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4090,7 +4285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4104,7 +4299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4119,7 +4314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4129,38 +4324,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_ea77d7fb-f95e-4ff9-8a52-d79c7343e57d_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ea77d7fb-f95e-4ff9-8a52-d79c7343e57d_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/PABASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
 ] .
 
 <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
@@ -4170,7 +4363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4181,57 +4374,49 @@
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/77625292-c91e-4cd0-a8e5-e1e37c0ed5ba_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
-] .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004146>
@@ -4249,9 +4434,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b7ebe3dc-387e-46fb-b572-bd23be8484a5_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/77625292-c91e-4cd0-a8e5-e1e37c0ed5ba_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4259,7 +4444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4271,20 +4456,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4293,7 +4480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4309,7 +4496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4320,14 +4507,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN>
+] .
 
 <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -4341,7 +4542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4349,40 +4550,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
-] .
+<http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
 ] .
 
 <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN>
@@ -4404,7 +4589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4412,19 +4597,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_13390>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_13390>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -4435,7 +4637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4448,46 +4650,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
@@ -4495,7 +4689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4513,7 +4707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4523,27 +4717,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4556,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4569,7 +4774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4580,7 +4785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4595,7 +4800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4615,7 +4820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4626,6 +4831,9 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000001788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/RXN3O-9789>
         a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4635,15 +4843,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/a779bd8f-a290-40a1-b670-dad2492c3ebd_RXN3O-9789> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/83d77982-3c29-4143-8670-6885b03f2199_RXN3O-9789> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4653,19 +4861,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_FOLSYN-PWY-1>
@@ -4673,46 +4898,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
+          <http://model.geneontology.org/RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
@@ -4720,11 +4943,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -4735,7 +4975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4748,7 +4988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4759,7 +4999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4767,36 +5007,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
+          <http://model.geneontology.org/CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -4807,7 +5047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4818,7 +5058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4829,19 +5069,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
+          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
@@ -4862,7 +5102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4879,7 +5119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4889,73 +5129,60 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
+          <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_69bdb889-9804-46fd-9fde-180daa71563c_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/69bdb889-9804-46fd-9fde-180daa71563c_METHENYLTHFCYCLOHYDRO-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
@@ -4967,13 +5194,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59789> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -4983,7 +5227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4998,7 +5242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5011,7 +5255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5022,7 +5266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5030,38 +5274,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_97ab9c65-84e3-4583-b85b-70b363dd58a2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5072,7 +5305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5083,7 +5316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5091,55 +5324,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_83d77982-3c29-4143-8670-6885b03f2199_RXN3O-9789_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5152,7 +5374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5162,44 +5384,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9789>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
-
-<http://model.geneontology.org/403b0286-4b00-4353-add1-cb4c6eeda386_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5213,7 +5418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5227,7 +5432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5238,7 +5443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5251,7 +5456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5261,36 +5466,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_b7ebe3dc-387e-46fb-b572-bd23be8484a5_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b7ebe3dc-387e-46fb-b572-bd23be8484a5_1.5.1.15-RXN>
+          <http://model.geneontology.org/f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
@@ -5302,7 +5507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5313,49 +5518,38 @@
 <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_ea77d7fb-f95e-4ff9-8a52-d79c7343e57d_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -5365,7 +5559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5382,7 +5576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5409,7 +5603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5422,84 +5616,75 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
-] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+          <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
 ] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_5c89f5cb-6bda-4538-9b3c-786c3ff58a47_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5510,7 +5695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5523,7 +5708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5531,36 +5716,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_RXN3O-9789>
+          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PABASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
@@ -5568,7 +5753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5576,36 +5761,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_73083_H2PTEROATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1>
@@ -5613,7 +5809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5628,7 +5824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5645,7 +5841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5658,7 +5854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5670,7 +5866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5686,7 +5882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5697,19 +5893,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_bdb69692-6a89-4769-8978-eef46b2be8f4_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bdb69692-6a89-4769-8978-eef46b2be8f4_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_FOLSYN-PWY-1>
@@ -5717,7 +5913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5732,7 +5928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5749,7 +5945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5766,7 +5962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5774,38 +5970,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/46b3f22b-6f21-4d3d-893c-550f2581200c_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_97ab9c65-84e3-4583-b85b-70b363dd58a2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/97ab9c65-84e3-4583-b85b-70b363dd58a2_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN>
@@ -5817,7 +5996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5837,9 +6016,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/1882331c-ca66-4ef0-8ad2-fd4c37f32fc5_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/ea77d7fb-f95e-4ff9-8a52-d79c7343e57d_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5847,7 +6026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5856,23 +6035,38 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -5881,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5896,7 +6090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5906,23 +6100,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_29748>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_29748>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58406> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5933,7 +6144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5952,7 +6163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5960,36 +6171,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PABASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
@@ -6001,9 +6195,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/731be01c-7291-47d4-b9c0-52f33851d0e3_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/0c5feed5-6e3e-4b46-9e0a-e200514422c2_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -6011,13 +6205,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction60166> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58406> ;
@@ -6028,7 +6256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6045,7 +6273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6053,56 +6281,53 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/b7ebe3dc-387e-46fb-b572-bd23be8484a5_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_73083_H2PTEROATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
+          <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -6112,7 +6337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6123,19 +6348,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_1882331c-ca66-4ef0-8ad2-fd4c37f32fc5_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1882331c-ca66-4ef0-8ad2-fd4c37f32fc5_GCVMULTI-RXN>
+          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_FOLSYN-PWY-1>
@@ -6143,7 +6368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6154,7 +6379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6162,36 +6387,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller>
+          <http://model.geneontology.org/CHEBI_13392_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
@@ -6211,7 +6436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6222,51 +6447,12 @@
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_bdb69692-6a89-4769-8978-eef46b2be8f4_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_a779bd8f-a290-40a1-b670-dad2492c3ebd_RXN3O-9789_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6277,7 +6463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6287,23 +6473,47 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
+
+<http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6316,27 +6526,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
@@ -6346,7 +6558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6361,7 +6573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6378,7 +6590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6390,10 +6602,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6406,7 +6620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6421,7 +6635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6434,7 +6648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6442,19 +6656,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+          <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
@@ -6462,7 +6676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6473,7 +6687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6493,7 +6707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6508,7 +6722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6525,7 +6739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6537,37 +6751,39 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
@@ -6575,61 +6791,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
-
-<http://model.geneontology.org/1882331c-ca66-4ef0-8ad2-fd4c37f32fc5_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6654,7 +6864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6671,7 +6881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6681,36 +6891,66 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
+          <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
 ] .
 
 <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
@@ -6722,7 +6962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6730,29 +6970,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6763,7 +6986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6778,7 +7001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6795,7 +7018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6807,39 +7030,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
+          <http://model.geneontology.org/2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PABASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
@@ -6847,7 +7068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6858,7 +7079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6866,55 +7087,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINALDOL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
@@ -6926,7 +7145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6934,11 +7153,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004329>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0004329>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
         a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6947,7 +7166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6955,31 +7174,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "NAD-dependent 5,10-methylenetetrahydrafolate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6987,16 +7219,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:FOLSYN-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -7007,7 +7245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7020,7 +7258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7032,7 +7270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7048,7 +7286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7063,7 +7301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7076,7 +7314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7089,7 +7327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7102,7 +7340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7110,36 +7348,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
+          <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
@@ -7147,7 +7385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7159,40 +7397,40 @@
 <http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
-] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7207,7 +7445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7220,7 +7458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7231,7 +7469,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLNSYN-PWY-GLNSYN-PWY.ttl
+++ b/models/GLNSYN-PWY-GLNSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,7 +228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -478,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/GLUCFERMEN-PWY-GLUCFERMEN-PWY.ttl
+++ b/models/GLUCFERMEN-PWY-GLUCFERMEN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16,39 +16,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'pyruvate + ATP &larr; phospho<i>enol</i>pyruvate + ADP + H<SUP>+</SUP>' 'null' 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15378_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-6161>
+          <http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -57,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,82 +67,86 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+          <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58289_3PGAREARR-RXN>
 ] .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004818>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+] .
 
 <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-274> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
-] .
 
 <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001635> ;
@@ -153,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -185,19 +187,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GLUCOKIN-RXN>
+          <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -205,19 +207,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
@@ -229,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,20 +240,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/F16ALDOLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLUCFERMEN-PWY>
@@ -259,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -334,36 +338,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_57642_TRIOSEPISOMERIZATION-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YER073W-MONOMER_RXN3O-274_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-274> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YER073W-MONOMER_RXN3O-274_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57642_TRIOSEPISOMERIZATION-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+          <http://model.geneontology.org/CHEBI_58272_RXN-15513>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_4170>
@@ -378,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -406,6 +410,17 @@
 <http://purl.obolibrary.org/obo/GO_0004396>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN3O-274_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
         a       <http://identifiers.org/sgd/S000003486> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -413,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,47 +438,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_30616_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
+          <http://model.geneontology.org/GLUCOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/YGL253W-MONOMER_GLUCOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN3O-274_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
@@ -475,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -554,44 +560,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YOR374W-MONOMER_RXN3O-274_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
+          <http://model.geneontology.org/RXN3O-274> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
+          <http://model.geneontology.org/YOR374W-MONOMER_RXN3O-274_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YER073W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_GLUCFERMEN-PWY>
@@ -599,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,22 +634,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_57540_ALDHDEHYDROG-RXN_SGD_GLUCFERMEN-PWY>
@@ -649,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,36 +708,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3PGAREARR-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58289_3PGAREARR-RXN>
+          <http://model.geneontology.org/CHEBI_57540_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLUCFERMEN-PWY>
@@ -739,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -799,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,34 +818,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
+          <http://model.geneontology.org/CHEBI_15378_RXN-6161>
 ] .
 
 <http://identifiers.org/sgd/S000000036>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_4167_GLUCOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_4167> ;
@@ -850,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,12 +853,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -874,9 +880,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+        a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -902,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -914,22 +929,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/F16ALDOLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57634_6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_GLUCFERMEN-PWY>
@@ -937,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,36 +987,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YER073W-MONOMER_RXN3O-274_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_13390_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-274> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER073W-MONOMER_RXN3O-274_controller>
+          <http://model.geneontology.org/CHEBI_13390_RXN3O-274>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_RXN-15513_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_RXN-15513>
+          <http://model.geneontology.org/RXN-15513>
 ] .
 
 <http://model.geneontology.org/CHEBI_57642_TRIOSEPISOMERIZATION-RXN>
@@ -1015,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1042,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1083,19 +1096,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL253W-MONOMER_GLUCOKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_GLUCOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
@@ -1107,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,46 +1150,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN>
+          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005446>
@@ -1190,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1198,19 +1209,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002411_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLUCFERMEN-PWY>
@@ -1218,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1226,19 +1237,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_456216_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_456216_PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY>
@@ -1246,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1291,19 +1302,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1312,7 +1323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,20 +1339,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58272_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+          <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_58272_3PGAREARR-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
         a       <http://identifiers.org/sgd/S000005982> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1350,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,23 +1380,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1387,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,44 +1424,55 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALCOHOL-DEHYDROG-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ALCOHOL-DEHYDROG-RXN>
+] .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000066_reaction_RXN3O-274_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-274> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-274_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
+          <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1460,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1482,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1490,19 +1512,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4167_GLUCOKIN-RXN>
+          <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
@@ -1512,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1525,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1536,33 +1558,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32966_6PFRUCTPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32966> ;
@@ -1573,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,19 +1618,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-6161>
+          <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
@@ -1613,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1629,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1656,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1671,30 +1700,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36910> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15378_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32966> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1705,7 +1717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1714,42 +1726,72 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-glucopyranose + ATP &rarr; D-glucopyranose 6-phosphate + ADP + H<SUP>+</SUP>' 'null' 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002413_PGLUCISOM-RXN_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PGLUCISOM-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002411_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,36 +1816,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002411_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004030>
@@ -1814,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1839,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1869,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1886,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1901,21 +1943,34 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1929,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1946,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,36 +2011,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58272_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3PGAREARR-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_3PGAREARR-RXN>
+          <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
@@ -1997,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2010,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2019,13 +2074,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_58289>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component>
+        a       <http://identifiers.org/sgd/S000003472> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_29067_ALDHDEHYDROG-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,51 +2111,38 @@
           <http://model.geneontology.org/CHEBI_29067_ALDHDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALCOHOL-DEHYDROG-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALCOHOL-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCFERMEN-PWY>
@@ -2088,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,7 +2199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2145,19 +2207,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY>
@@ -2165,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2196,7 +2258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2207,7 +2269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2218,7 +2280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2229,7 +2291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2268,29 +2330,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/F16BDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_6PFRUCTPHOS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001949>
@@ -2301,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2312,7 +2372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2320,23 +2380,6 @@
 
 <http://identifiers.org/sgd/S000003222>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YOR374W-MONOMER_RXN3O-274_controller_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-274> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR374W-MONOMER_RXN3O-274_controller>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2347,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2357,19 +2400,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
+          <http://model.geneontology.org/RXN3O-274> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
+          <http://model.geneontology.org/CHEBI_15343_RXN3O-274>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3PGAREARR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000066_reaction_RXN3O-274_location_lociGO_0005829_null_GLUCFERMEN-PWY>
@@ -2377,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2395,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2412,7 +2472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2429,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2438,22 +2498,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-glucopyranose + ATP &rarr; D-glucopyranose 6-phosphate + ADP + H<SUP>+</SUP>' 'null' 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002413_PGLUCISOM-RXN_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PGLUCISOM-RXN>
+          <http://model.geneontology.org/CHEBI_4170_GLUCOKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_RXN-15513_SGD_GLUCFERMEN-PWY>
@@ -2461,7 +2519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2473,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2489,19 +2547,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16236_ALCOHOL-DEHYDROG-RXN>
@@ -2513,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2529,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2540,19 +2615,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_null_GLUCFERMEN-PWY>
@@ -2560,29 +2635,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_58702_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58702_PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY>
@@ -2590,7 +2663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2601,27 +2674,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
@@ -2631,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2650,7 +2725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2663,19 +2738,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+          <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/YKL152C-MONOMER_3PGAREARR-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLUCFERMEN-PWY>
@@ -2683,7 +2758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2697,7 +2772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2708,37 +2783,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_13390_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDHDEHYDROG-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-274> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN3O-274>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_RXN-15513_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ALDHDEHYDROG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-15513>
+          <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/6PFRUCTPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003872> ;
@@ -2759,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2772,36 +2850,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002411_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLUCOKIN-RXN>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+          <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
@@ -2809,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2820,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2828,36 +2906,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-274> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN3O-274>
+          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
@@ -2869,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2886,7 +2964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2899,19 +2977,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2920,7 +2998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2950,7 +3028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2960,36 +3038,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_456216_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/YFR053C-MONOMER_GLUCOKIN-RXN_controller>
@@ -2999,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3012,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3030,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3043,44 +3123,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
+          <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -3091,7 +3175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3129,19 +3213,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002411_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3PGAREARR-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL152C-MONOMER_3PGAREARR-RXN_controller>
+          <http://model.geneontology.org/PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/GLUCFERMEN-PWY>
@@ -3153,7 +3237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glucose fermentation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3169,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3185,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3202,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3215,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3223,36 +3307,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDHDEHYDROG-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALDHDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN-6161>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY>
@@ -3260,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3275,7 +3359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3302,7 +3386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3320,7 +3404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,19 +3414,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002411_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/YOR374W-MONOMER_RXN3O-274_controller>
@@ -3352,7 +3436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3369,7 +3453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3382,19 +3466,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_32966_6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15343_ALCOHOL-DEHYDROG-RXN>
@@ -3406,7 +3490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3421,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3434,7 +3518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3445,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3472,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3482,57 +3566,71 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15377_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
+          <http://model.geneontology.org/RXN3O-274> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-274>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
+
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
+          <http://model.geneontology.org/GLUCOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
         a       <http://identifiers.org/sgd/S000001217> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3541,7 +3639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3555,7 +3653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3571,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3584,7 +3682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3597,7 +3695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3608,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3623,7 +3721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3632,22 +3730,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_6PFRUCTPHOS-RXN>
@@ -3659,13 +3755,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36966> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
+] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3675,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3685,20 +3798,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57634>
@@ -3709,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3720,7 +3835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3728,19 +3843,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
+          <http://model.geneontology.org/YAL038W-MONOMER_PEPDEPHOS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
@@ -3752,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3770,7 +3885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3783,7 +3898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3794,19 +3909,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GLUCOKIN-RXN>
@@ -3818,7 +3933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3826,14 +3941,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000004818_CPLX3O-77_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004818> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3850,7 +3976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3863,7 +3989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3882,7 +4008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3895,7 +4021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3910,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3924,7 +4050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3940,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3951,7 +4077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3966,7 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3976,19 +4102,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3PGAREARR-RXN>
+          <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15378_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY>
@@ -3996,7 +4122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4007,7 +4133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4021,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4032,7 +4158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4043,36 +4169,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4170_GLUCOKIN-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY>
@@ -4080,7 +4206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4088,36 +4214,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' 'acetaldehyde + NAD(P)<sup>+</sup> + H<sub>2</sub>O &rarr; acetate + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15377_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-274> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-274>
+          <http://model.geneontology.org/RXN3O-274>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15377_RXN3O-274_SGD_GLUCFERMEN-PWY>
@@ -4125,7 +4253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4136,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4147,7 +4275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4168,7 +4296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4178,19 +4306,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN-6161>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YER073W-MONOMER_RXN3O-274_controller_SGD_GLUCFERMEN-PWY>
@@ -4198,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4210,7 +4338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4226,41 +4354,54 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16236>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YMR170C-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_58702_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_GLUCFERMEN-PWY>
@@ -4268,7 +4409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4283,7 +4424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4291,32 +4432,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YMR170C-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829>
@@ -4327,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4341,7 +4471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4352,7 +4482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4367,7 +4497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4376,58 +4506,54 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_F16BDEPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_59776_TRIOSEPISOMERIZATION-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAL038W-MONOMER_PEPDEPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15361_PEPDEPHOS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004780>
@@ -4441,7 +4567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4467,7 +4593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4477,19 +4603,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
@@ -4504,7 +4630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4519,7 +4645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4536,7 +4662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4550,7 +4676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4566,19 +4692,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_58272_RXN-15513>
@@ -4590,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4607,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4620,7 +4746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4631,7 +4757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4654,7 +4780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4664,36 +4790,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -4708,7 +4834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4721,19 +4847,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
@@ -4747,7 +4873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4757,22 +4883,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_456216_6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY>
@@ -4780,7 +4904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4792,7 +4916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4808,7 +4932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4833,7 +4957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4849,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4859,39 +4983,39 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_13392_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-274> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_13392_RXN3O-274>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4902,18 +5026,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4924,7 +5057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4937,7 +5070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4945,56 +5078,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5005,7 +5136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5013,36 +5144,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_F16BDEPHOS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002411_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PEPDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ALCOHOL-DEHYDROG-RXN>
@@ -5054,7 +5202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5067,7 +5215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5082,7 +5230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5090,14 +5238,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR347C-MONOMER_PEPDEPHOS-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5105,23 +5283,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5129,19 +5296,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
+          <http://model.geneontology.org/YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ALDHDEHYDROG-RXN>
@@ -5161,7 +5328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5174,44 +5341,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3PGAREARR-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_null_GLUCFERMEN-PWY>
@@ -5219,7 +5388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5230,7 +5399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5243,10 +5412,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5259,26 +5430,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aldehyde dehydrogenase (minor mitochondrial)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5286,7 +5442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5316,7 +5472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5324,38 +5480,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aldehyde dehydrogenase (minor mitochondrial)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
+          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_13392_RXN3O-274>
@@ -5367,7 +5540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5380,44 +5553,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
+          <http://model.geneontology.org/reaction_GLUCOKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
@@ -5429,7 +5606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5442,19 +5619,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/SGD_S000004818_CPLX3O-77_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
@@ -5462,7 +5639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5470,19 +5647,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_13392_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-274> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_RXN3O-274>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_4170_GLUCOKIN-RXN>
@@ -5494,7 +5671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5507,7 +5684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5519,7 +5696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5539,13 +5716,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37096> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000003472>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15343_RXN3O-274>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
@@ -5556,7 +5736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5569,19 +5749,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
+          <http://model.geneontology.org/CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
@@ -5591,7 +5771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5604,7 +5784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5615,19 +5795,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_57642_TRIOSEPISOMERIZATION-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_57642_TRIOSEPISOMERIZATION-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY>
@@ -5635,7 +5815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5651,7 +5831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5668,7 +5848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5678,19 +5858,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_30616_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR347C-MONOMER_PEPDEPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_32966>
@@ -5701,29 +5881,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_58702_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY>
@@ -5731,7 +5909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5745,7 +5923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5757,7 +5935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5769,20 +5947,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+          <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+          <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_29067_ALDHDEHYDROG-RXN>
@@ -5794,7 +5974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5811,16 +5991,24 @@
 <http://purl.obolibrary.org/obo/GO_0004618>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
+] .
 
 <http://model.geneontology.org/YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller>
         a       <http://identifiers.org/sgd/S000005901> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5829,7 +6017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5838,22 +6026,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' 'acetaldehyde + NAD(P)<sup>+</sup> + H<sub>2</sub>O &rarr; acetate + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-274>
+          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002411_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY>
@@ -5861,28 +6047,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5899,7 +6079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -5912,29 +6092,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLUCOKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_GLUCFERMEN-PWY>
@@ -5942,7 +6120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5954,7 +6132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5967,565 +6145,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000003225>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_TRIOSEPISOMERIZATION-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_30089_RXN3O-274_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37296> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37096> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_16526_RXN-6161>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37042> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_PEPDEPHOS-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_30089>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphofructokinase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYComplex37312> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004365>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16BDEPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36989> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37296> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_null_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
-] .
-
-<http://model.geneontology.org/CHEBI_15377_RXN3O-274>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37096> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3PGAREARR-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
-] .
-
-<http://identifiers.org/sgd/S000001543>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58289_RXN-15513>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58289> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-phospho-D-glycerate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37243> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0004347>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YAL038W-MONOMER_PEPDEPHOS-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000036> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate kinase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37472> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_57540_ALDHDEHYDROG-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ALDHDEHYDROG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_ALDHDEHYDROG-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_RXN-15513_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001217>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_29067>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUCOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6536,84 +6160,19 @@
           <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/YER073W-MONOMER_ALDHDEHYDROG-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aldehyde dehydrogenase (minor mitochondrial)" ;
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_57540_ALCOHOL-DEHYDROG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36866> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000545> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glucokinase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37008> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
-] .
-
-<http://model.geneontology.org/YER073W-MONOMER_RXN3O-274_controller>
-        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aldehyde dehydrogenase (minor mitochondrial)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+<http://identifiers.org/sgd/S000003225>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6621,7 +6180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6638,7 +6197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6647,6 +6206,647 @@
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58289_RXN-15513>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_30089_RXN3O-274_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37296> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37096> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_16526_RXN-6161>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37042> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YFR053C-MONOMER_GLUCOKIN-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_30089>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphofructokinase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component> , <http://model.geneontology.org/SGD_S000004818_CPLX3O-77_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYComplex37312> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004365>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_null_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36989> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37296> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_null_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'pyruvate + ATP &larr; phospho<i>enol</i>pyruvate + ADP + H<SUP>+</SUP>' 'null' 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_null_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-6161>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
+] .
+
+<http://model.geneontology.org/CHEBI_15377_RXN3O-274>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37096> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
+] .
+
+<http://identifiers.org/sgd/S000001543>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58289_RXN-15513>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58289> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-phospho-D-glycerate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37243> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004347>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YAL038W-MONOMER_PEPDEPHOS-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000036> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate kinase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37472> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_57540_ALDHDEHYDROG-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ALDHDEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_ALDHDEHYDROG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+] .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_RXN-15513_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001217>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_29067>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_GLUCOKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_6PFRUCTPHOS-RXN>
+] .
+
+<http://model.geneontology.org/YER073W-MONOMER_ALDHDEHYDROG-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aldehyde dehydrogenase (minor mitochondrial)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_57540_ALCOHOL-DEHYDROG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36866> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000545> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glucokinase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37008> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+] .
+
+<http://model.geneontology.org/YER073W-MONOMER_RXN3O-274_controller>
+        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aldehyde dehydrogenase (minor mitochondrial)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000066_reaction_RXN3O-274_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-274> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-274_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004022>
@@ -6661,7 +6861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6677,7 +6877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6685,19 +6885,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YFR053C-MONOMER_GLUCOKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_4167_GLUCOKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -6709,7 +6909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6723,12 +6923,23 @@
 <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6739,7 +6950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6750,7 +6961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6758,38 +6969,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_null_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_GLUCFERMEN-PWY>
@@ -6797,7 +7008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6811,7 +7022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6834,7 +7045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6844,19 +7055,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
@@ -6864,7 +7075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6889,7 +7100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6904,7 +7115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLUCONEO-PWY-1-GLUCONEO-PWY-1.ttl
+++ b/models/GLUCONEO-PWY-1-GLUCONEO-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17,19 +17,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002411_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.1.1.39-RXN>
+          <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -45,29 +45,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_30616_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PEPCARBOXYKIN-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "peroxisome malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,20 +78,22 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_57540_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1>
@@ -97,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -114,27 +118,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_15361_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000066_reaction_1.1.1.39-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_1.1.1.39-RXN>
+          <http://model.geneontology.org/reaction_1.1.1.39-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
@@ -144,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,29 +163,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1>
@@ -187,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,19 +229,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
@@ -249,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -273,19 +277,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_4170>
@@ -293,19 +297,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -316,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,19 +343,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/2PGADEHYDRAT-RXN>
@@ -373,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -394,19 +398,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008948>
@@ -417,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,27 +460,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
+          <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_PEPCARBOXYKIN-RXN>
@@ -488,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -509,19 +515,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/CHEBI_58702_PEPCARBOXYKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1>
@@ -529,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -540,19 +546,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002411_PGLUCISOM-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/PGLUCISOM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1>
@@ -560,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -651,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,29 +708,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002411_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1>
@@ -732,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,19 +761,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
@@ -781,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,44 +795,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002411_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/F16BDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
+
+<http://identifiers.org/sgd/S000001568>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -881,29 +888,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + ATP &rarr; CO<SUB>2</SUB> + phospho<i>enol</i>pyruvate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_PEPCARBOXYKIN-RXN_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PEPCARBOXYKIN-RXN>
+          <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000003486>
@@ -914,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -925,44 +930,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_16526_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000066_reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PEPCARBOXYKIN-RXN>
+          <http://model.geneontology.org/reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_F16BDEPHOS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001635>
@@ -973,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,19 +1006,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_16526_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_15589_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_1.1.1.39-RXN>
+          <http://model.geneontology.org/CHEBI_15589_1.1.1.39-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1019,36 +1026,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
@@ -1063,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,19 +1086,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002411_RXN-15513_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-15513>
+          <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
@@ -1103,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1127,46 +1134,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
@@ -1178,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1188,19 +1193,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLUCONEO-PWY-1>
@@ -1208,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1219,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1243,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1260,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,22 +1274,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' 'null' '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_PHOSGLYPHOS-RXN_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_RXN-15513_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_58289_RXN-15513>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1>
@@ -1292,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1304,19 +1307,28 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005486> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57634> ;
@@ -1327,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1343,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1353,10 +1365,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "mitochondrial malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,22 +1379,20 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002333_YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1>
@@ -1388,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1410,19 +1422,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_16526_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1>
@@ -1430,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1438,19 +1450,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.39-RXN> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/CHEBI_58272_RXN-15513>
 ] .
 
 <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
@@ -1475,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1488,19 +1500,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1>
@@ -1508,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1522,27 +1534,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002411_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1>
@@ -1550,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1561,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1583,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1598,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1607,20 +1621,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &rarr; CO<SUB>2</SUB> + pyruvate + NADH' 'null' 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002413_PYRUVATE-CARBOXYLASE-RXN_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000400>
@@ -1635,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1652,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1661,59 +1677,59 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
+          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1>
@@ -1721,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1738,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1749,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1763,19 +1779,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1>
@@ -1783,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1791,19 +1807,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_456216_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_16452_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PEPCARBOXYKIN-RXN>
+          <http://model.geneontology.org/CHEBI_16452_PEPCARBOXYKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_GLUCONEO-PWY-1>
@@ -1811,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1825,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1843,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1853,19 +1869,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1>
@@ -1873,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1901,20 +1917,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_57945_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_57540_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.1.1.39-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.1.1.39-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
+        a       <http://identifiers.org/sgd/S000001568> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MALATE-DEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030060> ;
@@ -1935,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1945,36 +1973,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
@@ -1986,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2001,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2017,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2025,36 +2053,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1>
@@ -2062,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2073,29 +2118,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + ATP &rarr; CO<SUB>2</SUB> + phospho<i>enol</i>pyruvate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_PEPCARBOXYKIN-RXN_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PEPCARBOXYKIN-RXN>
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004634>
@@ -2106,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2137,7 +2180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2154,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2189,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2202,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2213,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2227,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2257,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2270,29 +2313,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000066_reaction_1.1.1.39-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.39-RXN> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.1.1.39-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
@@ -2304,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2329,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2342,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2353,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2376,36 +2417,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
@@ -2417,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2432,7 +2473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2453,19 +2494,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_PEPCARBOXYKIN-RXN>
@@ -2477,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2490,7 +2531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2498,38 +2539,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
@@ -2539,7 +2578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2549,19 +2588,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2579,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2592,7 +2631,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2602,22 +2652,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002411_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
+          <http://model.geneontology.org/1.1.1.39-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
@@ -2629,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2645,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2656,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2664,19 +2712,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_30616_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_PEPCARBOXYKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PEPCARBOXYKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002411_PGLUCISOM-RXN_SGD_GLUCONEO-PWY-1>
@@ -2684,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2692,52 +2740,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002411_PGLUCISOM-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PGLUCISOM-RXN>
+          <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "cytosolic malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCONEO-PWY-1Complex30780> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002333_YKL029C-MONOMER_1.1.1.39-RXN_controller_SGD_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.39-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL029C-MONOMER_1.1.1.39-RXN_controller>
-] .
 
 <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2748,7 +2781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2756,24 +2789,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58702>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_15361_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.1.39-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15361_1.1.1.39-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58702>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1>
@@ -2781,7 +2833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2792,7 +2844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2800,19 +2852,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002411_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/F16ALDOLASE-RXN>
+          <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
@@ -2824,7 +2876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2834,28 +2886,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,7 +2932,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
@@ -2875,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2904,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2931,37 +3000,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -2970,39 +3050,48 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000066_reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002411_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/F16BDEPHOS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004369>
@@ -3013,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3028,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3045,7 +3134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3054,20 +3143,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' 'null' '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_15589_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_PHOSGLYPHOS-RXN_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.39-RXN> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_1.1.1.39-RXN>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -3078,7 +3169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3088,20 +3179,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
+          <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1>
@@ -3109,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3123,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3136,7 +3229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3149,7 +3242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3157,19 +3250,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_57540_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
@@ -3183,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3198,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "gluconeogenesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3210,20 +3303,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3234,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3245,7 +3340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3256,7 +3351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3264,36 +3359,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
@@ -3305,7 +3400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3314,37 +3409,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + ATP &rarr; CO<SUB>2</SUB> + phospho<i>enol</i>pyruvate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_RXN-15513_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_PEPCARBOXYKIN-RXN_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58289_RXN-15513>
+          <http://model.geneontology.org/PEPCARBOXYKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002333_YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_16526_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_PEPCARBOXYKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0042132>
@@ -3355,7 +3452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3363,19 +3460,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002411_RXN-15513_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/RXN-15513>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004612>
@@ -3400,7 +3514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3413,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3424,7 +3538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3438,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3446,19 +3560,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002411_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_16526_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_16526_1.1.1.39-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
@@ -3470,7 +3584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3480,19 +3594,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1>
@@ -3500,7 +3614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3515,7 +3629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3531,7 +3645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3539,19 +3653,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1>
@@ -3559,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3570,27 +3684,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://www.w3.org/2004/02/skos/core#note>
@@ -3603,7 +3719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3616,7 +3732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3643,7 +3759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3658,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3671,39 +3787,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_32966>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000005486>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + ATP &rarr; CO<SUB>2</SUB> + phospho<i>enol</i>pyruvate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_16452_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_PEPCARBOXYKIN-RXN_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_PEPCARBOXYKIN-RXN>
+          <http://model.geneontology.org/PEPCARBOXYKIN-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -3711,19 +3832,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16BDEPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 <http://identifiers.org/sgd/S000003424>
@@ -3737,19 +3858,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_57540_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.1.1.39-RXN>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1>
@@ -3757,7 +3878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3768,19 +3889,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1>
@@ -3788,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3796,19 +3917,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1>
@@ -3816,7 +3937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3824,19 +3945,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
@@ -3848,7 +3969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3865,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3874,20 +3995,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002411_RXN-15513_SGD_GLUCONEO-PWY-1>
@@ -3895,7 +4018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +4032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3917,19 +4040,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1>
@@ -3937,7 +4060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3952,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3963,24 +4086,27 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000002236>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_RXN-15513>
+          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1>
@@ -3988,7 +4114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3999,19 +4125,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_456216_PEPCARBOXYKIN-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_PEPCARBOXYKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCONEO-PWY-1>
@@ -4019,7 +4145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4034,7 +4160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4054,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4066,22 +4192,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
@@ -4093,7 +4217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4113,7 +4237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4122,22 +4246,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &rarr; CO<SUB>2</SUB> + pyruvate + NADH' 'null' 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002413_PYRUVATE-CARBOXYLASE-RXN_null_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_57945_1.1.1.39-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57945_1.1.1.39-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1>
@@ -4145,7 +4267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4156,7 +4278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4171,7 +4293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4181,38 +4303,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_GLUCONEO-PWY-1>
@@ -4220,7 +4340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4228,19 +4348,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_GLUCONEO-PWY-1/GLUCONEO-PWY-1_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002333_YKL029C-MONOMER_1.1.1.39-RXN_controller_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/1.1.1.39-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCONEO-PWY-1/GLUCONEO-PWY-1>
+          <http://model.geneontology.org/YKL029C-MONOMER_1.1.1.39-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
@@ -4252,7 +4372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4262,19 +4382,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_GAPOXNPHOSPHN-RXN_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -4282,36 +4402,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
+] .
+
+<http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002236> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002411_F16ALDOLASE-RXN_SGD_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/F16ALDOLASE-RXN>
 ] .
 
 <http://model.geneontology.org/F16BDEPHOS-RXN>
@@ -4333,7 +4462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4346,7 +4475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLUCOSE-MANNOSYL-CHITO-DOLICHOL-GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
+++ b/models/GLUCOSE-MANNOSYL-CHITO-DOLICHOL-GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
@@ -1,59 +1,54 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9818> ;
+          <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_c126f8d8-cb76-439d-b7d2-37319c27b8db_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(5)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_1fb36b41-92cc-41ac-97fc-5b44c4eda87b_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(2)GlcNAc(2)-PP-Dol &rarr; GDP + Man(3)GlcNAc(2)-PP-Dol' 'null' 'GDP-&alpha;-D-mannose + Man(3)GlcNAc(2)-PP-Dol &rarr; GDP + Man(4)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002413_RXN3O-379_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-379> ;
+          <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-379>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_12427>
@@ -66,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,20 +70,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_860c6709-949d-423d-9bc1-a7dd3556bfa9_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/860c6709-949d-423d-9bc1-a7dd3556bfa9_RXN3O-259>
+          <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829>
 ] .
 
 <http://geneontology.org/lego/evidence>
@@ -102,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +110,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -121,38 +129,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP + H<SUP>+</SUP>' 'null' '<i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + GDP-&alpha;-D-mannose &rarr; Man(1)GlcNAc(2)-PP-Dol + GDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002413_RXN3O-9818_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.15-RXN> ;
+          <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.7.8.15-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-9818>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN>
+          <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002413_2.4.1.131-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -160,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -168,20 +176,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_28e2adfc-3508-4aec-8499-c9d92f1557ae_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_880968ce-be97-43d5-82b7-20b044941315_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/28e2adfc-3508-4aec-8499-c9d92f1557ae_RXN3O-411>
+          <http://model.geneontology.org/880968ce-be97-43d5-82b7-20b044941315_RXN3O-411>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -195,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,22 +223,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(5)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(6)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(6)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(7)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002413_RXN3O-3_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-3>
+          <http://model.geneontology.org/76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -227,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -249,50 +266,54 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000005313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(1)GlcNAc(2)-PP-Dol &rarr; a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide + Man(2)GlcNAc(2)-PP-Dol + GDP' 'null' 'GDP-&alpha;-D-mannose + Man(2)GlcNAc(2)-PP-Dol &rarr; GDP + Man(3)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002413_RXN3O-378_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-378>
+          <http://model.geneontology.org/976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000000274_CPLX3O-24_component_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-11> ;
+          <http://model.geneontology.org/CPLX3O-24_2.4.1.141-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/SGD_S000000274_CPLX3O-24_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000003015>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57865_2.7.8.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57865> ;
@@ -303,28 +324,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28094> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/fab1298a-87b6-4c40-bc8f-003f8bf03015_RXN3O-3>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -337,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,76 +351,67 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-glucosyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(3)Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000066_reaction_RXN3O-413_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002413_RXN3O-413_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-413> ;
+          <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-413>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/755a831c-6802-4e0d-a018-cc8c7834475e_RXN3O-9818>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(1)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0004577>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_24fb2177-ea24-4aa6-a539-30897d7a7836_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000066_reaction_RXN3O-378_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/24fb2177-ea24-4aa6-a539-30897d7a7836_RXN3O-378>
+          <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_20ed2ef1-ba2c-43f1-9762-f68a9d55d8ae_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(7)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0052925>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -430,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +438,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000000274_CPLX3O-24_component_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -451,19 +457,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002333_YBR110W-MONOMER_RXN3O-9818_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_58189_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller>
+          <http://model.geneontology.org/CHEBI_58189_RXN3O-9818>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_2.4.1.141-RXN>
@@ -475,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,79 +489,71 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(3)GlcNAc(2)-PP-Dol &rarr; GDP + Man(4)GlcNAc(2)-PP-Dol' 'null' 'GDP-&alpha;-D-mannose + Man(4)GlcNAc(2)-PP-Dol &rarr; GDP + Man(5)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002413_2.4.1.131-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-379> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.4.1.131-RXN>
-] .
-
-<http://model.geneontology.org/393b4170-2561-4db3-97c1-69a245ff8e8b_2.4.1.132-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-291> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_15378_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-379> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(8)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(9)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002413_RXN3O-411_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-259> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-411>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_2.4.1.141-RXN>
+          <http://model.geneontology.org/CHEBI_57705_2.4.1.141-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -563,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -574,18 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_7279663c-d44b-4a62-b068-bf2604ee0fdd_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,14 +595,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004993> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "alpha-1,2-mannosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,57 +632,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/f9f18886-515c-4e40-aa4e-bb08af72f589_RXN3O-259>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/eec08df3-144f-4ce0-9ca1-333e211c78b8_RXN3O-11>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_393b4170-2561-4db3-97c1-69a245ff8e8b_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_e6637db4-cd0b-4d87-a137-749685a1d31e_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -688,9 +652,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.131-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/fff23c38-54d1-437d-9669-799c6e300aa9_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> ;
+                <http://model.geneontology.org/299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a761b75d-27d2-4fa0-a617-d66c35da4d18_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> ;
+                <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> , <http://model.geneontology.org/eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -698,13 +662,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLBiochemicalReaction28203> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(6)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBR243C-MONOMER_2.7.8.15-RXN_controller>
         a       <http://identifiers.org/sgd/S000000447> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -713,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -723,19 +704,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_24cc1e29-1f9c-4b90-bd2e-d15592694d21_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR243C-MONOMER_2.7.8.15-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000066_reaction_2.4.1.132-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/24cc1e29-1f9c-4b90-bd2e-d15592694d21_2.4.1.132-RXN>
+          <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002413_RXN3O-9818_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN3O-3>
-        a       <http://purl.obolibrary.org/obo/GO_0052918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a dolichyl &beta;-D-mannosyl phosphate + Man(6)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(7)GlcNAc(2)-PP-Dol" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -772,9 +772,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-3_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/fab1298a-87b6-4c40-bc8f-003f8bf03015_RXN3O-3> , <http://model.geneontology.org/1fb36b41-92cc-41ac-97fc-5b44c4eda87b_RXN3O-3> ;
+                <http://model.geneontology.org/7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3> , <http://model.geneontology.org/0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-3> , <http://model.geneontology.org/7279663c-d44b-4a62-b068-bf2604ee0fdd_RXN3O-3> ;
+                <http://model.geneontology.org/36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3> , <http://model.geneontology.org/CHEBI_16214_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,38 +790,75 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/SGD_S000003015_CPLX3O-24_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003015> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(2)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-412> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57525_RXN3O-412>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-412> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-412>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002333_MONOMER3O-256_RXN3O-11_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000066_reaction_RXN3O-412_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -829,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -840,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -848,55 +885,60 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-3>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_6c77ddd3-e145-498d-b0f4-48aed6d9c3d7_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000003015_CPLX3O-24_component_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/e6637db4-cd0b-4d87-a137-749685a1d31e_RXN3O-379>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(3)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -907,35 +949,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/28e2adfc-3508-4aec-8499-c9d92f1557ae_RXN3O-411>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -950,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,31 +983,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_db88eae9-c03e-4543-9dee-ae8677bdf793_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/860c6709-949d-423d-9bc1-a7dd3556bfa9_RXN3O-259>
+<http://model.geneontology.org/50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(8)GlcNAc(2)-PP-Dol" ;
+                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -991,29 +1005,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000066_reaction_RXN3O-9818_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9818> ;
+          <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9818_location_lociGO_0005829>
+          <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003975>
@@ -1021,99 +1033,43 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-379> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+] .
+
+<http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-379> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_RXN3O-379>
-] .
-
-<http://model.geneontology.org/6c77ddd3-e145-498d-b0f4-48aed6d9c3d7_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/b682c5f4-dc1a-4d42-95ba-3efd295d7335_RXN3O-291>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(5)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_16214_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-259>
+          <http://model.geneontology.org/a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259>
 ] .
 
 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_fc182f73-0436-49c8-9b28-81f60f199d73_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_a761b75d-27d2-4fa0-a617-d66c35da4d18_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003033> ;
@@ -1122,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,23 +1086,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_eec08df3-144f-4ce0-9ca1-333e211c78b8_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1154,99 +1099,144 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_16214_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_2.7.8.15-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_a761b75d-27d2-4fa0-a617-d66c35da4d18_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a761b75d-27d2-4fa0-a617-d66c35da4d18_2.4.1.131-RXN>
+          <http://model.geneontology.org/299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58223>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-411> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller>
-] .
-
-<http://model.geneontology.org/1fb36b41-92cc-41ac-97fc-5b44c4eda87b_RXN3O-3>
+<http://model.geneontology.org/ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(6)GlcNAc(2)-PP-Dol" ;
+                "Man(8)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58223>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-411> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(4)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57525_RXN3O-413>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57525> ;
@@ -1257,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,19 +1260,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002333_YBL082C-MONOMER_RXN3O-291_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-3> ;
+          <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller>
 ] .
 
 <http://model.geneontology.org/reaction_2.4.1.141-RXN_location_lociGO_0005829>
@@ -1297,9 +1287,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0154d663-5caf-4043-abd6-5b6d69666c4e_RXN3O-11> , <http://model.geneontology.org/eec08df3-144f-4ce0-9ca1-333e211c78b8_RXN3O-11> ;
+                <http://model.geneontology.org/785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11> , <http://model.geneontology.org/b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-11> , <http://model.geneontology.org/db88eae9-c03e-4543-9dee-ae8677bdf793_RXN3O-11> ;
+                <http://model.geneontology.org/85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11> , <http://model.geneontology.org/CHEBI_16214_RXN3O-11> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1307,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,19 +1330,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.141-RXN> ;
+          <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller>
 ] .
 
 <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller>
@@ -1362,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,75 +1360,90 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_f9f18886-515c-4e40-aa4e-bb08af72f589_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000003015_CPLX3O-24_component_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-24_2.4.1.141-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003015_CPLX3O-24_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-413> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004578>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-11> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-413> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57525_RXN3O-413>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0004578>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_RXN3O-378>
+          <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
 ] .
 
 <http://identifiers.org/sgd/S000000447>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-3>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
@@ -1449,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,22 +1466,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + GDP-&alpha;-D-mannose &rarr; Man(1)GlcNAc(2)-PP-Dol + GDP' 'null' 'GDP-&alpha;-D-mannose + Man(1)GlcNAc(2)-PP-Dol &rarr; a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide + Man(2)GlcNAc(2)-PP-Dol + GDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002413_2.4.1.132-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.4.1.132-RXN>
+          <http://model.geneontology.org/4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -1488,32 +1491,21 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_fff23c38-54d1-437d-9669-799c6e300aa9_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-411> ;
+          <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58223_2.4.1.141-RXN>
@@ -1525,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,14 +1530,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-378>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102704> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "GDP-&alpha;-D-mannose + Man(2)GlcNAc(2)-PP-Dol &rarr; GDP + Man(3)GlcNAc(2)-PP-Dol" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1553,9 +1545,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/24fb2177-ea24-4aa6-a539-30897d7a7836_RXN3O-378> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
+                <http://model.geneontology.org/4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a16fb344-dfaf-4927-9777-ccaf872745da_RXN3O-378> , <http://model.geneontology.org/CHEBI_58189_RXN3O-378> ;
+                <http://model.geneontology.org/CHEBI_58189_RXN3O-378> , <http://model.geneontology.org/78777294-3fba-498c-8060-147650e8f41e_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1563,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,28 +1565,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_b682c5f4-dc1a-4d42-95ba-3efd295d7335_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b682c5f4-dc1a-4d42-95ba-3efd295d7335_RXN3O-291>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_58223_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_12427_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,64 +1594,58 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_2.4.1.141-RXN>
+          <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002333_YBR110W-MONOMER_RXN3O-9818_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.131-RXN> ;
+          <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller>
 ] .
-
-<http://model.geneontology.org/b0522bc8-77d3-4c21-8e1c-91c8fc278155_RXN3O-412>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(3)GlcNAc(2)-PP-Dol &rarr; GDP + Man(4)GlcNAc(2)-PP-Dol' 'null' 'GDP-&alpha;-D-mannose + Man(4)GlcNAc(2)-PP-Dol &rarr; GDP + Man(5)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002413_2.4.1.131-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-411> ;
+          <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
+          <http://model.geneontology.org/2.4.1.131-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57705>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_880968ce-be97-43d5-82b7-20b044941315_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1669,27 +1655,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_6c77ddd3-e145-498d-b0f4-48aed6d9c3d7_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6c77ddd3-e145-498d-b0f4-48aed6d9c3d7_RXN3O-291>
+          <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller>
@@ -1699,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1712,7 +1717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1722,20 +1727,39 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a dolichyl phosphate + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UMP' 'null' '<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002413_2.4.1.141-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.4.1.141-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_57527_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
+          <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002413_2.4.1.141-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -1743,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1751,71 +1775,78 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_b0522bc8-77d3-4c21-8e1c-91c8fc278155_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-412> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-412> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0522bc8-77d3-4c21-8e1c-91c8fc278155_RXN3O-412>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(7)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(8)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(8)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002413_RXN3O-259_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-259>
+          <http://model.geneontology.org/85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-9818_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(6)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(7)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(7)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(8)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002413_RXN3O-11_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-11>
+          <http://model.geneontology.org/36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3>
 ] .
 
 <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
@@ -1827,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1835,12 +1866,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(3)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002333_MONOMER3O-36_2.4.1.131-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1848,19 +1907,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_12427_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_12427_RXN3O-9818>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_16214_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -1868,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1879,56 +1938,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_e6637db4-cd0b-4d87-a137-749685a1d31e_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-379> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-379> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e6637db4-cd0b-4d87-a137-749685a1d31e_RXN3O-379>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_f9f18886-515c-4e40-aa4e-bb08af72f589_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f9f18886-515c-4e40-aa4e-bb08af72f589_RXN3O-259>
+          <http://model.geneontology.org/ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9818>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004578> ;
@@ -1941,7 +1991,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57527_RXN3O-9818> , <http://model.geneontology.org/CHEBI_12427_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> , <http://model.geneontology.org/755a831c-6802-4e0d-a018-cc8c7834475e_RXN3O-9818> ;
+                <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> , <http://model.geneontology.org/4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1949,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1957,12 +2007,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_24cc1e29-1f9c-4b90-bd2e-d15592694d21_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1972,45 +2022,50 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_57705_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
+          <http://model.geneontology.org/reaction_2.7.8.15-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002333_MONOMER3O-36_2.4.1.131-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_18278_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2025,7 +2080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2034,58 +2089,84 @@
                 "org.biopax.paxtools.model.level3.Pathway" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-glucosyl phosphate + Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002413_RXN3O-412_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-411> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-412>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000066_reaction_RXN3O-3_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-3> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-3_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_18278_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-411> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(5)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(6)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(6)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(7)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002413_RXN3O-3_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-291> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-3>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_16214_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18278_2.7.8.15-RXN>
+          <http://model.geneontology.org/CHEBI_16214_2.7.8.15-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0106073>
@@ -2096,7 +2177,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_78777294-3fba-498c-8060-147650e8f41e_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2107,49 +2199,66 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/880968ce-be97-43d5-82b7-20b044941315_RXN3O-411>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(1)GlcNAc(2)-PP-Dol &rarr; a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide + Man(2)GlcNAc(2)-PP-Dol + GDP' 'null' 'GDP-&alpha;-D-mannose + Man(2)GlcNAc(2)-PP-Dol &rarr; GDP + Man(3)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000066_reaction_2.4.1.141-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002413_RXN3O-378_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.141-RXN> ;
+          <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.4.1.141-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-378>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_eec08df3-144f-4ce0-9ca1-333e211c78b8_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eec08df3-144f-4ce0-9ca1-333e211c78b8_RXN3O-11>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
 <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller>
@@ -2159,7 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2168,13 +2277,13 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "Dol-PP-GlcNAc2:Man7:Man transferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2190,7 +2299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2201,55 +2310,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_fc182f73-0436-49c8-9b28-81f60f199d73_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000066_reaction_RXN3O-413_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-413> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-413> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fc182f73-0436-49c8-9b28-81f60f199d73_RXN3O-413>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_28e2adfc-3508-4aec-8499-c9d92f1557ae_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_a16fb344-dfaf-4927-9777-ccaf872745da_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a16fb344-dfaf-4927-9777-ccaf872745da_RXN3O-378>
+          <http://model.geneontology.org/4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -2260,7 +2360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2291,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2306,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2323,7 +2423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2336,28 +2436,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/24fb2177-ea24-4aa6-a539-30897d7a7836_RXN3O-378>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(2)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-379>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2368,9 +2451,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_RXN3O-379> , <http://model.geneontology.org/e6637db4-cd0b-4d87-a137-749685a1d31e_RXN3O-379> ;
+                <http://model.geneontology.org/CHEBI_57527_RXN3O-379> , <http://model.geneontology.org/34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8e9b0de5-586a-47cd-8eaa-4968c8e29506_RXN3O-379> , <http://model.geneontology.org/CHEBI_58189_RXN3O-379> ;
+                <http://model.geneontology.org/35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379> , <http://model.geneontology.org/CHEBI_58189_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2378,7 +2461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2388,38 +2471,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002333_CPLX3O-24_2.4.1.141-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_15378_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-24_2.4.1.141-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_2.4.1.141-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + GDP-&alpha;-D-mannose &rarr; Man(1)GlcNAc(2)-PP-Dol + GDP' 'null' 'GDP-&alpha;-D-mannose + Man(1)GlcNAc(2)-PP-Dol &rarr; a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide + Man(2)GlcNAc(2)-PP-Dol + GDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000066_reaction_2.4.1.131-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002413_2.4.1.132-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.131-RXN> ;
+          <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.4.1.131-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/2.4.1.132-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57525>
@@ -2427,44 +2510,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
-
-<http://model.geneontology.org/0154d663-5caf-4043-abd6-5b6d69666c4e_RXN3O-11>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(7)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2475,63 +2541,52 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/77e48b67-dd7d-4c0c-8e50-e49b201fbdad_RXN3O-412>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-291> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291>
+] .
+
+<http://model.geneontology.org/4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
+                "Man(1)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_16214_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-291> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-291>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_b0522bc8-77d3-4c21-8e1c-91c8fc278155_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2539,19 +2594,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_393b4170-2561-4db3-97c1-69a245ff8e8b_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/393b4170-2561-4db3-97c1-69a245ff8e8b_2.4.1.132-RXN>
+          <http://model.geneontology.org/5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002413_RXN3O-11_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2559,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2570,7 +2625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2581,31 +2636,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002333_YOR067C-MONOMER_RXN3O-412_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-412>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_25988acc-f125-4b96-927e-5b905783544b_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_18278_2.7.8.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_18278> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2616,7 +2660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2626,19 +2670,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002333_MONOMER3O-256_RXN3O-11_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-259> ;
+          <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000066_reaction_RXN3O-9818_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2646,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2654,19 +2698,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-378> ;
+          <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2677,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2688,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2702,38 +2746,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_77e48b67-dd7d-4c0c-8e50-e49b201fbdad_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000066_reaction_RXN3O-9818_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_RXN3O-9818>
+          <http://model.geneontology.org/reaction_RXN3O-9818_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2741,27 +2787,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000000274>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_CHEBI_58189_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_RXN3O-379>
+          <http://model.geneontology.org/CHEBI_57527_RXN3O-379>
 ] .
 
 <http://model.geneontology.org/reaction_2.7.8.15-RXN_location_lociGO_0005829>
@@ -2769,23 +2818,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002333_YNL219C-MONOMER_RXN3O-259_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_16214_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-259>
 ] .
 
 <http://model.geneontology.org/RXN3O-259>
-        a       <http://purl.obolibrary.org/obo/GO_0052918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a dolichyl &beta;-D-mannosyl phosphate + Man(8)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(9)GlcNAc(2)-PP-Dol" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2793,9 +2842,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/25988acc-f125-4b96-927e-5b905783544b_RXN3O-259> , <http://model.geneontology.org/860c6709-949d-423d-9bc1-a7dd3556bfa9_RXN3O-259> ;
+                <http://model.geneontology.org/a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259> , <http://model.geneontology.org/ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/f9f18886-515c-4e40-aa4e-bb08af72f589_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
+                <http://model.geneontology.org/1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2803,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2812,22 +2861,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(4)GlcNAc(2)-PP-Dol &rarr; GDP + Man(5)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(5)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(6)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002413_RXN3O-291_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-291>
+          <http://model.geneontology.org/eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
@@ -2839,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2847,12 +2894,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2860,19 +2918,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-412> ;
+          <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2880,7 +2938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2888,36 +2946,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_fab1298a-87b6-4c40-bc8f-003f8bf03015_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-3> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_57705_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-3> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fab1298a-87b6-4c40-bc8f-003f8bf03015_RXN3O-3>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_57865_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_2.7.8.15-RXN>
+          <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2925,44 +2983,53 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_0154d663-5caf-4043-abd6-5b6d69666c4e_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-11> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0154d663-5caf-4043-abd6-5b6d69666c4e_RXN3O-11>
-] .
+<http://model.geneontology.org/SGD_S000000274_CPLX3O-24_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000274> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(1)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18278_2.4.1.141-RXN>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
 <http://model.geneontology.org/RXN3O-411>
@@ -2974,9 +3041,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/20ed2ef1-ba2c-43f1-9762-f68a9d55d8ae_RXN3O-411> , <http://model.geneontology.org/CHEBI_57525_RXN3O-411> ;
+                <http://model.geneontology.org/880968ce-be97-43d5-82b7-20b044941315_RXN3O-411> , <http://model.geneontology.org/CHEBI_57525_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-411> , <http://model.geneontology.org/28e2adfc-3508-4aec-8499-c9d92f1557ae_RXN3O-411> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-411> , <http://model.geneontology.org/b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2984,7 +3051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3001,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3009,35 +3076,60 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_755a831c-6802-4e0d-a018-cc8c7834475e_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-11> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-413> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57525_RXN3O-413>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-413> ;
+          <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-413>
+          <http://model.geneontology.org/CHEBI_58189_RXN3O-378>
 ] .
 
-<http://model.geneontology.org/a761b75d-27d2-4fa0-a617-d66c35da4d18_2.4.1.131-RXN>
+<http://model.geneontology.org/8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -3046,7 +3138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3054,50 +3146,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002333_YGL065C-MONOMER_RXN3O-378_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-378> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_7a4e8ae1-0e56-49c8-b7b4-1a6ac0d9d624_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-413> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7a4e8ae1-0e56-49c8-b7b4-1a6ac0d9d624_RXN3O-413>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_b682c5f4-dc1a-4d42-95ba-3efd295d7335_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-413> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413>
+] .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-11>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
@@ -3108,7 +3183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3120,30 +3195,28 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(2)GlcNAc(2)-PP-Dol &rarr; GDP + Man(3)GlcNAc(2)-PP-Dol' 'null' 'GDP-&alpha;-D-mannose + Man(3)GlcNAc(2)-PP-Dol &rarr; GDP + Man(4)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002413_RXN3O-379_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_78777294-3fba-498c-8060-147650e8f41e_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-379>
+          <http://model.geneontology.org/78777294-3fba-498c-8060-147650e8f41e_RXN3O-378>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_24fb2177-ea24-4aa6-a539-30897d7a7836_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3151,31 +3224,33 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(7)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(8)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(8)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002413_RXN3O-259_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-259> ;
+          <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-259>
 ] .
 
 <http://model.geneontology.org/CPLX3O-24_2.4.1.141-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "UDP-N-acetylglucosamine: N-acetylglucosaminyl-diphosphodolichol N-acetylglucosaminyltransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003015_CPLX3O-24_component> , <http://model.geneontology.org/SGD_S000000274_CPLX3O-24_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3183,40 +3258,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP + H<SUP>+</SUP>' 'null' '<i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + GDP-&alpha;-D-mannose &rarr; Man(1)GlcNAc(2)-PP-Dol + GDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002413_RXN3O-9818_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_58223_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9818>
+          <http://model.geneontology.org/CHEBI_58223_2.4.1.141-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -3227,7 +3317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3237,20 +3327,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_20ed2ef1-ba2c-43f1-9762-f68a9d55d8ae_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/20ed2ef1-ba2c-43f1-9762-f68a9d55d8ae_RXN3O-411>
+          <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -3258,26 +3350,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/fc182f73-0436-49c8-9b28-81f60f199d73_RXN3O-413>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3286,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3294,31 +3386,42 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_c126f8d8-cb76-439d-b7d2-37319c27b8db_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c126f8d8-cb76-439d-b7d2-37319c27b8db_RXN3O-291>
+          <http://model.geneontology.org/8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_6ebbeda1-cf1d-4d3b-83a0-153356664e63_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3326,59 +3429,104 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6ebbeda1-cf1d-4d3b-83a0-153356664e63_2.4.1.132-RXN>
+          <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-glucosyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(3)Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002413_RXN3O-413_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-412> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-413>
-] .
+<http://model.geneontology.org/0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(6)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0102704>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-412> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3386,40 +3534,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(6)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(7)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(7)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(8)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000066_reaction_RXN3O-378_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002413_RXN3O-11_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-378> ;
+          <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-11>
 ] .
 
 <http://identifiers.org/sgd/S000000178>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/8e9b0de5-586a-47cd-8eaa-4968c8e29506_RXN3O-379>
+<http://model.geneontology.org/976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(4)GlcNAc(2)-PP-Dol" ;
+                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3438,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3451,21 +3599,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3473,19 +3635,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_58189_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_12427_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_RXN3O-9818>
+          <http://model.geneontology.org/CHEBI_12427_RXN3O-9818>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -3493,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3508,7 +3670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lipid-linked oligosaccharide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3516,23 +3678,12 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_0154d663-5caf-4043-abd6-5b6d69666c4e_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000066_reaction_2.4.1.132-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3543,20 +3694,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_8e9b0de5-586a-47cd-8eaa-4968c8e29506_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8e9b0de5-586a-47cd-8eaa-4968c8e29506_RXN3O-379>
+          <http://model.geneontology.org/34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379>
 ] .
+
+<http://model.geneontology.org/b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(7)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57527> ;
@@ -3567,28 +3735,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/25988acc-f125-4b96-927e-5b905783544b_RXN3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3600,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3615,7 +3766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3624,62 +3775,40 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(8)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(9)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002413_RXN3O-411_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-411>
+          <http://model.geneontology.org/1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000066_reaction_2.4.1.141-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57705_2.4.1.141-RXN>
+          <http://model.geneontology.org/reaction_2.4.1.141-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_fab1298a-87b6-4c40-bc8f-003f8bf03015_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_8e9b0de5-586a-47cd-8eaa-4968c8e29506_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
@@ -3690,7 +3819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3698,32 +3827,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_6ebbeda1-cf1d-4d3b-83a0-153356664e63_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002333_MONOMER3O-36_2.4.1.131-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.132-RXN> ;
+          <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002333_YNL219C-MONOMER_RXN3O-259_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -3731,7 +3849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3746,9 +3864,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b682c5f4-dc1a-4d42-95ba-3efd295d7335_RXN3O-291> , <http://model.geneontology.org/6c77ddd3-e145-498d-b0f4-48aed6d9c3d7_RXN3O-291> ;
+                <http://model.geneontology.org/8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291> , <http://model.geneontology.org/edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c126f8d8-cb76-439d-b7d2-37319c27b8db_RXN3O-291> , <http://model.geneontology.org/CHEBI_16214_RXN3O-291> ;
+                <http://model.geneontology.org/76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291> , <http://model.geneontology.org/CHEBI_16214_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3756,7 +3874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3766,21 +3884,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-glucosyl phosphate + Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000066_reaction_RXN3O-412_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002413_RXN3O-412_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-412> ;
+          <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-412>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -3788,61 +3906,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/7a4e8ae1-0e56-49c8-b7b4-1a6ac0d9d624_RXN3O-413>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_1fb36b41-92cc-41ac-97fc-5b44c4eda87b_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000066_reaction_RXN3O-3_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1fb36b41-92cc-41ac-97fc-5b44c4eda87b_RXN3O-3>
+          <http://model.geneontology.org/reaction_RXN3O-3_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_18278_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR243C-MONOMER_2.7.8.15-RXN_controller>
+          <http://model.geneontology.org/CHEBI_18278_2.7.8.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -3850,7 +3953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3868,9 +3971,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57525_RXN3O-412> , <http://model.geneontology.org/77e48b67-dd7d-4c0c-8e50-e49b201fbdad_RXN3O-412> ;
+                <http://model.geneontology.org/3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412> , <http://model.geneontology.org/CHEBI_57525_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-412> , <http://model.geneontology.org/b0522bc8-77d3-4c21-8e1c-91c8fc278155_RXN3O-412> ;
+                <http://model.geneontology.org/50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412> , <http://model.geneontology.org/CHEBI_16214_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3878,7 +3981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3888,19 +3991,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-11>
+          <http://model.geneontology.org/b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
@@ -3912,7 +4015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3925,11 +4028,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3939,7 +4059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3952,13 +4072,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28129> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_12427_RXN3O-9818>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_12427> ;
@@ -3969,7 +4100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3982,7 +4113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3993,19 +4124,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-413>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -4013,7 +4144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4024,46 +4155,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002333_YGL065C-MONOMER_RXN3O-378_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-379> ;
+          <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller>
 ] .
 
-<http://model.geneontology.org/c126f8d8-cb76-439d-b7d2-37319c27b8db_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(6)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004993> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "alpha-1,2-mannosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4076,27 +4190,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_25988acc-f125-4b96-927e-5b905783544b_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/25988acc-f125-4b96-927e-5b905783544b_RXN3O-259>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4104,36 +4229,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002333_CPLX3O-24_2.4.1.141-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.15-RXN> ;
+          <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+          <http://model.geneontology.org/CPLX3O-24_2.4.1.141-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_fff23c38-54d1-437d-9669-799c6e300aa9_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000066_reaction_2.4.1.131-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fff23c38-54d1-437d-9669-799c6e300aa9_2.4.1.131-RXN>
+          <http://model.geneontology.org/reaction_2.4.1.131-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -4150,7 +4277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4158,19 +4285,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
+          <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
 ] .
 
 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller>
@@ -4180,7 +4307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4197,7 +4324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4210,7 +4337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4218,19 +4345,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002333_YBL082C-MONOMER_RXN3O-291_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_16214_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-291>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57865>
@@ -4241,11 +4368,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(8)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000178> ;
@@ -4254,7 +4398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4267,7 +4411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4275,61 +4419,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.4.1.132-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002333_YOR067C-MONOMER_RXN3O-412_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.132-RXN> ;
+          <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller>
+          <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller>
 ] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-413> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-] .
-
-<http://model.geneontology.org/a16fb344-dfaf-4927-9777-ccaf872745da_RXN3O-378>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(3)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4337,19 +4464,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -4357,7 +4484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4372,7 +4499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4389,7 +4516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4400,38 +4527,21 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/20ed2ef1-ba2c-43f1-9762-f68a9d55d8ae_RXN3O-411>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_755a831c-6802-4e0d-a018-cc8c7834475e_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/755a831c-6802-4e0d-a018-cc8c7834475e_RXN3O-9818>
+          <http://model.geneontology.org/CHEBI_57527_RXN3O-9818>
 ] .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-291>
@@ -4443,11 +4553,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4456,7 +4583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4467,19 +4594,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_CHEBI_58189_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller>
+          <http://model.geneontology.org/CHEBI_58189_RXN3O-379>
 ] .
 
 <http://model.geneontology.org/CHEBI_57527_RXN3O-379>
@@ -4491,7 +4618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4499,21 +4626,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(4)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_12427_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002333_YNL219C-MONOMER_RXN3O-259_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-259> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.141-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
+          <http://model.geneontology.org/CHEBI_18278_2.4.1.141-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_16214_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -4521,48 +4682,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-291> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4575,7 +4719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4583,40 +4727,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/db88eae9-c03e-4543-9dee-ae8677bdf793_RXN3O-11>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(8)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_860c6709-949d-423d-9bc1-a7dd3556bfa9_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4631,7 +4747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4639,12 +4755,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_7a4e8ae1-0e56-49c8-b7b4-1a6ac0d9d624_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4652,46 +4768,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(4)GlcNAc(2)-PP-Dol &rarr; GDP + Man(5)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(5)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(6)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000066_reaction_2.4.1.132-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002413_RXN3O-291_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.132-RXN> ;
+          <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-291>
 ] .
-
-<http://model.geneontology.org/7279663c-d44b-4a62-b068-bf2604ee0fdd_RXN3O-3>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(7)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4702,89 +4801,22 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57525_RXN3O-412>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-3> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-3>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a dolichyl phosphate + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UMP' 'null' '<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002413_2.4.1.141-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.4.1.141-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_57527_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.132-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0052918>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/6ebbeda1-cf1d-4d3b-83a0-153356664e63_2.4.1.132-RXN>
+<http://model.geneontology.org/bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -4793,11 +4825,101 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.4.1.132-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-3> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_57865_2.7.8.15-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57865_2.7.8.15-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/78777294-3fba-498c-8060-147650e8f41e_RXN3O-378>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(3)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4820,7 +4942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4829,41 +4951,26 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_77e48b67-dd7d-4c0c-8e50-e49b201fbdad_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000066_reaction_RXN3O-412_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/77e48b67-dd7d-4c0c-8e50-e49b201fbdad_RXN3O-412>
+          <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/fff23c38-54d1-437d-9669-799c6e300aa9_2.4.1.131-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(4)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-413>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0106073> ;
@@ -4874,15 +4981,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57525_RXN3O-413> , <http://model.geneontology.org/fc182f73-0436-49c8-9b28-81f60f199d73_RXN3O-413> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-413> , <http://model.geneontology.org/75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7a4e8ae1-0e56-49c8-b7b4-1a6ac0d9d624_RXN3O-413> , <http://model.geneontology.org/CHEBI_16214_RXN3O-413> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-413> , <http://model.geneontology.org/cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4892,47 +4999,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_db88eae9-c03e-4543-9dee-ae8677bdf793_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/db88eae9-c03e-4543-9dee-ae8677bdf793_RXN3O-11>
+          <http://model.geneontology.org/785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_a16fb344-dfaf-4927-9777-ccaf872745da_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_7279663c-d44b-4a62-b068-bf2604ee0fdd_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7279663c-d44b-4a62-b068-bf2604ee0fdd_RXN3O-3>
+          <http://model.geneontology.org/7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002413_RXN3O-413_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -4940,35 +5036,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/24cc1e29-1f9c-4b90-bd2e-d15592694d21_2.4.1.132-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(1)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002333_YOR067C-MONOMER_RXN3O-412_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4979,7 +5058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4990,11 +5069,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004993>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/2.4.1.132-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004378> ;
@@ -5005,9 +5087,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> , <http://model.geneontology.org/24cc1e29-1f9c-4b90-bd2e-d15592694d21_2.4.1.132-RXN> ;
+                <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> , <http://model.geneontology.org/5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/393b4170-2561-4db3-97c1-69a245ff8e8b_2.4.1.132-RXN> , <http://model.geneontology.org/6ebbeda1-cf1d-4d3b-83a0-153356664e63_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
+                <http://model.geneontology.org/976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN> , <http://model.geneontology.org/bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5015,7 +5097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLUDEG-I-PWY-1-GLUDEG-I-PWY-1.ttl
+++ b/models/GLUDEG-I-PWY-1-GLUDEG-I-PWY-1.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -995,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1074,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLUGLNSYN-PWY-GLUGLNSYN-PWY.ttl
+++ b/models/GLUGLNSYN-PWY-GLUGLNSYN-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamate biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLUNH3-PWY-GLUNH3-PWY.ttl
+++ b/models/GLUNH3-PWY-GLUNH3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -74,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate biosynthesis from ammonia - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLUT-REDOX2-PWY-GLUT-REDOX2-PWY.ttl
+++ b/models/GLUT-REDOX2-PWY-GLUT-REDOX2-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -10,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,6 +62,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GLUTATHIONE-PEROXIDASE-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001476>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -65,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -171,9 +185,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57925_GSHTRAN-RXN> , <http://model.geneontology.org/ec3570f6-1c30-45ef-944d-1ad4e727a3c3_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN> , <http://model.geneontology.org/CHEBI_57925_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8d33b46f-793a-42ae-a699-e1b713f5e749_GSHTRAN-RXN> , <http://model.geneontology.org/158fa0c3-93a4-41fc-9f8b-7d6f3f4bc61d_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN> , <http://model.geneontology.org/61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YIR038C-MONOMER_GSHTRAN-RXN_controller> , <http://model.geneontology.org/YLL060C-MONOMER_GSHTRAN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -181,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,18 +220,26 @@
           <http://model.geneontology.org/YIR038C-MONOMER_GSHTRAN-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002411_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -293,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -323,23 +345,6 @@
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/8d33b46f-793a-42ae-a699-e1b713f5e749_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glutathione-<i>S</i>-conjugate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004364>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -354,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,13 +418,24 @@
           <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-PEROXIDASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_null_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_8d33b46f-793a-42ae-a699-e1b713f5e749_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,19 +443,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8d33b46f-793a-42ae-a699-e1b713f5e749_GSHTRAN-RXN>
+          <http://model.geneontology.org/9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_null_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -453,11 +458,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60972> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glutathione-<i>S</i>-conjugate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -473,24 +495,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin redox reactions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_8d33b46f-793a-42ae-a699-e1b713f5e749_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -504,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -645,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -660,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,11 +704,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_158fa0c3-93a4-41fc-9f8b-7d6f3f4bc61d_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +716,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/158fa0c3-93a4-41fc-9f8b-7d6f3f4bc61d_GSHTRAN-RXN>
+          <http://model.geneontology.org/61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -720,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -734,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,11 +845,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "HX" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -848,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -859,18 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +898,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -895,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,13 +953,24 @@
           <http://model.geneontology.org/reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_ec3570f6-1c30-45ef-944d-1ad4e727a3c3_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,19 +978,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ec3570f6-1c30-45ef-944d-1ad4e727a3c3_GSHTRAN-RXN>
+          <http://model.geneontology.org/cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_158fa0c3-93a4-41fc-9f8b-7d6f3f4bc61d_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -962,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +1004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1038,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1051,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1060,23 +1088,23 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_PRODISULFREDUCT-A-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_PRODISULFREDUCT-A-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1087,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1118,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1181,6 +1209,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "RX" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://identifiers.org/sgd/S000003983>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1189,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1288,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1300,16 +1345,13 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_PRODISULFREDUCT-A-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,18 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_ec3570f6-1c30-45ef-944d-1ad4e727a3c3_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1368,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1385,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1393,25 +1424,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://identifiers.org/sgd/S000001477>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ec3570f6-1c30-45ef-944d-1ad4e727a3c3_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "RX" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1419,7 +1436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1449,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1462,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1474,7 +1491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1609,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1623,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1665,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1673,13 +1690,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,31 +1717,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58297_PRODISULFREDUCT-A-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/158fa0c3-93a4-41fc-9f8b-7d6f3f4bc61d_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "HX" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/GLUTATHIONESYN-PWY-GLUTATHIONESYN-PWY.ttl
+++ b/models/GLUTATHIONESYN-PWY-GLUTATHIONESYN-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,28 +49,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YJL101C-MONOMER_GLUTCYSLIG-RXN_controller>
-        a       <http://identifiers.org/sgd/S000003637> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "gamma-glutamylcysteine synthetase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYProtein59749> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_GLUTCYSLIG-RXN_SGD_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,13 +66,28 @@
           <http://model.geneontology.org/CHEBI_35235_GLUTCYSLIG-RXN>
 ] .
 
+<http://model.geneontology.org/YJL101C-MONOMER_GLUTCYSLIG-RXN_controller>
+        a       <http://identifiers.org/sgd/S000003637> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "gamma-glutamylcysteine synthetase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYProtein59749> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTATHIONE-SYN-RXN_SGD_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,13 +953,24 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_null_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,23 +981,12 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_null_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_GLUTATHIONESYN-PWY/GLUTATHIONESYN-PWY_SGD_GLUTATHIONESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLYCLEAV-PWY-GLYCLEAV-PWY.ttl
+++ b/models/GLYCLEAV-PWY-GLYCLEAV-PWY.ttl
@@ -1,20 +1,3 @@
-<http://model.geneontology.org/a8ec7b53-430b-491a-b570-6b2810ed5b1b_GCVT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004801> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -22,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,18 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_a740b24f-8b18-47c6-805b-5ee0777d9960_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,24 +56,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_c348904a-e04a-436d-b4e0-4b0b9e71c97c_RXN-8629_SGD_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_a8ec7b53-430b-491a-b570-6b2810ed5b1b_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +70,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a8ec7b53-430b-491a-b570-6b2810ed5b1b_GCVT-RXN>
+          <http://model.geneontology.org/1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829>
@@ -117,11 +78,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_09ea6294-9d14-4b7f-bca9-b1dd607e17a7_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,8 +90,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/09ea6294-9d14-4b7f-bca9-b1dd607e17a7_GCVP-RXN>
+          <http://model.geneontology.org/8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -143,7 +115,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -154,35 +137,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/5df7c2a2-418c-4b75-aab1-cd52c85e7b59_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22641> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16526_GCVP-RXN_SGD_GLYCLEAV-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,11 +156,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_81d0ac5f-052f-4950-837e-88863f10e38a_RXN-8629_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +168,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/81d0ac5f-052f-4950-837e-88863f10e38a_RXN-8629>
+          <http://model.geneontology.org/f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_GLYCLEAV-PWY/GLYCLEAV-PWY_SGD_GLYCLEAV-PWY>
@@ -210,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -225,9 +191,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/09ea6294-9d14-4b7f-bca9-b1dd607e17a7_GCVP-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9b620eaf-6cbd-4e1c-825e-923ad5e66b71_GCVP-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> ;
+                <http://model.geneontology.org/83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -235,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -258,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -289,9 +255,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3a172124-a7e5-46a3-995d-708508f4d61b_GCVT-RXN> , <http://model.geneontology.org/a740b24f-8b18-47c6-805b-5ee0777d9960_GCVT-RXN> ;
+                <http://model.geneontology.org/60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN> , <http://model.geneontology.org/043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a8ec7b53-430b-491a-b570-6b2810ed5b1b_GCVT-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> , <http://model.geneontology.org/5df7c2a2-418c-4b75-aab1-cd52c85e7b59_GCVT-RXN> ;
+                <http://model.geneontology.org/1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN> , <http://model.geneontology.org/89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -299,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -321,13 +287,30 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,13 +321,24 @@
           <http://model.geneontology.org/CHEBI_28938_GCVT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_null_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,16 +349,22 @@
           <http://model.geneontology.org/CHEBI_57305_GCVP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_null_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLYCLEAV-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -405,8 +405,42 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -414,7 +448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,18 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_a8ec7b53-430b-491a-b570-6b2810ed5b1b_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -466,6 +489,23 @@
 
 <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22641> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -476,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,11 +595,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_3a172124-a7e5-46a3-995d-708508f4d61b_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +607,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3a172124-a7e5-46a3-995d-708508f4d61b_GCVT-RXN>
+          <http://model.geneontology.org/60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -576,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,6 +627,28 @@
           <http://model.geneontology.org/CHEBI_15378_GCVP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -596,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,17 +669,6 @@
           <http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_9b620eaf-6cbd-4e1c-825e-923ad5e66b71_GCVP-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -626,18 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_81d0ac5f-052f-4950-837e-88863f10e38a_RXN-8629_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,6 +707,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_GCVP-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -685,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,11 +786,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_a740b24f-8b18-47c6-805b-5ee0777d9960_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +798,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a740b24f-8b18-47c6-805b-5ee0777d9960_GCVT-RXN>
+          <http://model.geneontology.org/043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN>
 ] .
 
 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller>
@@ -757,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,9 +847,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/81d0ac5f-052f-4950-837e-88863f10e38a_RXN-8629> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
+                <http://model.geneontology.org/f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/c348904a-e04a-436d-b4e0-4b0b9e71c97c_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -806,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,11 +867,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_c348904a-e04a-436d-b4e0-4b0b9e71c97c_RXN-8629_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +879,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c348904a-e04a-436d-b4e0-4b0b9e71c97c_RXN-8629>
+          <http://model.geneontology.org/65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
@@ -837,36 +888,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/c348904a-e04a-436d-b4e0-4b0b9e71c97c_RXN-8629>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_3a172124-a7e5-46a3-995d-708508f4d61b_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004047>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -883,7 +906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,11 +919,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_9b620eaf-6cbd-4e1c-825e-923ad5e66b71_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,11 +931,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9b620eaf-6cbd-4e1c-825e-923ad5e66b71_GCVP-RXN>
+          <http://model.geneontology.org/83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -926,28 +960,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22696> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/3a172124-a7e5-46a3-995d-708508f4d61b_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -959,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,24 +987,13 @@
           <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_5df7c2a2-418c-4b75-aab1-cd52c85e7b59_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000050_GLYCLEAV-PWY/GLYCLEAV-PWY_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,30 +1004,13 @@
           <http://model.geneontology.org/GLYCLEAV-PWY/GLYCLEAV-PWY>
 ] .
 
-<http://model.geneontology.org/09ea6294-9d14-4b7f-bca9-b1dd607e17a7_GCVP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_57945_RXN-8629_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1066,23 +1055,12 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_09ea6294-9d14-4b7f-bca9-b1dd607e17a7_GCVP-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002413_GCVT-RXN_null_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,11 +1091,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_5df7c2a2-418c-4b75-aab1-cd52c85e7b59_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,23 +1103,62 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5df7c2a2-418c-4b75-aab1-cd52c85e7b59_GCVT-RXN>
+          <http://model.geneontology.org/89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN>
 ] .
 
-<http://model.geneontology.org/a740b24f-8b18-47c6-805b-5ee0777d9960_GCVT-RXN>
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1151,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine cleavage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1196,32 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/9b620eaf-6cbd-4e1c-825e-923ad5e66b71_GCVP-RXN>
+<http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000066_reaction_RXN-8629_location_lociGO_0005829_null_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15378_GCVP-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -1188,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,55 +1238,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000066_reaction_RXN-8629_location_lociGO_0005829_null_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/81d0ac5f-052f-4950-837e-88863f10e38a_RXN-8629>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://identifiers.org/sgd/S000001876>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15378_GCVP-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_GLYCLEAV-PWY/GLYCLEAV-PWY_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/GLYCOCAT-YEAST-PWY-GLYCOCAT-YEAST-PWY.ttl
+++ b/models/GLYCOCAT-YEAST-PWY-GLYCOCAT-YEAST-PWY.ttl
@@ -1,39 +1,37 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a glycogen &rarr; maltotetraose' 'null' 'maltotetraose + D-glucopyranose &harr; maltotriose + maltose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000066_reaction_3.2.1.3-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002413_AMYLOMALT-RXN_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3.2.1.3-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'an &alpha;-limit dextrin &harr; a &alpha;-limit dextrin with short branches' 'null' 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002413_3.2.1.33-RXN_null_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4038> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/AMYLOMALT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3.2.1.33-RXN>
+          <http://model.geneontology.org/43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_null_GLYCOCAT-YEAST-PWY>
@@ -41,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -121,51 +119,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '{6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n</sub> + H<sub>2</sub>O &rarr; {6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n-1</sub> + D-glucopyranose' 'null' 'maltotetraose + D-glucopyranose &harr; maltotriose + maltose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_AMYLOMALT-RXN_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AMYLOMALT-RXN>
+          <http://model.geneontology.org/RXN-9024>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_4170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002333_YIL099W-MONOMER_RXN-9024_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9025> ;
+          <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829>
+          <http://model.geneontology.org/YIL099W-MONOMER_RXN-9024_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY>
@@ -173,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -192,19 +186,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002333_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_28460_AMYLOMALT-RXN>
@@ -216,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,17 +227,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller>
         a       <http://identifiers.org/sgd/S000006388> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -251,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,21 +242,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3.2.1.3-RXN>
+          <http://model.geneontology.org/481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9024>
@@ -285,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,49 +287,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_7f83a05b-9e09-4e8f-b482-fd02e87490e3_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0330d08f-03eb-47d6-adab-52d962f8f6e2_GLYCOPHOSPHORYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002233_CHEBI_24384_RXN3O-4038_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4038> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_24384_RXN3O-4038>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_GLYCOCAT-YEAST-PWY>
@@ -343,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,19 +317,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9023> ;
+          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
+          <http://model.geneontology.org/YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_AMYLOMALT-RXN_null_GLYCOCAT-YEAST-PWY>
@@ -371,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -381,10 +347,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycogen phosphorylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,10 +382,7 @@
           <http://model.geneontology.org/reaction_AMYLOMALT-RXN_location_lociGO_0005829>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/d4d00372-5938-4d90-9e55-d45feaa87240_3.2.1.33-RXN>
+<http://model.geneontology.org/481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -426,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,12 +399,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_24384_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -448,67 +427,78 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_24384_3.2.1.3-RXN>
-] .
+<http://model.geneontology.org/f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_15377_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_15377_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.2.1.3-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_3.2.1.3-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-9024>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002413_RXN-9023_null_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ae9f5bcb-1ace-4e8b-8c4d-60ddbda20e98_RXN-9025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a debranched &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YIL099W-MONOMER_RXN-9024_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001361> ;
@@ -517,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,36 +517,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.2.1.33-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.33-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002234_CHEBI_58601_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58601_RXN-9025>
+          <http://model.geneontology.org/CHEBI_43474_RXN-9025>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -564,21 +554,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a glycogen + phosphate &rarr; an &alpha;-limit dextrin + &alpha;-D-glucopyranose 1-phosphate' 'null' 'an &alpha;-limit dextrin &harr; a &alpha;-limit dextrin with short branches' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002413_RXN-9023_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
+          <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9023>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY>
@@ -586,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,54 +605,95 @@
 <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24384>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a glycogen &rarr; maltotetraose' 'null' 'maltotetraose + D-glucopyranose &harr; maltotriose + maltose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n H<sub>2</sub>O &rarr; n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002413_AMYLOMALT-RXN_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9024_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4038> ;
+          <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AMYLOMALT-RXN>
+          <http://model.geneontology.org/RXN-9024>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_24384>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_2ab9a943-742e-4346-9604-1bcde8c92efd_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002234_CHEBI_28460_RXN3O-4038_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4038> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_28460_RXN3O-4038>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000066_reaction_RXN-9023_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2ab9a943-742e-4346-9604-1bcde8c92efd_RXN-9023>
+          <http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -674,7 +705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,23 +716,12 @@
           <http://model.geneontology.org/CHEBI_17306_AMYLOMALT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_0330d08f-03eb-47d6-adab-52d962f8f6e2_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000066_reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +736,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/46f94b45-d6cb-401c-9a20-bf8475423866_RXN-9024> , <http://model.geneontology.org/CHEBI_15377_RXN-9024> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-9024> , <http://model.geneontology.org/2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_4167_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -724,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,19 +754,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_4167_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9024>
+          <http://model.geneontology.org/CHEBI_4167_3.2.1.3-RXN>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -754,36 +774,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002333_YIL099W-MONOMER_RXN-9024_controller_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL099W-MONOMER_RXN-9024_controller>
+          <http://model.geneontology.org/2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_24384_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/CHEBI_24384_GLYCOPHOSPHORYL-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58601_PHOSPHOGLUCMUT-RXN>
@@ -795,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +827,7 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/AMYLOMALT-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004135> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "maltotetraose + D-glucopyranose &harr; maltotriose + maltose" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -823,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -836,67 +856,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_d4d00372-5938-4d90-9e55-d45feaa87240_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d4d00372-5938-4d90-9e55-d45feaa87240_3.2.1.33-RXN>
+          <http://model.geneontology.org/c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_d4d00372-5938-4d90-9e55-d45feaa87240_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002333_CPLX3O-10513_RXN-9025_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4038> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9025> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-10513_RXN-9025_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58601_PHOSPHOGLUCMUT-RXN>
 ] .
 
 <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN>
@@ -910,7 +919,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_24384_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/0330d08f-03eb-47d6-adab-52d962f8f6e2_GLYCOPHOSPHORYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -918,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,12 +952,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002333_YPR184W-MONOMER_RXN3O-4038_controller_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -962,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,6 +1011,9 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000006364>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_28460_RXN3O-4038>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28460> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1000,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,19 +1033,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_15377_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3.2.1.3-RXN>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN>
@@ -1034,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1044,19 +1067,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9024> ;
+          <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
+          <http://model.geneontology.org/YPR184W-MONOMER_RXN-9023_controller>
 ] .
 
 <http://model.geneontology.org/reaction_AMYLOMALT-RXN_location_lociGO_0005829>
@@ -1071,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,19 +1104,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
+          <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
+          <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY>
@@ -1101,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1127,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1151,19 +1174,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.33-RXN> ;
+          <http://model.geneontology.org/3.2.1.3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
+          <http://model.geneontology.org/3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58601_RXN-9025>
@@ -1175,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,50 +1208,82 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN-9025>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a glycogen + phosphate &rarr; an &alpha;-limit dextrin + &alpha;-D-glucopyranose 1-phosphate' 'null' 'an &alpha;-limit dextrin &harr; a &alpha;-limit dextrin with short branches' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002413_RXN-9023_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9023>
+          <http://model.geneontology.org/ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN>
 ] .
+
+<http://model.geneontology.org/c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a &alpha;-limit dextrin with short branches" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1241,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1250,43 +1305,60 @@
 <http://purl.obolibrary.org/obo/GO_0004614>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a debranched &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n H<sub>2</sub>O &rarr; n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9024_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9024>
+          <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002234_CHEBI_28460_RXN3O-4038_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4038> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28460_RXN3O-4038>
+          <http://model.geneontology.org/reaction_RXN3O-4038_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
@@ -1294,41 +1366,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000066_reaction_RXN-9023_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9023> ;
+          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
+          <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_ae9f5bcb-1ace-4e8b-8c4d-60ddbda20e98_RXN-9025_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1340,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1354,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1387,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1402,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1415,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1469,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1485,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,52 +1552,65 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_4167_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4167_3.2.1.3-RXN>
-] .
-
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_46f94b45-d6cb-401c-9a20-bf8475423866_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.2.1.3-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_24384_3.2.1.3-RXN>
+] .
+
+<http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/46f94b45-d6cb-401c-9a20-bf8475423866_RXN-9024>
+          <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1549,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1557,81 +1629,66 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_24384_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_24384_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
-
-<http://model.geneontology.org/46f94b45-d6cb-401c-9a20-bf8475423866_RXN-9024>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a debranched &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_89e02f8a-773a-4d6c-87ba-bddf29f0ba84_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000066_reaction_3.2.1.33-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.2.1.33-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.33-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/89e02f8a-773a-4d6c-87ba-bddf29f0ba84_3.2.1.33-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002333_CPLX3O-10513_RXN-9025_controller_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-10513_RXN-9025_controller>
+          <http://model.geneontology.org/def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY>
@@ -1639,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1647,19 +1704,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58601_PHOSPHOGLUCMUT-RXN>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002333_YIL099W-MONOMER_3.2.1.3-RXN_controller_SGD_GLYCOCAT-YEAST-PWY>
@@ -1667,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1678,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1692,7 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1703,47 +1760,66 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000001610>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/7f83a05b-9e09-4e8f-b482-fd02e87490e3_RXN-9023>
+<http://model.geneontology.org/43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-limit dextrin" ;
+                "a &alpha;-limit dextrin with short branches" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000001610>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n phosphate &rarr; n &alpha;-D-glucopyranose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9025_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.3-RXN> ;
+          <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
+          <http://model.geneontology.org/RXN-9025>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002333_YPR184W-MONOMER_RXN3O-4038_controller_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4038> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPR184W-MONOMER_RXN3O-4038_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002234_CHEBI_28460_RXN3O-4038_SGD_GLYCOCAT-YEAST-PWY>
@@ -1751,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1759,20 +1835,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPR184W-MONOMER_RXN-9023_controller>
+          <http://model.geneontology.org/f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1780,7 +1867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1806,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1834,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1871,7 +1958,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_43474_RXN-9025> , <http://model.geneontology.org/ae9f5bcb-1ace-4e8b-8c4d-60ddbda20e98_RXN-9025> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN-9025> , <http://model.geneontology.org/def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58601_RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1881,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,19 +1978,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002333_YIL099W-MONOMER_3.2.1.3-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3.2.1.33-RXN>
+          <http://model.geneontology.org/YIL099W-MONOMER_3.2.1.3-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829>
@@ -1914,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1922,36 +2009,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002234_CHEBI_4167_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9025> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_0330d08f-03eb-47d6-adab-52d962f8f6e2_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9024> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_4167_RXN-9024>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0330d08f-03eb-47d6-adab-52d962f8f6e2_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_GLYCOCAT-YEAST-PWY>
@@ -1959,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1973,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1992,19 +2079,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller>
+          <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9024_null_GLYCOCAT-YEAST-PWY>
@@ -2012,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2020,21 +2107,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a debranched &alpha;-limit dextrin + n phosphate &rarr; n &alpha;-D-glucopyranose 1-phosphate' 'null' '&alpha;-D-glucopyranose 1-phosphate &harr; D-glucopyranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4038> ;
+          <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4038_location_lociGO_0005829>
+          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
@@ -2042,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2057,9 +2144,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> , <http://model.geneontology.org/89e02f8a-773a-4d6c-87ba-bddf29f0ba84_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d4d00372-5938-4d90-9e55-d45feaa87240_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> , <http://model.geneontology.org/481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2069,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,19 +2166,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002333_CPLX3O-10513_RXN-9025_controller_SGD_GLYCOCAT-YEAST-PWY>
@@ -2099,28 +2186,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/89e02f8a-773a-4d6c-87ba-bddf29f0ba84_3.2.1.33-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a &alpha;-limit dextrin with short branches" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2128,7 +2198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2142,6 +2212,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_28460>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/YPR184W-MONOMER_AMYLOMALT-RXN_controller>
         a       <http://identifiers.org/sgd/S000006388> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2149,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2162,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2173,27 +2246,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000066_reaction_3.2.1.3-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_24384_3.2.1.3-RXN>
+          <http://model.geneontology.org/reaction_3.2.1.3-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002333_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_SGD_GLYCOCAT-YEAST-PWY>
@@ -2201,7 +2276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2209,21 +2284,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'an &alpha;-limit dextrin &harr; a &alpha;-limit dextrin with short branches' 'null' 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002413_3.2.1.33-RXN_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9024> ;
+          <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829>
+          <http://model.geneontology.org/3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_4167_AMYLOMALT-RXN_SGD_GLYCOCAT-YEAST-PWY>
@@ -2231,29 +2306,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000066_reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
+          <http://model.geneontology.org/CPLX3O-10513_RXN-9025_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
@@ -2265,7 +2338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2273,25 +2346,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9025_null_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9025_null_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2304,7 +2377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2317,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2325,38 +2398,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '{6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n</sub> + H<sub>2</sub>O &rarr; {6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n-1</sub> + D-glucopyranose' 'null' 'maltotetraose + D-glucopyranose &harr; maltotriose + maltose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000066_reaction_3.2.1.33-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_AMYLOMALT-RXN_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.2.1.3-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/AMYLOMALT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.33-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_ae9f5bcb-1ace-4e8b-8c4d-60ddbda20e98_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ae9f5bcb-1ace-4e8b-8c4d-60ddbda20e98_RXN-9025>
+          <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829>
@@ -2364,37 +2439,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002333_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
+          <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
+          <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller>
 ] .
-
-<http://model.geneontology.org/2ab9a943-742e-4346-9604-1bcde8c92efd_RXN-9023>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a &alpha;-limit dextrin with short branches" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2406,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2426,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2442,7 +2500,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2453,29 +2522,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n phosphate &rarr; n &alpha;-D-glucopyranose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9025_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9025>
+          <http://model.geneontology.org/3.2.1.3-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY>
@@ -2483,44 +2550,53 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002333_YPR184W-MONOMER_RXN3O-4038_controller_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4038> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPR184W-MONOMER_RXN3O-4038_controller>
-] .
+<http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006364> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_7f83a05b-9e09-4e8f-b482-fd02e87490e3_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002233_CHEBI_24384_RXN3O-4038_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4038> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_24384_RXN3O-4038>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7f83a05b-9e09-4e8f-b482-fd02e87490e3_RXN-9023>
+          <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN>
@@ -2532,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2546,7 +2622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2566,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2579,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2590,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2601,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2612,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2625,7 +2701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2634,7 +2710,7 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RXN-9023>
-        a       <http://purl.obolibrary.org/obo/GO_0004135> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "an &alpha;-limit dextrin &harr; a &alpha;-limit dextrin with short branches" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2642,9 +2718,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/7f83a05b-9e09-4e8f-b482-fd02e87490e3_RXN-9023> ;
+                <http://model.geneontology.org/f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/2ab9a943-742e-4346-9604-1bcde8c92efd_RXN-9023> ;
+                <http://model.geneontology.org/43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_RXN-9023_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2652,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2662,68 +2738,59 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002333_YIL099W-MONOMER_3.2.1.3-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL099W-MONOMER_3.2.1.3-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002234_CHEBI_4167_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9024> ;
+          <http://model.geneontology.org/3.2.1.3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4167_RXN-9024>
+          <http://model.geneontology.org/CHEBI_24384_3.2.1.3-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_4167>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_15377_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
+          <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/CHEBI_15377_RXN-9024>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_89e02f8a-773a-4d6c-87ba-bddf29f0ba84_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000066_reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_4167>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004614> ;
@@ -2742,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2753,51 +2820,66 @@
 <http://purl.obolibrary.org/obo/GO_0004339>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.33-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_46f94b45-d6cb-401c-9a20-bf8475423866_RXN-9024_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a debranched &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a debranched &alpha;-limit dextrin + n phosphate &rarr; n &alpha;-D-glucopyranose 1-phosphate' 'null' '&alpha;-D-glucopyranose 1-phosphate &harr; D-glucopyranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_null_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.2.1.33-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002234_CHEBI_58601_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN>
+          <http://model.geneontology.org/CHEBI_58601_RXN-9025>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000066_reaction_3.2.1.3-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
@@ -2805,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2830,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2838,32 +2920,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_2ab9a943-742e-4346-9604-1bcde8c92efd_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
+          <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_GLYCOCAT-YEAST-PWY>
@@ -2871,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2882,7 +2955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2898,10 +2971,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycogen phosphorylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYCOLYSIS-GLYCOLYSIS.ttl
+++ b/models/GLYCOLYSIS-GLYCOLYSIS.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,53 +15,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002411_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PEPDEPHOS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLYCOLYSIS> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
+          <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://geneontology.org/lego/evidence>
@@ -72,27 +74,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000004818>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57634_6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
@@ -102,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,29 +120,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_3PGAREARR-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
+          <http://model.geneontology.org/3PGAREARR-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -145,11 +148,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +160,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
@@ -169,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,19 +182,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -210,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,22 +222,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002411_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/2PGADEHYDRAT-RXN>
@@ -256,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,19 +284,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_456216_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAL038W-MONOMER_PEPDEPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456216_PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS>
@@ -303,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -325,19 +326,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58272_3PGAREARR-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_58272_3PGAREARR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLYCOLYSIS>
@@ -345,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -375,19 +376,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_6PFRUCTPHOS-RXN>
@@ -399,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -431,21 +432,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
@@ -459,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -547,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,19 +578,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_TRIOSEPISOMERIZATION-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS>
@@ -597,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,39 +622,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
@@ -664,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -683,19 +682,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3PGAREARR-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_456216_PEPDEPHOS-RXN_SGD_GLYCOLYSIS>
@@ -703,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,22 +740,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS>
@@ -764,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -783,19 +780,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_F16BDEPHOS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001635>
@@ -808,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,11 +818,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +830,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_GLYCOLYSIS>
@@ -841,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -852,19 +849,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_RXN-15513_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58289_RXN-15513>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS>
@@ -872,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -880,19 +877,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
@@ -907,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -939,39 +936,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004818_CPLX3O-77_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
@@ -983,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1004,19 +999,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_58702_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR347C-MONOMER_PEPDEPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58702_PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS>
@@ -1024,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1092,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,19 +1097,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+          <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/YKL152C-MONOMER_3PGAREARR-RXN_controller>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -1132,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1145,19 +1140,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
@@ -1169,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1191,40 +1186,47 @@
 <http://purl.obolibrary.org/obo/CHEBI_58289>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component>
+        a       <http://identifiers.org/sgd/S000003472> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+          <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS>
@@ -1232,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1278,19 +1280,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
@@ -1301,27 +1303,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLYCOLYSIS>
@@ -1329,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,67 +1399,69 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_57642_TRIOSEPISOMERIZATION-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57642_TRIOSEPISOMERIZATION-RXN>
+          <http://model.geneontology.org/reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_30616_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1472,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1483,29 +1489,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002411_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3PGAREARR-RXN> ;
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_null_GLYCOLYSIS>
@@ -1513,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1521,19 +1525,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
@@ -1544,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1552,19 +1556,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_32966_F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLYCOLYSIS>
@@ -1572,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1586,20 +1590,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_32966_6PFRUCTPHOS-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/6PFRUCTPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003872> ;
@@ -1620,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,20 +1639,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_RXN-15513>
+          <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLYCOLYSIS>
@@ -1653,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1661,19 +1670,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
@@ -1685,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1709,19 +1718,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/3PGAREARR-RXN>
@@ -1743,7 +1752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1752,20 +1761,22 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLYCOLYSIS>
@@ -1773,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1798,19 +1809,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/YAL038W-MONOMER_PEPDEPHOS-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004634>
@@ -1841,7 +1852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1867,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1884,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1894,19 +1905,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
@@ -1918,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1945,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1960,7 +1971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1981,19 +1992,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_RXN-15513_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-15513>
+          <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/GLYCOLYSIS>
@@ -2005,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycolysis I (from glucose 6-phosphate) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2015,11 +2026,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2027,7 +2038,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004743>
@@ -2038,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2062,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2083,36 +2094,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
+          <http://model.geneontology.org/CHEBI_59776_TRIOSEPISOMERIZATION-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
@@ -2122,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2158,19 +2171,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15378_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15361_PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_6PFRUCTPHOS-RXN>
@@ -2182,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2201,19 +2214,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58289_3PGAREARR-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
@@ -2225,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2241,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2249,21 +2262,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+          <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_30616_PEPDEPHOS-RXN_SGD_GLYCOLYSIS>
@@ -2271,9 +2284,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004818_CPLX3O-77_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004818> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2282,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2298,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2308,38 +2330,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/F16ALDOLASE-RXN>
+          <http://model.geneontology.org/CHEBI_456216_6PFRUCTPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
@@ -2351,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2364,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2378,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2386,28 +2406,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_RXN-15513_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
+          <http://model.geneontology.org/CHEBI_58289_RXN-15513>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,7 +2435,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+          <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_null_GLYCOLYSIS>
@@ -2423,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2438,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2447,37 +2467,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
@@ -2489,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2505,7 +2527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2520,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2529,22 +2551,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGLUCISOM-RXN> ;
+          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YOR347C-MONOMER_PEPDEPHOS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS>
@@ -2552,7 +2572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2560,19 +2580,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_null_GLYCOLYSIS>
@@ -2580,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2591,19 +2611,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -2618,7 +2638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2631,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2646,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2659,21 +2679,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS>
@@ -2681,7 +2701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2696,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2713,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2726,27 +2746,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -2761,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2774,19 +2796,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_3PGAREARR-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3PGAREARR-RXN>
+          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLYCOLYSIS>
@@ -2794,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2802,20 +2824,26 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_57540_GAPOXNPHOSPHN-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/PEPDEPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004743> ;
@@ -2834,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2842,14 +2870,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2859,7 +2892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2867,19 +2900,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002411_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_57642_TRIOSEPISOMERIZATION-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_57642_TRIOSEPISOMERIZATION-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
@@ -2890,7 +2923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2898,19 +2931,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_456216_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_30616_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLYCOLYSIS>
@@ -2918,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2933,7 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2946,44 +2979,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58272_3PGAREARR-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_3PGAREARR-RXN>
+          <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0042132>
@@ -2994,7 +3029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3005,29 +3040,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6PFRUCTPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/RXN-15513>
@@ -3049,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3058,22 +3091,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/F16BDEPHOS-RXN>
+          <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS>
@@ -3081,7 +3112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3089,19 +3120,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_58272_RXN-15513>
 ] .
 
 <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
@@ -3113,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3129,7 +3160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3140,7 +3171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3148,19 +3179,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002411_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLYCOLYSIS>
@@ -3168,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3179,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3190,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3198,20 +3229,26 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
+          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000003472>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003424> ;
@@ -3220,16 +3257,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOLYSISProtein32828> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3239,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3247,39 +3281,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_32966>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGLUCISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
+          <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58272_3PGAREARR-RXN_SGD_GLYCOLYSIS>
@@ -3287,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3298,19 +3334,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_F16BDEPHOS-RXN>
+          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS>
@@ -3318,7 +3354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3329,7 +3365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3346,47 +3382,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_6PFRUCTPHOS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15513> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/CHEBI_30616_6PFRUCTPHOS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_RXN-15513_SGD_GLYCOLYSIS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-15513>
+] .
 
 <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3394,19 +3430,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
+          <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS>
@@ -3414,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3425,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3440,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3457,7 +3493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3470,7 +3506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3478,29 +3514,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2PGADEHYDRAT-RXN> ;
+          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphofructokinase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component> , <http://model.geneontology.org/SGD_S000004818_CPLX3O-77_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3513,7 +3551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3524,11 +3562,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_58702_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15378_PEPDEPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3536,7 +3574,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PEPDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58702_PEPDEPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
@@ -3548,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3567,7 +3605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3578,7 +3616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3586,39 +3624,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3PGAREARR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL152C-MONOMER_3PGAREARR-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58289_3PGAREARR-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
+          <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000001543>
@@ -3633,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3648,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3666,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3676,56 +3716,105 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001217>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_null_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/F16ALDOLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_GLYCOLYSIS/GLYCOLYSIS_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYCOLYSIS/GLYCOLYSIS>
+          <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_GLYCOLYSIS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_null_GLYCOLYSIS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/6PFRUCTPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/F16BDEPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_GLYCOLYSIS>
@@ -3733,7 +3822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3748,7 +3837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3757,22 +3846,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002411_2PGADEHYDRAT-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN> ;
+          <http://model.geneontology.org/RXN-15513> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -3780,19 +3867,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/F16ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
@@ -3803,29 +3890,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_null_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002411_PHOSGLYPHOS-RXN_SGD_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PEPDEPHOS-RXN> ;
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_RXN-15513_SGD_GLYCOLYSIS>
@@ -3833,7 +3918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3844,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3855,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3866,7 +3951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3891,7 +3976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3908,7 +3993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYOXYLATE-BYPASS-GLYOXYLATE-BYPASS.ttl
+++ b/models/GLYOXYLATE-BYPASS-GLYOXYLATE-BYPASS.ttl
@@ -1,18 +1,20 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_null_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
+          <http://model.geneontology.org/CITSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -23,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,10 +118,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "cytosolic malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,22 +132,20 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_null_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_57287_MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_CITSYN-RXN>
@@ -155,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,19 +167,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS>
+          <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -186,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -247,21 +249,24 @@
 <http://purl.obolibrary.org/obo/GO_0004108>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000002236>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS>
@@ -269,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,13 +337,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSProtein16754> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://identifiers.org/sgd/S000005486>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -348,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -376,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -395,36 +403,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MALSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ISOCIT-CLEAV-RXN_SGD_GLYOXYLATE-BYPASS> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15562_ISOCIT-CLEAV-RXN>
+          <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_GLYOXYLATE-BYPASS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_GLYOXYLATE-BYPASS>
@@ -432,9 +440,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
+        a       <http://identifiers.org/sgd/S000001568> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -443,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -479,13 +496,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSBiochemicalReaction16694> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_null_GLYOXYLATE-BYPASS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MALATE-DEH-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15378_MALSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -496,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,19 +542,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
+          <http://model.geneontology.org/GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -533,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,17 +598,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MALSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -593,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,12 +626,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_CITSYN-RXN_SGD_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,23 +676,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -681,19 +728,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS>
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_GLYOXYLATE-BYPASS>
@@ -701,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -780,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -806,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,19 +863,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIR031C-MONOMER_MALSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_MALSYN-RXN>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -836,19 +883,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ISOCIT-CLEAV-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15562_ISOCIT-CLEAV-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15589_MALSYN-RXN>
@@ -860,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -939,10 +986,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "peroxisome malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -955,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -981,19 +1030,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003994>
@@ -1005,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1038,36 +1087,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36655_MALSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS_SGD_GLYOXYLATE-BYPASS> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_GLYOXYLATE-BYPASS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_GLYOXYLATE-BYPASS>
@@ -1075,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1189,22 +1238,37 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YIR031C-MONOMER_MALSYN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16947>
@@ -1215,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,23 +1304,23 @@
           <http://model.geneontology.org/ISOCIT-CLEAV-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1296,19 +1360,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1317,7 +1381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1412,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1437,36 +1501,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_MALSYN-RXN>
+          <http://model.geneontology.org/CHEBI_36655_MALSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_ISOCIT-CLEAV-RXN>
+          <http://model.geneontology.org/GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1480,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1511,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1543,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1556,27 +1620,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
+          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_GLYOXYLATE-BYPASS>
@@ -1584,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1596,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1612,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1637,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1650,29 +1716,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_null_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1681,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1732,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1779,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,19 +1853,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL117W-MONOMER_MALSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15589_MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_GLYOXYLATE-BYPASS/GLYOXYLATE-BYPASS_SGD_GLYOXYLATE-BYPASS>
@@ -1809,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1822,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1831,22 +1895,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' 'null' 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_null_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MALSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30031_ISOCIT-CLEAV-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1855,7 +1917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,6 +1928,9 @@
           <http://model.geneontology.org/CHEBI_15562_ACONITATEHYDR-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000001568>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_36655> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1875,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1894,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1918,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1928,19 +1993,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1949,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,12 +2025,21 @@
           <http://model.geneontology.org/CHEBI_15378_CITSYN-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002236> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1977,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1993,57 +2067,69 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005486> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_ACONITATEDEHYDR-RXN_SGD_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_null_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_null_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_MALSYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_GLYOXYLATE-BYPASS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ISOCIT-CLEAV-RXN_SGD_GLYOXYLATE-BYPASS>
@@ -2051,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2063,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2079,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2096,18 +2182,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YNL117W-MONOMER_MALSYN-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2118,27 +2221,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' 'null' 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_null_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
+          <http://model.geneontology.org/MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_null_GLYOXYLATE-BYPASS>
@@ -2146,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2158,7 +2263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,7 +2282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2191,7 +2296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2208,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2222,29 +2327,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_null_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CITSYN-RXN>
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2253,7 +2356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2288,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2305,7 +2408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2318,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2336,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2350,7 +2453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2366,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2377,7 +2480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2388,36 +2491,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_MALSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_null_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
+          <http://model.geneontology.org/reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2426,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2437,12 +2542,23 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2452,10 +2568,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "mitochondrial malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2465,19 +2583,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
@@ -2489,7 +2607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2519,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2547,7 +2665,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2562,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYSYN-ALA-PWY-GLYSYN-ALA-PWY.ttl
+++ b/models/GLYSYN-ALA-PWY-GLYSYN-ALA-PWY.ttl
@@ -1,11 +1,11 @@
 <http://model.geneontology.org/MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000001864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "alanine:glyoxylate aminotransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
+<http://identifiers.org/sgd/S000001864>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYSYN-PWY-GLYSYN-PWY.ttl
+++ b/models/GLYSYN-PWY-GLYSYN-PWY.ttl
@@ -3,9 +3,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -16,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,23 +58,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/2d7db0b2-7f84-4959-98a5-1ed44c1c8c31_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/GLYSYN-PWY/GLYSYN-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -71,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -84,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -118,11 +112,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_2d7db0b2-7f84-4959-98a5-1ed44c1c8c31_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +124,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2d7db0b2-7f84-4959-98a5-1ed44c1c8c31_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -140,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,6 +145,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -160,23 +165,12 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_2d7db0b2-7f84-4959-98a5-1ed44c1c8c31_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_GLYSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,17 +215,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_9186a0d5-a907-4591-9d39-6cdc74c5c98f_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -247,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,6 +295,40 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -320,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -331,11 +348,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_9186a0d5-a907-4591-9d39-6cdc74c5c98f_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +360,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9186a0d5-a907-4591-9d39-6cdc74c5c98f_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -361,15 +378,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/2d7db0b2-7f84-4959-98a5-1ed44c1c8c31_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/9186a0d5-a907-4591-9d39-6cdc74c5c98f_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,29 +454,12 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/9186a0d5-a907-4591-9d39-6cdc74c5c98f_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYSYN-THR-PWY-GLYSYN-THR-PWY.ttl
+++ b/models/GLYSYN-THR-PWY-GLYSYN-THR-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/HEME-BIOSYNTHESIS-II-HEME-BIOSYNTHESIS-II.ttl
+++ b/models/HEME-BIOSYNTHESIS-II-HEME-BIOSYNTHESIS-II.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,17 +364,6 @@
           <http://model.geneontology.org/CHEBI_17627_PROTOHEMEFERROCHELAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -383,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,6 +382,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_UROGENDECARBOX-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -524,21 +524,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/CHEBI_29033_PROTOHEMEFERROCHELAT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29033> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Fe<SUP>2+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEME-BIOSYNTHESIS-IISmallMolecule42259> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_HEME-BIOSYNTHESIS-II>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,6 +575,9 @@
           <http://model.geneontology.org/CHEBI_15379_RXN0-1461>
 ] .
 
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -569,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,23 +596,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/CHEBI_29033_PROTOHEMEFERROCHELAT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29033> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Fe<SUP>2+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEME-BIOSYNTHESIS-IISmallMolecule42259> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PROTOHEMEFERROCHELAT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004325> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -699,7 +699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "heme <i>b</i> biosynthesis I (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,7 +1377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,7 +1397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,7 +1491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>

--- a/models/HEXPPSYN-PWY-2-HEXPPSYN-PWY-2.ttl
+++ b/models/HEXPPSYN-PWY-2-HEXPPSYN-PWY-2.ttl
@@ -4,29 +4,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_58057>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_HEXPPSYN-PWY-2/HEXPPSYN-PWY-2_SGD_HEXPPSYN-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,35 +70,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2BiochemicalReaction56207> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -115,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,13 +95,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,23 +198,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_null_HEXPPSYN-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "hexaprenyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,6 +905,17 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -913,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,17 +935,6 @@
           <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'isopentenyl diphosphate + (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; geranylgeranyl diphosphate + diphosphate' 'null' 'geranylgeranyl diphosphate + isopentenyl diphosphate &rarr; geranylfarnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1180,7 +1180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,17 +1191,6 @@
           <http://model.geneontology.org/HEXPPSYN-PWY-2/HEXPPSYN-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58179> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1211,13 +1200,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56117> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1291,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1468,14 +1468,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_58756_RXN-8813>
         a       <http://purl.obolibrary.org/obo/CHEBI_58756> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1486,13 +1483,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56156> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YJL167W-MONOMER_GPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003703> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1514,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1531,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,23 +1601,6 @@
           <http://model.geneontology.org/FPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_128769_RXN3O-9805>
@@ -1629,13 +1612,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56107> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58756> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1660,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1704,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1758,7 +1758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/HISTSYN-PWY-HISTSYN-PWY.ttl
+++ b/models/HISTSYN-PWY-HISTSYN-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,30 +403,30 @@
           <http://model.geneontology.org/CHEBI_15377_HISTALDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_null_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTCYCLOHYD-RXN_SGD_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_null_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://model.geneontology.org/reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000535> ;
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,28 +1286,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_59457_HISTCYCLOHYD-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_59457> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(5-phospho-&beta;-D-ribosyl)-AMP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24384> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1315,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,6 +1309,23 @@
           <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_59457_HISTCYCLOHYD-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_59457> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(5-phospho-&beta;-D-ribosyl)-AMP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24384> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58525> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1335,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1349,7 +1349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1361,7 @@
 ] .
 
 <http://model.geneontology.org/HISTOLDEHYD-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004636> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1379,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,6 +1466,23 @@
           <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57699_HISTIDPHOS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_HISTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_GLUTAMIDOTRANS-RXN>
@@ -1477,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1485,29 +1502,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_HISTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
-] .
-
 <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-histidine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1614,16 +1614,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_null_HISTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -1636,30 +1644,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_null_HISTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1667,7 +1667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1690,7 +1690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1769,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,7 +1847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1878,7 +1878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1940,7 +1940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2011,7 +2011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2027,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2038,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2053,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2067,7 +2067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2115,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2130,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2143,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2182,7 +2182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2228,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2284,7 +2284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2309,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2337,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2367,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2416,7 +2416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2433,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2467,7 +2467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2489,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2500,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2511,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2526,7 +2526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2546,7 +2546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2562,7 +2562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2574,7 +2574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2610,18 +2610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTIDPHOS-RXN_SGD_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2632,9 +2621,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTIDPHOS-RXN_SGD_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2643,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2655,7 +2655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2700,7 +2700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2714,7 +2714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2733,7 +2733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2749,7 +2749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2778,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2814,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2829,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2844,7 +2844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2860,7 +2860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2876,7 +2876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2888,7 +2888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2899,13 +2899,28 @@
           <http://model.geneontology.org/YFR025C-MONOMER_HISTIDPHOS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005728> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "imidazole glycerol-phosphate dehydratase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYProtein24529> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_HISTSYN-PWY/HISTSYN-PWY_SGD_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2916,27 +2931,12 @@
           <http://model.geneontology.org/HISTSYN-PWY/HISTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005728> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "imidazole glycerol-phosphate dehydratase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYProtein24529> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_HISTPRATPHYD-RXN_SGD_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2948,7 +2948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2971,7 +2971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2985,7 +2985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3012,7 +3012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3024,7 +3024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3044,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3058,7 +3058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3074,7 +3074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3089,7 +3089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3109,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3127,7 +3127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3144,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3157,7 +3157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3168,7 +3168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3186,7 +3186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,7 +3205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3222,7 +3222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3256,7 +3256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3270,7 +3270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3297,7 +3297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3308,7 +3308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3322,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3334,7 +3334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3364,7 +3364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3400,7 +3400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3422,7 +3422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3438,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3453,7 +3453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3462,7 +3462,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/HISTALDEHYD-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004636> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "histidinal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-histidine + NADH + 2 H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3478,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3491,7 +3491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3509,7 +3509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3525,7 +3525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3545,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3559,7 +3559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3575,7 +3575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3598,7 +3598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3614,7 +3614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3631,7 +3631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3650,7 +3650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3665,7 +3665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3689,7 +3689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3703,7 +3703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/HOMOCYS-CYS-CONVERT-HOMOCYS-CYS-CONVERT.ttl
+++ b/models/HOMOCYS-CYS-CONVERT-HOMOCYS-CYS-CONVERT.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,8 +102,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -111,7 +119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,13 +130,16 @@
           <http://model.geneontology.org/CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,18 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -817,7 +817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -892,7 +892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,7 +1095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "homocysteine and cysteine interconversion - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1143,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,6 +1174,21 @@
           <http://model.geneontology.org/CHEBI_35235_CYSTAGLY-RXN>
 ] .
 
+<http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
+        a       <http://identifiers.org/sgd/S000003891> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "cystathionine gamma-synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTProtein61185> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1183,28 +1198,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTSmallMolecule61088> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
-        a       <http://identifiers.org/sgd/S000003891> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "cystathionine gamma-synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTProtein61185> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_30089_RXN-721>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30089> ;
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1272,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1455,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,7 +1469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,7 +1486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1549,7 +1549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1624,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,7 +1655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/HOMOCYSDEGR-PWY-1-HOMOCYSDEGR-PWY-1.ttl
+++ b/models/HOMOCYSDEGR-PWY-1-HOMOCYSDEGR-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-cysteine biosynthesis III (from L-homocysteine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/HOMOSER-THRESYN-PWY-HOMOSER-THRESYN-PWY.ttl
+++ b/models/HOMOSER-THRESYN-PWY-HOMOSER-THRESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/HOMOSERSYN-PWY-HOMOSERSYN-PWY.ttl
+++ b/models/HOMOSERSYN-PWY-HOMOSERSYN-PWY.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homoserine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,18 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +128,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,23 +267,23 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002411_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,13 +777,24 @@
           <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,17 +805,6 @@
           <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -993,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,13 +1181,16 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000003900>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,9 +1200,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
-
-<http://identifiers.org/sgd/S000003900>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1232,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/ILEUSYN-PWY-1-ILEUSYN-PWY-1.ttl
+++ b/models/ILEUSYN-PWY-1-ILEUSYN-PWY-1.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_ILEUSYN-PWY-1/ILEUSYN-PWY-1_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOOHBUTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ILEUSYN-PWY-1/ILEUSYN-PWY-1>
+          <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,22 +116,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_null_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THREDEHYD-RXN> ;
+          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THREDEHYD-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -140,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,9 +160,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
+        a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -174,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,6 +224,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829>
 ] .
+
+<http://identifiers.org/sgd/S000004714>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -237,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -269,20 +279,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_null_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_ILEUSYN-PWY-1>
@@ -290,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,19 +340,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_THREDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_57926_THREDEHYD-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -349,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -376,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,24 +524,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000515> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+          <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -538,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -578,6 +599,23 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_ILEUSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THREDEHYD-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YER086W-MONOMER_THREDEHYD-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
@@ -585,7 +623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,6 +668,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_49256_ACETOOHBUTREDUCTOISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_49256> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -639,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,22 +697,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_null_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOOHBUTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_null_ILEUSYN-PWY-1>
@@ -671,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -730,19 +777,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_ILEUSYN-PWY-1/ILEUSYN-PWY-1_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57926_THREDEHYD-RXN>
+          <http://model.geneontology.org/ILEUSYN-PWY-1/ILEUSYN-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0052656>
@@ -754,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,7 +868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -880,19 +927,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -901,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -961,19 +1008,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER086W-MONOMER_THREDEHYD-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16763_THREDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ACETOOHBUTREDUCTOISOM-RXN>
@@ -995,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,19 +1221,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_ILEUSYN-PWY-1/ILEUSYN-PWY-1_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THREDEHYD-RXN> ;
+          <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ILEUSYN-PWY-1/ILEUSYN-PWY-1>
+          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_null_ILEUSYN-PWY-1>
@@ -1194,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1206,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1226,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1267,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1322,13 +1369,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ILEUSYN-PWY-1Protein71475> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-threonine &rarr; 2-oxobutanoate + ammonium' 'null' 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_null_ILEUSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THREDEHYD-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
+] .
 
 <http://model.geneontology.org/reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1339,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,10 +1420,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetolactate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component> , <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,13 +1469,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ILEUSYN-PWY-1BiochemicalReaction71684> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1418,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-isoleucine biosynthesis I (from threonine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1431,19 +1502,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_ILEUSYN-PWY-1/ILEUSYN-PWY-1_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_49258_DIHYDROXYMETVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/ILEUSYN-PWY-1/ILEUSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_ILEUSYN-PWY-1/ILEUSYN-PWY-1_SGD_ILEUSYN-PWY-1>
@@ -1451,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1505,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1516,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1529,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,20 +1609,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_null_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16763_THREDEHYD-RXN>
+          <http://model.geneontology.org/reaction_THREDEHYD-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1560,7 +1633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1606,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1614,13 +1687,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000000515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1657,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1671,7 +1747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,6 +1758,17 @@
           <http://model.geneontology.org/CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004160>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1690,18 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1715,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1723,19 +1799,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1746,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1780,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1795,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1803,12 +1879,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1818,22 +1905,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-threonine &rarr; 2-oxobutanoate + ammonium' 'null' 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_null_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THREDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
+          <http://model.geneontology.org/CHEBI_28938_THREDEHYD-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1842,7 +1927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1865,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1878,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/IPPSYN-PWY-IPPSYN-PWY.ttl
+++ b/models/IPPSYN-PWY-IPPSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,6 +161,23 @@
           <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_MEVALONATE-KINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_IPPSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57623_IPPISOM-RXN>
@@ -172,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,29 +197,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_IPPSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_IPPSYN-PWY/IPPSYN-PWY_SGD_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -965,7 +965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1311,7 +1311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1334,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1388,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1434,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1480,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,23 +1508,12 @@
           <http://model.geneontology.org/CHEBI_58146_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57287_1.1.1.34-RXN_SGD_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1536,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,6 +1536,17 @@
           <http://model.geneontology.org/IPPSYN-PWY/IPPSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_128769>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1556,7 +1556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,7 +1573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1620,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1634,7 +1634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1669,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1710,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1858,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1935,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1961,7 +1961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +1978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,7 +1998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2051,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2085,7 +2085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2101,7 +2101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2115,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2131,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2146,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2163,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2214,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2248,20 +2248,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002411_MEVALONATE-KINASE-RXN_SGD_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 <http://model.geneontology.org/CHEBI_36464_MEVALONATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36464> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2271,7 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2279,12 +2265,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002411_MEVALONATE-KINASE-RXN_SGD_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_null_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2295,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2335,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2355,7 +2355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2368,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2380,7 +2380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2427,7 +2427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2440,7 +2440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2455,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2469,7 +2469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2485,7 +2485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2496,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2513,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2530,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2541,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2553,7 +2553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2570,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2581,13 +2581,16 @@
           <http://model.geneontology.org/YPL117C-MONOMER_IPPISOM-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0003985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2598,9 +2601,6 @@
           <http://model.geneontology.org/CHEBI_57557_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0003985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YML075C-MONOMER_1.1.1.34-RXN_controller>
         a       <http://identifiers.org/sgd/S000004540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2608,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2627,7 +2627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2638,7 +2638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2655,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2667,7 +2667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,6 +2676,25 @@
           <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_IPPSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
@@ -2687,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2695,31 +2714,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_IPPSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
-] .
-
 <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2737,7 +2737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2750,7 +2750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/LEUSYN-PWY-1-LEUSYN-PWY-1.ttl
+++ b/models/LEUSYN-PWY-1-LEUSYN-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,20 +37,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1SmallMolecule49773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005634> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "alpha-isopropylmalate synthase, minor isozyme" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,30 +92,13 @@
           <http://model.geneontology.org/CHEBI_57945_RXN-13158>
 ] .
 
-<http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1SmallMolecule49773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,26 +802,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
 <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_LEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002411_RXN-13163_SGD_LEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,23 +844,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_LEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,16 +1147,8 @@
           <http://model.geneontology.org/LEUSYN-PWY-1/LEUSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_LEUSYN-PWY-1/LEUSYN-PWY-1_SGD_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://identifiers.org/sgd/S000005634>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1164,7 +1156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,11 +1167,19 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_LEUSYN-PWY-1/LEUSYN-PWY-1_SGD_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-leucine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1207,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1241,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1321,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1371,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1398,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,7 +1450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,11 +1475,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "branched-chain amino acid transaminase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1Protein49874> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1489,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1500,21 +1515,6 @@
           <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "branched-chain amino acid transaminase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1Protein49874> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1524,7 +1524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/LIPASYN-PWY-1-LIPASYN-PWY-1.ttl
+++ b/models/LIPASYN-PWY-1-LIPASYN-PWY-1.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,7 +76,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,30 +87,13 @@
           <http://model.geneontology.org/CHEBI_295975_PHOSPHOLIPASE-C-RXN>
 ] .
 
-<http://model.geneontology.org/a5589bad-1471-4c5c-adc2-36b2720d8a91_3.1.4.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15354_PHOSCHOL-RXN_SGD_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,17 +103,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15354_PHOSCHOL-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_a5589bad-1471-4c5c-adc2-36b2720d8a91_3.1.4.11-RXN_SGD_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -147,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -251,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -369,11 +341,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_a5589bad-1471-4c5c-adc2-36b2720d8a91_3.1.4.11-RXN_SGD_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN_SGD_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +353,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a5589bad-1471-4c5c-adc2-36b2720d8a91_3.1.4.11-RXN>
+          <http://model.geneontology.org/329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004435>
@@ -392,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -613,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -638,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -817,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +818,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/a5589bad-1471-4c5c-adc2-36b2720d8a91_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -856,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -873,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -948,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipids degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1058,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,6 +1041,17 @@
           <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN_SGD_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -1077,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1088,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1212,6 +1195,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1220,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,16 +1225,22 @@
           <http://model.geneontology.org/reaction_PHOSPHOLIPASE-C-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1248,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/LYSDEGII-PWY-LYSDEGII-PWY.ttl
+++ b/models/LYSDEGII-PWY-LYSDEGII-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -119,7 +119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -418,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,7 +747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,7 +826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1258,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1291,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1465,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1522,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,7 +1575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,16 +1673,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26417> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_79192>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57540_KETAMID-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1693,7 +1690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,12 +1698,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_79192>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_null_LYSDEGII-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,7 +1779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1802,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1846,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1875,7 +1875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1894,7 +1894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1910,7 +1910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1922,7 +1922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1942,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1997,7 +1997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2059,7 +2059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2072,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2106,7 +2106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2122,7 +2122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2133,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2147,7 +2147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2158,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/LYSINE-AMINOAD-PWY-2-LYSINE-AMINOAD-PWY-2.ttl
+++ b/models/LYSINE-AMINOAD-PWY-2-LYSINE-AMINOAD-PWY-2.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -792,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -941,7 +941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,7 +1262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,24 +1304,13 @@
           <http://model.geneontology.org/LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002411_1.5.1.7-RXN_SGD_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000050_LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2_SGD_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,12 +1321,23 @@
           <http://model.geneontology.org/LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002411_1.5.1.7-RXN_SGD_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_58672_RXN3O-9808_SGD_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,7 +1421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,7 +1438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,7 +1455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1544,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1555,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1573,7 +1573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1666,7 +1666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1707,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1719,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,7 +1739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,9 +1750,6 @@
           <http://model.geneontology.org/CHEBI_57951_RXN3O-127>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YDL182W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002341> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1760,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1801,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1812,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1826,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1866,7 +1863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1883,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,7 +1945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1976,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1990,7 +1987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2009,7 +2006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2045,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2057,7 +2054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2080,7 +2077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2097,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2113,7 +2110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2138,7 +2135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2172,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2202,7 +2199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2229,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2243,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2255,7 +2252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2289,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2309,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2323,7 +2320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2342,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2367,7 +2364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2381,7 +2378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2397,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2426,7 +2423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2439,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2451,7 +2448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2467,18 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002333_YBR115C-MONOMER_RXN3O-9808_controller_SGD_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2490,7 +2476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2501,12 +2487,23 @@
           <http://model.geneontology.org/CHEBI_58672_RXN3O-9808>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002333_YBR115C-MONOMER_RXN3O-9808_controller_SGD_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57540_1.5.1.7-RXN_SGD_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2520,7 +2517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2540,7 +2537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2573,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2589,7 +2586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2600,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2615,13 +2612,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YBR115C-MONOMER_RXN3O-9808_controller>
         a       <http://identifiers.org/sgd/S000000319> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2630,24 +2638,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2Protein73565> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32551_1.5.1.7-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32551> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2658,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2675,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2692,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2707,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2721,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2741,7 +2738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,7 +2758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2775,7 +2772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2790,13 +2787,13 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/MONOMER3O-363_RXN3O-127_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005333> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "saccharopine dehydrogenase (NADP+, L-glutamate-forming)" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2812,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2830,7 +2827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2847,7 +2844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2864,7 +2861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,7 +2878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2897,7 +2894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2912,7 +2909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2926,7 +2923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2943,7 +2940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,7 +2960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2979,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2994,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3007,7 +3004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3021,7 +3018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3044,7 +3041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3064,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3081,7 +3078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3093,6 +3090,9 @@
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57499>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000005333>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0047536>
@@ -3107,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3124,7 +3124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3141,7 +3141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3158,7 +3158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3177,7 +3177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,7 +3197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3211,7 +3211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3227,7 +3227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3241,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3252,7 +3252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3263,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3275,7 +3275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/NADSYN-PWY-NADSYN-PWY.ttl
+++ b/models/NADSYN-PWY-NADSYN-PWY.ttl
@@ -1,44 +1,133 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_58125>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000003839>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
+] .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,157 +135,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57502>
+<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "formate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23466> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000003242>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -207,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,27 +175,120 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_NADSYN-PWY>
+<http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "gln" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23219> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADPH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23427> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/GO_0033754>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,79 +296,226 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
+          <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_994_RXN-5721>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58017>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynureninase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23397> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23192> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_456215>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "Nicotinamide adenine dinucleotide (NAD) is an essential cofactor for cellular redox reactions and energy metabolism. NAD also has been shown to be an important substrate in a variety of biological processes, including transcriptional regulation, DNA repair, calcium-dependent signaling pathways, calorie-restriction-mediated life-span extension and age-associated diseases |CITS: [12736687],[12648681]|. NAD appears to affect these processes by regulating the Sir2p family of NAD-dependent deacetylases (Sirtuins) |CITS: [12648681]|. There are a number of pathways for NAD biosynthesis. In yeast and most other organisms, the two major pathways are de novo synthesis of NAD (the de novo pathway) and regeneration of NAD from its nicotinamide degradation products (the NAD salvage pathway) |CITS: [12972620], [12648681]|. NAD is synthesized de novo from tryptophan via kynurenine |CITS: [12972620]|. In this pathway tryptophan is converted to nicotinic acid mononucleotide (NAMN) in 6 enzymatic steps (catalyzed by Bna1-2p, and Bna4-7p) and one non-enzymatic step |CITS: [12972620]|. At NAMN the de novo pathway converges with the NAD salvage pathway and the last two steps to NAD are shared |CITS: [12972620], [12648681]|. In the yeast NAD salvage pathway, the vitamin precursors nicotinamide and nicotinic acid are converted to NAMN, the point of convergence with the de novo pathway |CITS: [12648681]|. The steps from nicotinic acid to NAD were elucidated by Preiss and Handler and are sometimes referred to as the Preiss-Handler pathway |CITS: [13416279], [13563526]|. Yeast can also import extracellular nicotinic acid into the cell by the permease Tna1p and then convert it into NAD via the Preiss-Handler pathway |CITS: [12648681]|. There are four additional pathways for synthesizing NAD in yeast: two salvage pathways from the vitamin precursor nicotinamide riboside (NR) and two salvage pathways from nicotinic acid riboside (NaR) |CITS: [15137942], [17482543], [17914902]|. Three of these salvage pathways converge first with the NAD salvage pathway and then with the de novo pathway, while the fourth, the NR salvage pathway I, is independent of both of these pathways. In the NR salvage pathway I, NR is phosphorylated to nicotinamide mononucleotide by the kinase Nrk1p, and then adenylated to NAD by Nma1p or Nma2p |CITS: [15137942]|. Bacteria such as Haemophilus influenza that lack the enzymes of the de novo and Preiss-Handler pathway can synthesize NAD from NR and nicotinamide mononucleotide as well |CITS: [15137942]|. Humans also appear to have this NR salvage pathway |CITS: [15137942]|. Yeast have a second NR salvage pathway (NR salvage pathway II) that is independent of Nrk1p; in NR salvage pathway II NR is split into a ribosyl product and nicotinamide, which is subsequently converted to NAD via enzymes of the NAD salvage pathway and de novo pathway |CITS: [17482543]|. The initial steps in the two NaR salvage pathways are similar to those of the NR salvage pathways and are catalyzed by the same enzymes; Nrk1p catalyzes the first step in the NR and NaR salvage pathways I and Urh1p and Pnp1p catalyze the first steps of the NR and NaR salvage pathways II |CITS: [17914902]|." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD <i>de novo</i> biosynthesis II (from tryptophan)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "NADSYN-PWY" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,108 +538,53 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+<http://identifiers.org/sgd/S000001116>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
+] .
+
+<http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
+                "3-hydroxyanthranilate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23354> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15740>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003839> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Tryptophan 2,3-dioxygenase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23338> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58629_RXN-8665>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -449,7 +594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,73 +605,170 @@
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ala" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23390> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+          <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
+<http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glutamine-dependent NAD synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23274> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_null_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_58629_RXN-8665>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-Formyl-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23331> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29959>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
+] .
+
+<http://identifiers.org/sgd/S000001943>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003839> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Tryptophan 2,3-dioxygenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23338> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15740>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -536,7 +778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,84 +789,282 @@
           <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15379_RXN-8665>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "O<SUB>2</SUB>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23305> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Arylformamidase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23473> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/1.13.11.6-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0000334> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/RXN-5721> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23341> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+] .
+
+<http://model.geneontology.org/CHEBI_29959_QUINOPRIBOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29959> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "quinolinate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23079> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynurenine aminotransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23479> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_null_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29959_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29959_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://identifiers.org/sgd/S000000194>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003952>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004502> ;
@@ -645,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,594 +1093,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
+<http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "O<SUB>2</SUB>" ;
+                "glu" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23305> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23236> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_29959_QUINOPRIBOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29959> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "quinolinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23079> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23111> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_29959_RXN-5721>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "quinolinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23079> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_456215>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002411_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
-] .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_36559>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0004061>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
-] .
-
-<http://identifiers.org/sgd/S000001943>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
-] .
-
-<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynurenine aminotransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23479> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58017>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
-] .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
-] .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_null_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58125> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxy-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23376> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000004320>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.13.11.6-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1248,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,298 +1127,14 @@
           <http://model.geneontology.org/CHEBI_15379_RXN-8665>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58125>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
-] .
-
-<http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23412> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030429> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/1.13.11.6-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23364> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001943> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Quinolinate phosphoribosyl transferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23175> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0003952>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/RXN-8665>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033754> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57912_RXN-8665> , <http://model.geneontology.org/CHEBI_15379_RXN-8665> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58629_RXN-8665> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23292> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_994_RXN-5721>
-        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-3-carboxymuconate-6-semialdehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ala" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23390> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1560,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,318 +1155,114 @@
           <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_null_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0000334>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-<http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004514> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29959_QUINOPRIBOTRANS-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23097> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-5721>
+          <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADPH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23427> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000002836>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
+<http://identifiers.org/sgd/S000004320>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' 'null' '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004514>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+<http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
+                "diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23192> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_NADSYN-PWY>
+<http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
-] .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1890,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1901,88 +1281,43 @@
           <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_15377_RXN-5721>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
+          <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "formate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23466> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
+<http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1993,218 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0033754>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004320> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23289> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58629> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-Formyl-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23331> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0030429>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58437> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "nicotinate adenine dinucleotide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23205> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29959_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2215,69 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57912_RXN-8665>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57912> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "trp" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23319> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
-] .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2285,189 +1347,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxyanthranilate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23354> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+          <http://model.geneontology.org/RXN-5721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_994_RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29959_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2479,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,65 +1401,103 @@
           <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "glutamine-dependent NAD synthase" ;
+                "ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23274> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23178> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
+] .
 
 <http://identifiers.org/sgd/S000003596>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004061>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NaMN" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23139> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2559,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,40 +1517,21 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
 ] .
-
-<http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "AMP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23252> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2612,7 +1542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2620,74 +1550,81 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
-] .
+<http://purl.obolibrary.org/obo/GO_0000334>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
-] .
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "gln" ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001943> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Quinolinate phosphoribosyl transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23219> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23175> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
 <http://model.geneontology.org/RXN-5721>
@@ -2707,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2715,142 +1652,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://identifiers.org/sgd/S000004221>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23442> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57912_RXN-8665>
+          <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004061> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller> , <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23452> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58125> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxy-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23376> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2860,7 +1677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2871,212 +1688,67 @@
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23412> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_57972>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+<http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
+                "AMP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23192> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23252> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
-] .
+<http://purl.obolibrary.org/obo/CHEBI_57959>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
+<http://purl.obolibrary.org/obo/GO_0004502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23283> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29959_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29959_QUINOPRIBOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynureninase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23397> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23178> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57912_RXN-8665>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3084,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3095,19 +1767,756 @@
           <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57959>
+<http://purl.obolibrary.org/obo/CHEBI_994>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
+] .
+
+<http://model.geneontology.org/CHEBI_58629_RXN-8665>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-Formyl-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23331> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Arylformamidase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23473> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-3-carboxymuconate-6-semialdehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004514>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_57972>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23412> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15379>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57912>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NaMN" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23139> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN-5721>
+] .
+
+<http://model.geneontology.org/CHEBI_15377_RXN-5721>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0030429>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58629> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-Formyl-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23331> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "NAD <i>de novo</i> biosynthesis II (from tryptophan) - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58125> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxy-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23376> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58629>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23192> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+<http://identifiers.org/sgd/S000003242>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_null_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
+] .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004320> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23289> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004515> ;
@@ -3128,7 +2537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3136,56 +2545,264 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23111> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/GO_0004061> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller> , <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23452> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58629_RXN-8665>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
+] .
+
+<http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000003839>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58437> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "nicotinate adenine dinucleotide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23205> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
+          <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "O<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23305> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23412> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29959_RXN-5721>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3193,7 +2810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3204,113 +2821,100 @@
           <http://model.geneontology.org/CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/RXN-8665>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033754> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_57912_RXN-8665> , <http://model.geneontology.org/CHEBI_15379_RXN-8665> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_58629_RXN-8665> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23292> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58437>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-3-carboxymuconate-6-semialdehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004515>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23236> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://identifiers.org/sgd/S000000194>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15379>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3318,31 +2922,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+          <http://model.geneontology.org/RXN-5721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
+          <http://model.geneontology.org/CHEBI_29959_RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_29959_RXN-5721>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "quinolinate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23079> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -3353,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3361,167 +2971,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57502> ;
+<http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "NaMN" ;
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23139> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000003786>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15379_RXN-8665>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "O<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23305> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0004502>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_57912>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' 'null' '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-5721>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
-] .
-
-<http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "Nicotinamide adenine dinucleotide (NAD) is an essential cofactor for cellular redox reactions and energy metabolism. NAD also has been shown to be an important substrate in a variety of biological processes, including transcriptional regulation, DNA repair, calcium-dependent signaling pathways, calorie-restriction-mediated life-span extension and age-associated diseases |CITS: [12736687],[12648681]|. NAD appears to affect these processes by regulating the Sir2p family of NAD-dependent deacetylases (Sirtuins) |CITS: [12648681]|. There are a number of pathways for NAD biosynthesis. In yeast and most other organisms, the two major pathways are de novo synthesis of NAD (the de novo pathway) and regeneration of NAD from its nicotinamide degradation products (the NAD salvage pathway) |CITS: [12972620], [12648681]|. NAD is synthesized de novo from tryptophan via kynurenine |CITS: [12972620]|. In this pathway tryptophan is converted to nicotinic acid mononucleotide (NAMN) in 6 enzymatic steps (catalyzed by Bna1-2p, and Bna4-7p) and one non-enzymatic step |CITS: [12972620]|. At NAMN the de novo pathway converges with the NAD salvage pathway and the last two steps to NAD are shared |CITS: [12972620], [12648681]|. In the yeast NAD salvage pathway, the vitamin precursors nicotinamide and nicotinic acid are converted to NAMN, the point of convergence with the de novo pathway |CITS: [12648681]|. The steps from nicotinic acid to NAD were elucidated by Preiss and Handler and are sometimes referred to as the Preiss-Handler pathway |CITS: [13416279], [13563526]|. Yeast can also import extracellular nicotinic acid into the cell by the permease Tna1p and then convert it into NAD via the Preiss-Handler pathway |CITS: [12648681]|. There are four additional pathways for synthesizing NAD in yeast: two salvage pathways from the vitamin precursor nicotinamide riboside (NR) and two salvage pathways from nicotinic acid riboside (NaR) |CITS: [15137942], [17482543], [17914902]|. Three of these salvage pathways converge first with the NAD salvage pathway and then with the de novo pathway, while the fourth, the NR salvage pathway I, is independent of both of these pathways. In the NR salvage pathway I, NR is phosphorylated to nicotinamide mononucleotide by the kinase Nrk1p, and then adenylated to NAD by Nma1p or Nma2p |CITS: [15137942]|. Bacteria such as Haemophilus influenza that lack the enzymes of the de novo and Preiss-Handler pathway can synthesize NAD from NR and nicotinamide mononucleotide as well |CITS: [15137942]|. Humans also appear to have this NR salvage pathway |CITS: [15137942]|. Yeast have a second NR salvage pathway (NR salvage pathway II) that is independent of Nrk1p; in NR salvage pathway II NR is split into a ribosyl product and nicotinamide, which is subsequently converted to NAD via enzymes of the NAD salvage pathway and de novo pathway |CITS: [17482543]|. The initial steps in the two NaR salvage pathways are similar to those of the NR salvage pathways and are catalyzed by the same enzymes; Nrk1p catalyzes the first step in the NR and NaR salvage pathways I and Urh1p and Pnp1p catalyze the first steps of the NR and NaR salvage pathways II |CITS: [17914902]|." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD <i>de novo</i> biosynthesis II (from tryptophan)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "NADSYN-PWY" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3529,8 +3002,170 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_994_RXN-5721>
+        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-3-carboxymuconate-6-semialdehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
+] .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23442> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23283> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_29959>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+] .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3538,7 +3173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3549,12 +3184,366 @@
           <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23093> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1.13.11.6-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000194> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynurenine 3-mono oxygenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23449> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
+] .
+
+<http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030429> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/1.13.11.6-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23364> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000003786>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58125> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxy-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23376> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_36559>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3567,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3575,185 +3564,75 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002411_QUINOPRIBOTRANS-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
-] .
-
-<http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000194> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynurenine 3-mono oxygenase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23449> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_null_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:NADSYN-PWY" ;
+                "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
+] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58629>
+<http://identifiers.org/sgd/S000004221>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58437>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NaMN" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23139> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "NAD <i>de novo</i> biosynthesis II (from tryptophan) - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
@@ -3764,7 +3643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3772,25 +3651,149 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004514> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29959_QUINOPRIBOTRANS-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23097> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_57912_RXN-8665>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57912> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "trp" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23319> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_NADSYN-PWY/NADSYN-PWY_SGD_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
+          <http://model.geneontology.org/RXN-8665> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
+          <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
+] .
+
+<http://model.geneontology.org/1.13.11.6-RXN>
+        a       <http://purl.obolibrary.org/obo/GO_0000334> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/NADSYN-PWY/NADSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN-5721> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23341> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .

--- a/models/NONOXIPENT-PWY-NONOXIPENT-PWY.ttl
+++ b/models/NONOXIPENT-PWY-NONOXIPENT-PWY.ttl
@@ -1,12 +1,29 @@
 <http://purl.obolibrary.org/obo/GO_0004751>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/NONOXIPENT-PWY/NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "The reactions of the non-oxidative branch of the pentose phosphate pathway are reversible and are important for generating ribose-5-phosphate, which is required for the biosynthesis of several biomolecules, including RNA and DNA. These reactions also catalyze the interconversion of a variety of 3, 5 and 6 carbon sugars, which is important for several biosynthetic pathways, including the biosynthesis of pyrimidines, purines, tryptophan, histidine, and aromatic amino acids |CITS:[8929392]||CITS:[15960801]||CITS:[7916691]||CITS:[14690456]|. The flow of glucose 6-phosphate through glycolysis and the pentose phosphate pathway is linked through two enzymes of the non-oxidative branch of the pentose phosphate pathway, transketolase (Tkl1p and Tkl2p) and transaldolase (Tal1p). The ability of these enzymes to convert one type of sugar into another allows them to convert the byproduct of one pathway into the substrate of another pathway in order to meet the metabolic needs of the cell. For example, if the cell needs ribose 5-phosphate, glyceraldehyde 3-phosphate and fructose 6-phosphate will be converted to ribose 5-phosphate. If the cell needs NADPH or ATP more than ribose 5-phosphate, ribose 5-phosphate will be converted to glyceraldehyde 3-phosphate and fructose 6-phosphate for use by the oxidative branch of the pentose phosphate pathway or glycolysis, respectively |CITS:[11298766]||CITS:[15960801]||CITS:[1628611]|." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pentose phosphate pathway (non-oxidative branch)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "NONOXIPENT-PWY" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
 <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -29,22 +46,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/NONOXIPENT-PWY/NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "The reactions of the non-oxidative branch of the pentose phosphate pathway are reversible and are important for generating ribose-5-phosphate, which is required for the biosynthesis of several biomolecules, including RNA and DNA. These reactions also catalyze the interconversion of a variety of 3, 5 and 6 carbon sugars, which is important for several biosynthetic pathways, including the biosynthesis of pyrimidines, purines, tryptophan, histidine, and aromatic amino acids |CITS:[8929392]||CITS:[15960801]||CITS:[7916691]||CITS:[14690456]|. The flow of glucose 6-phosphate through glycolysis and the pentose phosphate pathway is linked through two enzymes of the non-oxidative branch of the pentose phosphate pathway, transketolase (Tkl1p and Tkl2p) and transaldolase (Tal1p). The ability of these enzymes to convert one type of sugar into another allows them to convert the byproduct of one pathway into the substrate of another pathway in order to meet the metabolic needs of the cell. For example, if the cell needs ribose 5-phosphate, glyceraldehyde 3-phosphate and fructose 6-phosphate will be converted to ribose 5-phosphate. If the cell needs NADPH or ATP more than ribose 5-phosphate, ribose 5-phosphate will be converted to glyceraldehyde 3-phosphate and fructose 6-phosphate for use by the oxidative branch of the pentose phosphate pathway or glycolysis, respectively |CITS:[11298766]||CITS:[15960801]||CITS:[1628611]|." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pentose phosphate pathway (non-oxidative branch)" ;
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "NONOXIPENT-PWY" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57634_2TRANSKETO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -55,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,24 +74,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_NONOXIPENT-PWY/NONOXIPENT-PWY_SGD_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +203,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_59776_1TRANSKETO-RXN> , <http://model.geneontology.org/CHEBI_57483_1TRANSKETO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57737_1TRANSKETO-RXN> , <http://model.geneontology.org/CHEBI_78346_1TRANSKETO-RXN> ;
+                <http://model.geneontology.org/CHEBI_78346_1TRANSKETO-RXN> , <http://model.geneontology.org/CHEBI_57737_1TRANSKETO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR074C-MONOMER_1TRANSKETO-RXN_controller> , <http://model.geneontology.org/YBR117C-MONOMER_1TRANSKETO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,7 +273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,24 +311,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,6 +327,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_59776_2TRANSKETO-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,20 +477,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_null_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -503,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,12 +500,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_null_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_null_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,13 +565,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,9 +585,6 @@
           <http://model.geneontology.org/YLR354C-MONOMER_TRANSALDOL-RXN_controller>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://identifiers.org/sgd/S000000321>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -594,7 +594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (non-oxidative branch) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1109,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1166,7 +1166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1384,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1403,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1419,7 +1419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1470,7 +1470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1504,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1531,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1665,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/OXIDATIVEPENT-PWY-OXIDATIVEPENT-PWY.ttl
+++ b/models/OXIDATIVEPENT-PWY-OXIDATIVEPENT-PWY.ttl
@@ -13,7 +13,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (oxidative branch) I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,13 +348,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=OXIDATIVEPENT-PWYSmallMolecule35918> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000001206>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -365,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,13 +418,13 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/MONOMER3O-4047_6PGLUCONOLACT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003480> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "6-phosphogluconolactonase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,16 +432,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -446,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,8 +452,16 @@
           <http://model.geneontology.org/CHEBI_15377_6PGLUCONOLACT-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -468,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,6 +539,9 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000003480>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000005185>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -544,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,7 +607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -645,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -772,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,13 +802,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-4032_6PGLUCONOLACT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001206> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "6-phosphogluconolactonase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -818,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -833,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,9 +870,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -879,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -923,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1050,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1153,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/P4-PWY-1-P4-PWY-1.ttl
+++ b/models/P4-PWY-1-P4-PWY-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,23 +296,6 @@
           <http://model.geneontology.org/YER052C-MONOMER_ASPARTATEKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/3986b8f9-5b2f-4891-9f26-e6544a76a752_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/RXN3O-22>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -322,9 +305,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/3986b8f9-5b2f-4891-9f26-e6544a76a752_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/0d34ce22-17f1-46e6-8d6d-67dea8989080_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -332,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -401,11 +384,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_3986b8f9-5b2f-4891-9f26-e6544a76a752_RXN3O-22_SGD_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22_SGD_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +396,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3986b8f9-5b2f-4891-9f26-e6544a76a752_RXN3O-22>
+          <http://model.geneontology.org/17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -422,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,6 +454,17 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22_SGD_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -480,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -570,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,17 +838,6 @@
           <http://model.geneontology.org/HOMOSERKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_0d34ce22-17f1-46e6-8d6d-67dea8989080_RXN3O-22_SGD_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16452_ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16452> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -864,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -922,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -939,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1088,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1130,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1237,7 +1220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1268,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1282,7 +1265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1373,7 +1356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1404,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1419,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1447,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1460,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1481,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1495,7 +1478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,29 +1557,12 @@
           <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/0d34ce22-17f1-46e6-8d6d-67dea8989080_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1610,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1638,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1649,7 +1615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1661,7 +1627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1681,7 +1647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1779,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1793,7 +1759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1870,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1890,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1929,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,11 +1905,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_0d34ce22-17f1-46e6-8d6d-67dea8989080_RXN3O-22_SGD_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22_SGD_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1951,7 +1917,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0d34ce22-17f1-46e6-8d6d-67dea8989080_RXN3O-22>
+          <http://model.geneontology.org/4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_P4-PWY-1>
@@ -1959,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1971,7 +1937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,7 +1956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2023,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2046,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2074,7 +2040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2106,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2120,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2140,7 +2106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2157,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2170,7 +2136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2190,7 +2156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2206,7 +2172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2218,7 +2184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2229,24 +2195,13 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_3986b8f9-5b2f-4891-9f26-e6544a76a752_RXN3O-22_SGD_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2273,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2304,7 +2259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2320,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2332,7 +2287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2351,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2380,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2397,7 +2352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,7 +2375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2436,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2450,7 +2405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2477,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2489,7 +2444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2507,7 +2462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2520,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2531,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2546,7 +2501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2560,6 +2515,23 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2569,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2585,7 +2557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2612,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2626,7 +2598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2637,7 +2609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2649,7 +2621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,7 +2644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2692,7 +2664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2712,7 +2684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2728,7 +2700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2746,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2759,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2776,7 +2748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2806,7 +2778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2820,7 +2792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2836,7 +2808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2847,7 +2819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2860,7 +2832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2877,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2891,7 +2863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2911,7 +2883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2924,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2936,7 +2908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2953,7 +2925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2969,7 +2941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2981,7 +2953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3009,7 +2981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3023,7 +2995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3039,7 +3011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3066,7 +3038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3083,7 +3055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3105,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3123,7 +3095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3143,7 +3115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3159,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3173,7 +3145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3184,7 +3156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3195,7 +3167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3210,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3227,7 +3199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3243,7 +3215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3255,7 +3227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3271,7 +3243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3284,7 +3256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3302,7 +3274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3316,7 +3288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3346,7 +3318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3363,7 +3335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine and methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3380,7 +3352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3393,7 +3365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3405,7 +3377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3425,7 +3397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3445,7 +3417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,7 +3433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3472,7 +3444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3486,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3501,7 +3473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3521,7 +3493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3541,7 +3513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3554,7 +3526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3567,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3581,7 +3553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3592,6 +3564,17 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22_SGD_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004069>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3600,7 +3583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3611,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3629,7 +3612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3642,7 +3625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3654,7 +3637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3670,7 +3653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3685,7 +3668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3698,7 +3681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3715,7 +3698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3731,7 +3714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3742,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3754,7 +3737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3765,12 +3748,29 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3781,7 +3781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3792,7 +3792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3804,7 +3804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3821,7 +3821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3837,7 +3837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3849,7 +3849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3866,7 +3866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3882,7 +3882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3896,7 +3896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3907,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3925,7 +3925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3942,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3956,7 +3956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3972,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3987,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4000,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4015,7 +4015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4031,7 +4031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4043,7 +4043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PANTOSYN2-PWY-PANTOSYN2-PWY.ttl
+++ b/models/PANTOSYN2-PWY-PANTOSYN2-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15,6 +15,9 @@
           <http://model.geneontology.org/CHEBI_58349_2-DEHYDROPANTOATE-REDUCT-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000003509>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -24,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,28 +61,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25329> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/f697a45d-daf0-4f7f-ab10-950ead5a2c84_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -89,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -116,11 +102,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_f697a45d-daf0-4f7f-ab10-950ead5a2c84_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +114,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f697a45d-daf0-4f7f-ab10-950ead5a2c84_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004595>
@@ -140,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,9 +256,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/8705125f-ac7c-434f-97fd-2fa5e272df91_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/f697a45d-daf0-4f7f-ab10-950ead5a2c84_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -280,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,12 +277,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000000380>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,13 +371,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-487_PANTEPADENYLYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003509> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pantetheine-phosphate adenylyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +390,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,20 +471,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005580> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphopantothenoylcysteine decarboxylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,13 +533,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-268_PANTOTHENATE-KIN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000002939> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pantothenate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,13 +583,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25230> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000001345>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -600,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,13 +689,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000000380> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "3-methyl-2-oxobutanoate hydroxymethyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,11 +754,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001780>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -766,7 +772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -794,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,6 +828,23 @@
           <http://model.geneontology.org/CHEBI_16526_P-PANTOCYSDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -830,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -853,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -888,13 +911,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-474_P-PANTOCYSDECARB-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001780> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphopantothenoylcysteine decarboxylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -985,7 +1008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,20 +1024,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-504_DEPHOSPHOCOAKIN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002604> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dephospho-CoA kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1039,7 +1062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1097,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1129,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1204,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1221,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1235,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,7 +1275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,13 +1286,16 @@
           <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000005580>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000050_PANTOSYN2-PWY/PANTOSYN2-PWY_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,17 +1309,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_8705125f-ac7c-434f-97fd-2fa5e272df91_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1302,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1329,13 +1344,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_35235>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_11561>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_10986_PANTOTHENATE-KIN-RXN>
@@ -1347,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,16 +1373,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_11561>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1411,13 +1426,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000001105>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1434,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1464,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,17 +1505,6 @@
           <http://model.geneontology.org/CHEBI_15378_PANTEPADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_f697a45d-daf0-4f7f-ab10-950ead5a2c84_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_DEPHOSPHOCOAKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1507,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1534,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1558,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1569,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1581,7 +1588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pantothenate and coenzyme A biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1615,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1642,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,7 +1689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1715,7 +1722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1732,7 +1739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1766,7 +1773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1782,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1793,7 +1800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1804,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1815,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1826,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1869,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1886,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,7 +1910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1934,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1956,7 +1963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1975,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1997,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2023,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2036,11 +2043,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002939>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2048,7 +2058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2068,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2084,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2095,7 +2105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2109,7 +2119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2126,7 +2136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,7 +2179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2186,7 +2196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2216,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2228,7 +2238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2244,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2256,7 +2266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,7 +2283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,7 +2300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,28 +2316,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/8705125f-ac7c-434f-97fd-2fa5e272df91_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2344,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2358,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,19 +2363,22 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-214_2-DEHYDROPANTOATE-REDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001105> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "gluconate 5-dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYProtein25091> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://identifiers.org/sgd/S000001571>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_60377_P-PANTOCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
@@ -2393,7 +2389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2406,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2418,7 +2414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2435,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2476,20 +2472,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-285_P-PANTOCYSLIG-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001345> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphopantothenate-cysteine ligase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2506,7 +2502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2526,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2534,12 +2530,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_15378_P-PANTOCYSLIG-RXN_SGD_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2551,7 +2558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2567,7 +2574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2579,7 +2586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2595,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2620,7 +2627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2636,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2648,7 +2655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2664,7 +2671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2699,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2722,7 +2729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2749,7 +2756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2766,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2780,7 +2787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2796,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2835,7 +2842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2851,7 +2858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2866,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2883,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2896,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2907,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2921,7 +2928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2937,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2952,7 +2959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2962,11 +2969,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_8705125f-ac7c-434f-97fd-2fa5e272df91_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2974,7 +2981,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8705125f-ac7c-434f-97fd-2fa5e272df91_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -2989,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3006,7 +3013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3026,7 +3033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3042,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3060,7 +3067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3077,7 +3084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3096,7 +3103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3107,7 +3114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3136,7 +3143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3152,14 +3159,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PANTOSYN2-PWY/PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3170,7 +3174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3184,7 +3188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,7 +3204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3215,7 +3219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3228,7 +3232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3240,7 +3244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3256,7 +3260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3268,7 +3272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3288,7 +3292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3301,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3312,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3326,7 +3330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3346,7 +3350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3357,6 +3361,23 @@
 <http://purl.obolibrary.org/obo/GO_0003864>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-pantothenate + ATP &rarr; (<i>R</i>)-4'-phosphopantothenate + ADP + H<SUP>+</SUP>' 'null' '(<i>R</i>)-4'-phosphopantothenate + L-cysteine + CTP &rarr; (R)-4'-phosphopantothenoyl-L-cysteine + CMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -3365,7 +3386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3382,7 +3403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3402,7 +3423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3415,7 +3436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3430,7 +3451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3447,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3464,7 +3485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3477,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3495,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3509,7 +3530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3534,7 +3555,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15377_RXN-9015> , <http://model.geneontology.org/CHEBI_15379_RXN-9015> , <http://model.geneontology.org/CHEBI_45725_RXN-9015> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16240_RXN-9015> , <http://model.geneontology.org/CHEBI_57834_RXN-9015> , <http://model.geneontology.org/CHEBI_18090_RXN-9015> ;
+                <http://model.geneontology.org/CHEBI_16240_RXN-9015> , <http://model.geneontology.org/CHEBI_18090_RXN-9015> , <http://model.geneontology.org/CHEBI_57834_RXN-9015> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR020W-MONOMER_RXN-9015_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3542,7 +3563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3555,7 +3576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3566,7 +3587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3581,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3598,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3615,7 +3636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3632,7 +3653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3648,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3666,7 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3675,13 +3696,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-299_P-PANTOCYSDECARB-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001571> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphopantothenoylcysteine decarboxylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3695,7 +3716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3711,18 +3732,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002604>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_456216_PANTOTHENATE-KIN-RXN_SGD_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3734,7 +3758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3753,7 +3777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3768,7 +3792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3784,7 +3808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3796,7 +3820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3812,7 +3836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3824,7 +3848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3840,7 +3864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3855,7 +3879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3869,7 +3893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3888,7 +3912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3903,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3917,7 +3941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3940,7 +3964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3960,7 +3984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3988,7 +4012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4007,7 +4031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4019,7 +4043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4035,7 +4059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4047,7 +4071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4067,7 +4091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4084,7 +4108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4097,7 +4121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4112,7 +4136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4128,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4143,7 +4167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4160,7 +4184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4173,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4184,7 +4208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4198,7 +4222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4215,7 +4239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4231,7 +4255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4245,7 +4269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4268,7 +4292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4285,7 +4309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4303,7 +4327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4330,7 +4354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4346,7 +4370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4360,7 +4384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PENTOSE-P-PWY-PENTOSE-P-PWY.ttl
+++ b/models/PENTOSE-P-PWY-PENTOSE-P-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,6 +43,9 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9952>
 ] .
 
+<http://identifiers.org/sgd/S000001206>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15378_GLU6PDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -52,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,14 +85,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005185> ;
@@ -98,13 +98,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYProtein34949> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/RIB5PISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004751> ;
@@ -125,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -469,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -510,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,20 +529,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-4047_6PGLUCONOLACT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003480> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "6-phosphogluconolactonase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -669,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -686,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -702,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,7 +808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -868,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -951,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1014,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1051,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1197,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1225,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1265,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1278,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1381,7 +1384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1465,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1494,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1508,7 +1511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1602,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,7 +1619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1649,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1664,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1672,13 +1675,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_59776>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_PENTOSE-P-PWY/PENTOSE-P-PWY_SGD_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,10 +1695,7 @@
           <http://model.geneontology.org/PENTOSE-P-PWY/PENTOSE-P-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_59776>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
+<http://identifiers.org/sgd/S000003480>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1701,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1728,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1743,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1796,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1808,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1853,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1895,7 +1898,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_59776_1TRANSKETO-RXN> , <http://model.geneontology.org/CHEBI_57483_1TRANSKETO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57737_1TRANSKETO-RXN> , <http://model.geneontology.org/CHEBI_78346_1TRANSKETO-RXN> ;
+                <http://model.geneontology.org/CHEBI_78346_1TRANSKETO-RXN> , <http://model.geneontology.org/CHEBI_57737_1TRANSKETO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR074C-MONOMER_1TRANSKETO-RXN_controller> , <http://model.geneontology.org/YBR117C-MONOMER_1TRANSKETO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1903,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1916,7 +1919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1928,7 +1931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1945,7 +1948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,7 +1965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2029,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2043,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2054,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2068,7 +2071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2084,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2096,7 +2099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,7 +2116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2130,7 +2133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2146,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2172,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2186,7 +2189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2203,7 +2206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2219,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2230,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2244,7 +2247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2279,7 +2282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2292,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2307,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,7 +2323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2332,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2351,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2363,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2379,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,7 +2422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2433,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2464,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2478,7 +2481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2495,7 +2498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2526,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2540,7 +2543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2556,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2570,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2581,20 +2584,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-4032_6PGLUCONOLACT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001206> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "6-phosphogluconolactonase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2608,7 +2611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2627,7 +2630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2649,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2669,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2682,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2693,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2708,7 +2711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2724,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2738,7 +2741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2749,17 +2752,6 @@
           <http://model.geneontology.org/reaction_1TRANSKETO-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_PENTOSE-P-PWY/PENTOSE-P-PWY_SGD_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_78346_RIB5PISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_78346> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2769,13 +2761,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYSmallMolecule35040> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_PENTOSE-P-PWY/PENTOSE-P-PWY_SGD_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58759_6PGLUCONOLACT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58759> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2786,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2800,7 +2803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2820,7 +2823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2837,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2850,7 +2853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PERIPLASMA-NAD-DEGRADATION-PERIPLASMA-NAD-DEGRADATION.ttl
+++ b/models/PERIPLASMA-NAD-DEGRADATION-PERIPLASMA-NAD-DEGRADATION.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "periplasmic NAD degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,24 +329,13 @@
           <http://model.geneontology.org/CHEBI_456215_NADPYROPHOSPHAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_15377_AMP-DEPHOSPHORYLATION-RXN_SGD_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +351,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>

--- a/models/PHOS-PWY-PHOS-PWY.ttl
+++ b/models/PHOS-PWY-PHOS-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,23 +145,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
 ] .
-
-<http://model.geneontology.org/976a3895-56d3-4cd4-bd2c-f20aa6dc9222_RXN4FS-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -175,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,6 +441,23 @@
           <http://model.geneontology.org/PHOS-PWY/PHOS-PWY>
 ] .
 
+<http://model.geneontology.org/42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -593,30 +593,8 @@
 <http://purl.obolibrary.org/obo/GO_0004306>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_2.7.7.14-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_c7ff47c8-6fbb-43d6-a1e7-7f9316dc975f_PHOSPHASERSYN-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/RXN4FS-2>
-        a       <http://purl.obolibrary.org/obo/GO_0000773> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -624,7 +602,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/976a3895-56d3-4cd4-bd2c-f20aa6dc9222_RXN4FS-2> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
+                <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> , <http://model.geneontology.org/42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -632,13 +610,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38600> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_2.7.7.14-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -648,7 +637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +653,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,11 +691,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_eee92866-57f7-4092-a7d8-6cf5e1a6ea69_PGPPHOSPHA-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +703,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eee92866-57f7-4092-a7d8-6cf5e1a6ea69_PGPPHOSPHA-RXN>
+          <http://model.geneontology.org/53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PHOS-PWY>
@@ -711,7 +711,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -825,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -839,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -868,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,11 +926,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_6612303e-ed9f-4108-bd2a-a49dc74a8357_RXN3O-349_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,36 +938,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6612303e-ed9f-4108-bd2a-a49dc74a8357_RXN3O-349>
+          <http://model.geneontology.org/07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349>
 ] .
-
-<http://model.geneontology.org/eee92866-57f7-4092-a7d8-6cf5e1a6ea69_PGPPHOSPHA-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_cd3101e8-de5d-43f7-bc63-d0c42f6abb48_2.1.1.71-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_295975>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -976,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -996,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1079,35 +1062,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/f3763598-6aa8-4154-8217-f4d4671d1320_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,7 +1105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,11 +1149,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_c7ff47c8-6fbb-43d6-a1e7-7f9316dc975f_PHOSPHASERSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1161,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c7ff47c8-6fbb-43d6-a1e7-7f9316dc975f_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PHOS-PWY>
@@ -1203,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1260,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,7 +1273,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/c7ff47c8-6fbb-43d6-a1e7-7f9316dc975f_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1317,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,11 +1293,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_01ea7757-599a-471a-a770-368736a66dcb_CDPDIGLYSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1305,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/01ea7757-599a-471a-a770-368736a66dcb_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1348,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,7 +1339,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/01ea7757-599a-471a-a770-368736a66dcb_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1381,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,16 +1399,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYProtein39202> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0000773>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000510> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1451,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,11 +1424,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_d890e90a-5cc1-4149-93dc-ee117595de14_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,7 +1436,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d890e90a-5cc1-4149-93dc-ee117595de14_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
@@ -1485,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1500,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1514,7 +1477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,18 +1493,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1553,6 +1533,23 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -1562,7 +1559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,7 +1594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1608,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,11 +1637,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39151> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1653,18 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_6612303e-ed9f-4108-bd2a-a49dc74a8357_RXN3O-349_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1675,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1689,7 +1692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,7 +1711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1745,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1759,14 +1762,14 @@
 <http://identifiers.org/sgd/S000003239>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_null_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1775,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1800,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,14 +1811,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_null_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PHOS-PWY" ;
+                "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1827,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1856,7 +1859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1900,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1915,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1929,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1977,7 +1980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1990,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2004,7 +2007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2032,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2051,7 +2054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,23 +2065,6 @@
           <http://model.geneontology.org/reaction_RXN-5781_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/753b1ff9-394a-4eee-bfd1-16c085eaa09c_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004123> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2086,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2100,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2125,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2137,7 +2123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2154,7 +2140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2170,11 +2156,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_cd3101e8-de5d-43f7-bc63-d0c42f6abb48_2.1.1.71-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2182,7 +2168,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cd3101e8-de5d-43f7-bc63-d0c42f6abb48_2.1.1.71-RXN>
+          <http://model.geneontology.org/e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2191,7 +2177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2224,7 +2210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2235,6 +2221,23 @@
           <http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2243,7 +2246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,7 +2266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2283,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,13 +2302,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/6612303e-ed9f-4108-bd2a-a49dc74a8357_RXN3O-349>
+<http://model.geneontology.org/07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -2314,7 +2317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2327,7 +2330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2344,7 +2347,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/753b1ff9-394a-4eee-bfd1-16c085eaa09c_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2352,7 +2355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2366,7 +2369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2393,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2428,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2444,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2456,23 +2459,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17815>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/d890e90a-5cc1-4149-93dc-ee117595de14_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2482,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2495,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2509,7 +2495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2523,12 +2509,40 @@
 <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2540,7 +2554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2551,9 +2565,6 @@
           <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57856>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-choline &harr; a phosphatidylcholine + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -2562,7 +2573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,23 +2584,15 @@
           <http://model.geneontology.org/RXN-5781>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_d890e90a-5cc1-4149-93dc-ee117595de14_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57856>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHAGLYPSYN-RXN_null_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2603,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2614,11 +2617,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_753b1ff9-394a-4eee-bfd1-16c085eaa09c_2.1.1.17-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2626,7 +2629,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/753b1ff9-394a-4eee-bfd1-16c085eaa09c_2.1.1.17-RXN>
+          <http://model.geneontology.org/268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2635,7 +2638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2651,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2662,11 +2665,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2674,7 +2694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2691,7 +2711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2707,29 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_01ea7757-599a-471a-a770-368736a66dcb_CDPDIGLYSYN-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_4494cc74-e81d-4581-85e5-984ef111077d_2.7.8.11-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2743,7 +2741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2760,7 +2758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2781,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,7 +2792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2805,11 +2803,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_976a3895-56d3-4cd4-bd2c-f20aa6dc9222_RXN4FS-2_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2817,19 +2815,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/976a3895-56d3-4cd4-bd2c-f20aa6dc9222_RXN4FS-2>
+          <http://model.geneontology.org/42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2837,7 +2824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2848,12 +2835,23 @@
           <http://model.geneontology.org/CHEBI_64716_CARDIOLIPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2865,7 +2863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,7 +2879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2892,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2904,7 +2902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2921,7 +2919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2941,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2961,7 +2959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2974,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2985,7 +2983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2998,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3015,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3028,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3053,7 +3051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3070,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3078,13 +3076,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHASERSYN-RXN_null_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_2.7.7.15-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3095,23 +3104,12 @@
           <http://model.geneontology.org/CHEBI_295975_2.7.7.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHASERSYN-RXN_null_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3129,7 +3127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3145,7 +3143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3159,7 +3157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,7 +3177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3187,25 +3185,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/4494cc74-e81d-4581-85e5-984ef111077d_2.7.8.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/RXN3O-349>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000773> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3213,7 +3194,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6612303e-ed9f-4108-bd2a-a49dc74a8357_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3221,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3237,7 +3218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3260,7 +3241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3277,7 +3258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3297,7 +3278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3316,7 +3297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3327,7 +3308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3339,7 +3320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3356,7 +3337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3374,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3391,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3408,9 +3389,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/d890e90a-5cc1-4149-93dc-ee117595de14_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/70bc166d-a0d1-4c62-9878-2ec52ebfff52_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3418,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3432,7 +3413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3448,7 +3429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3473,7 +3454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3490,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3504,7 +3485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3521,7 +3502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3544,7 +3525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3561,7 +3542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3577,7 +3558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3588,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3602,7 +3583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3613,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3625,7 +3606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3645,7 +3626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3659,7 +3640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3682,7 +3663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3695,7 +3676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3709,7 +3690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3732,7 +3713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3749,7 +3730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3768,7 +3749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,7 +3769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3801,7 +3782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3812,7 +3793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3827,7 +3808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3841,7 +3822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3860,7 +3841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3879,7 +3860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3891,7 +3872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3910,7 +3891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3930,7 +3911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3943,7 +3924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3958,7 +3939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3975,7 +3956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3995,11 +3976,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38616> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4011,7 +4009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4030,7 +4028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4042,7 +4040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4061,7 +4059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4081,7 +4079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4094,7 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4108,7 +4106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4123,7 +4121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4140,7 +4138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4156,7 +4154,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4174,7 +4183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4192,7 +4201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4205,7 +4214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4217,7 +4226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4234,7 +4243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4250,7 +4259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4265,7 +4274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4278,7 +4287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4289,28 +4298,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_RXN-5781_SGD_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5781> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58779_RXN-5781>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_2.1.1.17-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4321,16 +4313,22 @@
           <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_976a3895-56d3-4cd4-bd2c-f20aa6dc9222_RXN4FS-2_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_RXN-5781_SGD_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5781> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58779_RXN-5781>
+] .
 
 <http://model.geneontology.org/2.7.7.14-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004306> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4351,7 +4349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,7 +4364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4379,7 +4377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4394,7 +4392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4408,12 +4406,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4424,7 +4433,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4435,7 +4455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4447,7 +4467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4463,7 +4483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4475,7 +4495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4495,7 +4515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4511,7 +4531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4522,7 +4542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4533,7 +4553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4544,7 +4564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4556,7 +4576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4573,7 +4593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4589,7 +4609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4607,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4622,7 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4636,7 +4656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4656,7 +4676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4673,7 +4693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4689,7 +4709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4703,7 +4723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4721,7 +4741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4737,7 +4757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4748,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4766,7 +4786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4781,7 +4801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4794,7 +4814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4806,7 +4826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4822,7 +4842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4837,7 +4857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4848,23 +4868,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58190>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/cd3101e8-de5d-43f7-bc63-d0c42f6abb48_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -4873,7 +4876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4892,7 +4895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4908,7 +4911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4919,7 +4922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4930,7 +4933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4944,7 +4947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4961,7 +4964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4971,6 +4974,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16110_RXN4FS-2>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004123>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4984,7 +4998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5000,7 +5014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5011,7 +5025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5019,11 +5033,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_70bc166d-a0d1-4c62-9878-2ec52ebfff52_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5031,7 +5045,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/70bc166d-a0d1-4c62-9878-2ec52ebfff52_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5040,7 +5054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5059,7 +5073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5076,7 +5090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5092,18 +5106,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5118,7 +5132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5126,12 +5140,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5142,18 +5156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_753b1ff9-394a-4eee-bfd1-16c085eaa09c_2.1.1.17-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5168,7 +5171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5188,7 +5191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5205,7 +5208,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/4494cc74-e81d-4581-85e5-984ef111077d_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5213,7 +5216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5234,7 +5237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5247,7 +5250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5261,7 +5264,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5273,7 +5287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5293,7 +5307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidic acid and phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5310,7 +5324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5332,7 +5346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5348,7 +5362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5359,7 +5373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5373,7 +5387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5385,7 +5399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5401,7 +5415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5419,7 +5433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5436,7 +5450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5449,28 +5463,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.17-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5481,8 +5478,42 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-5781>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.17-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
+] .
+
+<http://model.geneontology.org/588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000773> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -5490,9 +5521,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/cd3101e8-de5d-43f7-bc63-d0c42f6abb48_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/f3763598-6aa8-4154-8217-f4d4671d1320_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5500,7 +5531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5517,7 +5548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5536,7 +5567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5556,7 +5587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5573,7 +5604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5586,28 +5617,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39044> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5615,7 +5629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5626,26 +5640,32 @@
           <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004142>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_f3763598-6aa8-4154-8217-f4d4671d1320_2.1.1.71-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39044> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004142>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_null_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5660,7 +5680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5673,11 +5693,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_f3763598-6aa8-4154-8217-f4d4671d1320_2.1.1.71-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5685,7 +5705,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f3763598-6aa8-4154-8217-f4d4671d1320_2.1.1.71-RXN>
+          <http://model.geneontology.org/05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5694,7 +5714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5714,7 +5734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5728,7 +5748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5750,7 +5770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5770,7 +5790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5787,7 +5807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5795,12 +5815,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5815,7 +5846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5832,6 +5863,17 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YPR113W-MONOMER_2.7.8.11-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006317> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5839,7 +5881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5852,7 +5894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5866,7 +5908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5877,7 +5919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5889,7 +5931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5905,7 +5947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5920,7 +5962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5936,7 +5978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5948,7 +5990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5965,7 +6007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5981,18 +6023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_70bc166d-a0d1-4c62-9878-2ec52ebfff52_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6003,7 +6034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6017,7 +6048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6033,7 +6064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6045,7 +6076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6065,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6078,7 +6109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6089,7 +6120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6104,7 +6135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6120,7 +6151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6131,6 +6162,34 @@
           <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6140,7 +6199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6153,7 +6212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6165,7 +6224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6178,11 +6237,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_4494cc74-e81d-4581-85e5-984ef111077d_2.7.8.11-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6190,7 +6249,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4494cc74-e81d-4581-85e5-984ef111077d_2.7.8.11-RXN>
+          <http://model.geneontology.org/2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
@@ -6212,13 +6271,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38740> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004609> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6239,7 +6309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6247,24 +6317,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6283,7 +6342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6300,7 +6359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6316,7 +6375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6327,14 +6386,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -6347,7 +6403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6367,7 +6423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6375,22 +6431,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/c7ff47c8-6fbb-43d6-a1e7-7f9316dc975f_PHOSPHASERSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6398,7 +6440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6409,6 +6451,17 @@
           <http://model.geneontology.org/YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6418,39 +6471,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/70bc166d-a0d1-4c62-9878-2ec52ebfff52_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6460,7 +6485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6480,7 +6505,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/eee92866-57f7-4092-a7d8-6cf5e1a6ea69_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6488,24 +6513,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38993> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_eee92866-57f7-4092-a7d8-6cf5e1a6ea69_PGPPHOSPHA-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -6516,7 +6530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6533,7 +6547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6544,29 +6558,12 @@
           <http://model.geneontology.org/CHEBI_37563_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/01ea7757-599a-471a-a770-368736a66dcb_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN3O-349_null_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PHOSLIPSYN2-PWY-1-PHOSLIPSYN2-PWY-1.ttl
+++ b/models/PHOSLIPSYN2-PWY-1-PHOSLIPSYN2-PWY-1.ttl
@@ -1,10 +1,27 @@
+<http://model.geneontology.org/92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,28 +103,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27052> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/437ec4de-c695-47b4-8457-50405c9157d5_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -152,11 +152,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_1929ab13-c576-4b93-8ab7-cdf6997b0008_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +164,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1929ab13-c576-4b93-8ab7-cdf6997b0008_2.1.1.17-RXN>
+          <http://model.geneontology.org/7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -173,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,21 +230,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_null_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
@@ -256,9 +259,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/ccac6c0d-5197-4331-98c6-e5643fc50d26_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/205d5775-4a1e-45be-937b-dabc9976fa87_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -268,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,8 +279,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -285,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -412,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,12 +440,29 @@
           <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,18 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_437ec4de-c695-47b4-8457-50405c9157d5_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -542,17 +565,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_16110>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_6a4bfb48-8525-4d82-9b24-2e4842bbb248_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004608>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -563,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,11 +619,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_ccac6c0d-5197-4331-98c6-e5643fc50d26_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,26 +631,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ccac6c0d-5197-4331-98c6-e5643fc50d26_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylserine decarboxylase, mitochondria" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27298> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -649,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,12 +654,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylserine decarboxylase, mitochondria" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27298> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_PHOSLIPSYN2-PWY-1/PHOSLIPSYN2-PWY-1_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +700,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/f007dee7-1ae7-46cb-9096-21c1906357fa_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -700,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,11 +769,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_94d1a2f6-552f-4973-bd07-a5feb82f5e07_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +781,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/94d1a2f6-552f-4973-bd07-a5feb82f5e07_RXN3O-349>
+          <http://model.geneontology.org/bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1>
@@ -777,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -821,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -833,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,7 +896,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/1929ab13-c576-4b93-8ab7-cdf6997b0008_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -892,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -906,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -940,7 +952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,12 +963,12 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_205d5775-4a1e-45be-937b-dabc9976fa87_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1047,11 +1059,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0f271716-0804-4021-b1ce-36127f42cd5f_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1071,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0f271716-0804-4021-b1ce-36127f42cd5f_2.1.1.71-RXN>
+          <http://model.geneontology.org/e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1068,7 +1080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,11 +1093,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_205d5775-4a1e-45be-937b-dabc9976fa87_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,18 +1105,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/205d5775-4a1e-45be-937b-dabc9976fa87_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/GO_0000773>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1122,28 +1131,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27040> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/1929ab13-c576-4b93-8ab7-cdf6997b0008_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1153,29 +1145,12 @@
 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/6a4bfb48-8525-4d82-9b24-2e4842bbb248_PGPPHOSPHA-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,23 +1193,6 @@
           <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/205d5775-4a1e-45be-937b-dabc9976fa87_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1243,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,40 +1217,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_ccac6c0d-5197-4331-98c6-e5643fc50d26_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_1929ab13-c576-4b93-8ab7-cdf6997b0008_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1307,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1324,7 +1277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,11 +1290,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_f007dee7-1ae7-46cb-9096-21c1906357fa_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,7 +1302,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f007dee7-1ae7-46cb-9096-21c1906357fa_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1360,7 +1313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1415,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1428,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1436,11 +1389,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_437ec4de-c695-47b4-8457-50405c9157d5_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1401,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/437ec4de-c695-47b4-8457-50405c9157d5_2.1.1.71-RXN>
+          <http://model.geneontology.org/d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -1462,7 +1415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1530,7 +1483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1541,22 +1494,27 @@
           <http://model.geneontology.org/CHEBI_64716_CARDIOLIPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ccac6c0d-5197-4331-98c6-e5643fc50d26_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1564,7 +1522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1605,11 +1563,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_6a4bfb48-8525-4d82-9b24-2e4842bbb248_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,7 +1575,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6a4bfb48-8525-4d82-9b24-2e4842bbb248_PGPPHOSPHA-RXN>
+          <http://model.geneontology.org/6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN>
 ] .
 
 <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
@@ -1627,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1668,14 +1626,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-349>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000773> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1683,7 +1641,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/94d1a2f6-552f-4973-bd07-a5feb82f5e07_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1691,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1710,7 +1668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,13 +1682,30 @@
 <http://purl.obolibrary.org/obo/GO_0004609>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,24 +1716,13 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_f007dee7-1ae7-46cb-9096-21c1906357fa_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1785,35 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/f007dee7-1ae7-46cb-9096-21c1906357fa_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1824,28 +1760,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/94d1a2f6-552f-4973-bd07-a5feb82f5e07_RXN3O-349>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1855,35 +1785,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0f271716-0804-4021-b1ce-36127f42cd5f_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1895,7 +1808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,7 +1825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,13 +1839,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1961,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,11 +1898,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1986,7 +1913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1997,9 +1924,6 @@
           <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2009,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2026,13 +1950,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27192> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2042,7 +1977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,7 +1996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2077,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2088,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2117,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2131,45 +2066,51 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_null_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_null_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_94d1a2f6-552f-4973-bd07-a5feb82f5e07_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2181,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2203,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2223,7 +2164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2237,7 +2178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2254,7 +2195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2274,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2287,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2305,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2318,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,7 +2291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2363,11 +2304,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2375,7 +2333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2391,7 +2349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2403,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2424,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2437,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2448,18 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0f271716-0804-4021-b1ce-36127f42cd5f_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2473,7 +2420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,7 +2437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2507,7 +2454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2523,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2540,18 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2560,8 +2496,41 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003402>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
         a       <http://identifiers.org/sgd/S000003834> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2570,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2582,7 +2551,7 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000773> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2590,9 +2559,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/0f271716-0804-4021-b1ce-36127f42cd5f_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/437ec4de-c695-47b4-8457-50405c9157d5_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2600,7 +2569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2614,7 +2583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2634,7 +2603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,7 +2623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2668,7 +2637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2691,7 +2660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2705,7 +2674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2716,6 +2685,40 @@
           <http://model.geneontology.org/CHEBI_17754_CARDIOLIPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CMP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27155> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2725,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2738,35 +2741,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CMP" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27155> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2781,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2801,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2817,7 +2814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2853,7 +2850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2870,7 +2867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2882,7 +2879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2899,7 +2896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2916,7 +2913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2932,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2947,7 +2944,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6a4bfb48-8525-4d82-9b24-2e4842bbb248_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2955,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2968,7 +2965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2986,7 +2983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2999,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3024,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3037,7 +3034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PLPSAL-PWY-PLPSAL-PWY.ttl
+++ b/models/PLPSAL-PWY-PLPSAL-PWY.ttl
@@ -1,37 +1,35 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_597326_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRAMKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PYRAMKIN-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_28938_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PNPOXI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_597326_PNPOXI-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15379_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_PMPOXI-RXN>
+          <http://model.geneontology.org/CHEBI_15379_PMPOXI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_597326_PMPOXI-RXN>
@@ -43,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,19 +82,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_58451_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+          <http://model.geneontology.org/PYRAMKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
+          <http://model.geneontology.org/CHEBI_58451_PYRAMKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY>
@@ -104,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -115,27 +113,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_15378_PNKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PNKIN-RXN>
+          <http://model.geneontology.org/reaction_PNKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_456216_PNKIN-RXN_SGD_PLPSAL-PWY>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -207,42 +207,60 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_58589_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_456216_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_PYRIDOXKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58589_PNPOXI-RXN>
+          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRAMKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PMPOXI-RXN> ;
+          <http://model.geneontology.org/CPLX3O-38_PYRAMKIN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PMPOXI-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component>
 ] .
+
+<http://identifiers.org/sgd/S000000755>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58451_PYRAMKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58451> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -253,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,20 +303,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_15378_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRAMKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PYRAMKIN-RXN>
+          <http://model.geneontology.org/reaction_PYRAMKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY>
@@ -306,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -355,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -379,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,19 +435,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_30616_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PYRIDOXKIN-RXN>
+          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -435,19 +455,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002333_CPLX3O-38_PNKIN-RXN_controller_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_15378_PNKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-38_PNKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_PNKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -472,13 +492,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYBiochemicalReaction36782> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRIDOXKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_597326>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -488,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyridoxal 5'-phosphate salvage I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -520,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,39 +561,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_58589_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR035C-MONOMER_PNPOXI-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58589_PNPOXI-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_58451_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58451_PMPOXI-RXN>
+          <http://model.geneontology.org/reaction_PMPOXI-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_PNKIN-RXN_location_lociGO_0005829>
@@ -573,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -584,19 +617,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002333_CPLX3O-38_PYRAMKIN-RXN_controller_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_15378_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRAMKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-38_PYRAMKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_PYRAMKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58451>
@@ -604,19 +637,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_16709_PNKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002333_YBR035C-MONOMER_PMPOXI-RXN_controller_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PNKIN-RXN> ;
+          <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16709_PNKIN-RXN>
+          <http://model.geneontology.org/YBR035C-MONOMER_PMPOXI-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_16709_PNKIN-RXN>
@@ -628,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,38 +674,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_30616_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_597326_PYRIDOXKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PYRIDOXKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000066_reaction_PNPOXI-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002333_CPLX3O-38_PNKIN-RXN_controller_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PNPOXI-RXN> ;
+          <http://model.geneontology.org/PNKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PNPOXI-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-38_PNKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002333_CPLX3O-38_PNKIN-RXN_controller_SGD_PLPSAL-PWY>
@@ -680,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,35 +764,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_30616_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRAMKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PYRAMKIN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-38_PNKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -769,19 +783,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_597326_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PNPOXI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR035C-MONOMER_PNPOXI-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_58451_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_597326_PMPOXI-RXN>
+          <http://model.geneontology.org/CHEBI_58451_PMPOXI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_PNKIN-RXN>
@@ -793,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -810,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,46 +868,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000066_reaction_PYRIDOXKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002333_CPLX3O-38_PYRAMKIN-RXN_controller_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+          <http://model.geneontology.org/PYRAMKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PYRIDOXKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-38_PYRAMKIN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_456216_PNKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_16709_PNKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PNKIN-RXN>
+          <http://model.geneontology.org/CHEBI_16709_PNKIN-RXN>
 ] .
 
 <http://model.geneontology.org/PYRIDOXKIN-RXN>
@@ -885,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -934,14 +974,33 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_597326_PYRIDOXKIN-RXN>
+] .
+
 <http://model.geneontology.org/CPLX3O-38_PNKIN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyridoxal kinase / pyridoxamine kinase / pyridoxine kinase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,37 +1009,39 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_16240_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000066_reaction_PNPOXI-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16240_PNPOXI-RXN>
+          <http://model.geneontology.org/reaction_PNPOXI-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRIDOXKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PMPOXI-RXN> ;
+          <http://model.geneontology.org/CPLX3O-38_PYRIDOXKIN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PMPOXI-RXN>
+          <http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
@@ -995,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1019,19 +1080,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_456216_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_30616_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRAMKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PYRAMKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PYRAMKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1039,19 +1100,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_28938_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PNKIN-RXN> ;
+          <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
+          <http://model.geneontology.org/CHEBI_28938_PMPOXI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58589_PNPOXI-RXN>
@@ -1063,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1076,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1087,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1097,16 +1158,29 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyridoxal kinase / pyridoxamine kinase / pyridoxine kinase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYComplex36675> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRAMKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1116,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1127,9 +1201,285 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000066_reaction_PYRIDOXKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PYRIDOXKIN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_456216_PNKIN-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PNKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_PNKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15379_PNPOXI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "O<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36697> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16240>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_16240_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PNPOXI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16240_PNPOXI-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PMPOXI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_PMPOXI-RXN>
+] .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_28938_PMPOXI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ammonium" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36739> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_456216_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRAMKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_PYRAMKIN-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_30616_PYRAMKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36609> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PNKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
+] .
+
+<http://model.geneontology.org/reaction_PNPOXI-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/CHEBI_15378_PYRAMKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36655> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/YBR035C-MONOMER_PMPOXI-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000239> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyridoxine phosphate oxidase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYProtein36760> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_null_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1139,7 +1489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,282 +1517,6 @@
           <http://model.geneontology.org/PNKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PNPOXI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15379_PNPOXI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "O<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36697> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16240>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRAMKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
-] .
-
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_16240_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PMPOXI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16240_PMPOXI-RXN>
-] .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_28938_PMPOXI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ammonium" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36739> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + pyridoxamine &rarr; ADP + pyridoxamine 5'-phosphate + H<SUP>+</SUP>' 'null' 'pyridoxamine 5'-phosphate + oxygen + H<sub>2</sub>O &rarr; ammonium + hydrogen peroxide + pyridoxal 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002413_PMPOXI-RXN_null_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRAMKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PMPOXI-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_30616_PYRAMKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36609> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_30616_PNKIN-RXN_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PNKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PNKIN-RXN>
-] .
-
-<http://model.geneontology.org/reaction_PNPOXI-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/CHEBI_15378_PYRAMKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36655> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/YBR035C-MONOMER_PMPOXI-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000239> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyridoxine phosphate oxidase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYProtein36760> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_null_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-38_PYRIDOXKIN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_15379_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PNPOXI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_PNPOXI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_PMPOXI-RXN>
@@ -1454,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,19 +1541,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PNKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PMPOXI-RXN> ;
+          <http://model.geneontology.org/CPLX3O-38_PNKIN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
+          <http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component>
 ] .
 
 <http://model.geneontology.org/reaction_PYRAMKIN-RXN_location_lociGO_0005829>
@@ -1504,7 +1578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,10 +1590,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyridoxal kinase / pyridoxamine kinase / pyridoxine kinase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,18 +1608,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_28938_PMPOXI-RXN_SGD_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1554,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1562,19 +1641,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_57761_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRAMKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57761_PYRAMKIN-RXN>
+          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15379_PMPOXI-RXN_SGD_PLPSAL-PWY>
@@ -1582,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1590,19 +1669,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002333_YBR035C-MONOMER_PMPOXI-RXN_controller_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_16240_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR035C-MONOMER_PMPOXI-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16240_PMPOXI-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_PMPOXI-RXN_location_lociGO_0005829>
@@ -1612,37 +1691,39 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + pyridoxamine &rarr; ADP + pyridoxamine 5'-phosphate + H<SUP>+</SUP>' 'null' 'pyridoxamine 5'-phosphate + oxygen + H<sub>2</sub>O &rarr; ammonium + hydrogen peroxide + pyridoxal 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_17310_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002413_PMPOXI-RXN_null_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRAMKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PMPOXI-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_30616_PNKIN-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17310_PYRIDOXKIN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_58589_PNKIN-RXN_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58589_PNKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PNKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_58451_PMPOXI-RXN_SGD_PLPSAL-PWY>
@@ -1650,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1662,14 +1743,31 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15379>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://purl.obolibrary.org/obo/CHEBI_15379>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0008478>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-38_PYRIDOXKIN-RXN_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_456216_PYRIDOXKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1680,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1690,19 +1788,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_597326_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_15379_PNPOXI-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PNPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_597326_PNPOXI-RXN>
+          <http://model.geneontology.org/CHEBI_15379_PNPOXI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_15378_PNKIN-RXN_SGD_PLPSAL-PWY>
@@ -1710,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1725,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1735,19 +1833,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15379_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_PMPOXI-RXN>
+          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17310>
@@ -1762,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1779,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1804,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1814,19 +1912,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_58451_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_57761_PYRAMKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PYRAMKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58451_PYRAMKIN-RXN>
+          <http://model.geneontology.org/CHEBI_57761_PYRAMKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_PYRAMKIN-RXN>
@@ -1838,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,22 +1945,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_null_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_597326_PMPOXI-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PNKIN-RXN> ;
+          <http://model.geneontology.org/PMPOXI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PNKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_597326_PMPOXI-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000239>
@@ -1876,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1887,9 +1983,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component>
+        a       <http://identifiers.org/sgd/S000000755> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1898,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1920,36 +2025,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_456216_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_17310_PYRIDOXKIN-RXN_SGD_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17310_PYRIDOXKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_58589_PNKIN-RXN_SGD_PLPSAL-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIDOXKIN-RXN> ;
+          <http://model.geneontology.org/PNKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PYRIDOXKIN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000050_PLPSAL-PWY/PLPSAL-PWY_SGD_PLPSAL-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PNPOXI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PLPSAL-PWY/PLPSAL-PWY>
+          <http://model.geneontology.org/CHEBI_58589_PNKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16240_PMPOXI-RXN>
@@ -1961,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/POLYAMSYN-YEAST-PWY-POLYAMSYN-YEAST-PWY.ttl
+++ b/models/POLYAMSYN-YEAST-PWY-POLYAMSYN-YEAST-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,23 +163,23 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_POLYAMSYN-YEAST-PWY/POLYAMSYN-YEAST-PWY_SGD_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_POLYAMSYN-YEAST-PWY/POLYAMSYN-YEAST-PWY_SGD_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -236,24 +247,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYSmallMolecule27685> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57443>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -392,39 +392,13 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_null_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005412> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "S-adenosylmethionine decarboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYProtein27692> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,6 +409,32 @@
           <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005412> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "S-adenosylmethionine decarboxylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYProtein27692> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_null_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17509> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -826,7 +826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1066,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of polyamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1217,7 +1217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1443,7 +1443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,23 +1452,6 @@
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SPERMIDINESYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_POLYAMSYN-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ORNDECARBOX-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_326268_ORNDECARBOX-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_SPERMIDINESYN-RXN_location_lociGO_0005829>
@@ -1483,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,11 +1476,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_POLYAMSYN-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ORNDECARBOX-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_326268_ORNDECARBOX-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SPERMINE-SYNTHASE-RXN_SGD_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1536,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1614,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PROSYN-PWY-PROSYN-PWY.ttl
+++ b/models/PROSYN-PWY-PROSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -960,7 +960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,7 +979,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_null_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -990,20 +1001,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_null_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1019,7 +1019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,45 +1084,13 @@
           <http://model.geneontology.org/YOR323C-MONOMER_GLUTSEMIALDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000825> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "delta 1-pyrroline-5-carboxylate reductase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROSYN-PWYProtein29003> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60039> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pro" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROSYN-PWYSmallMolecule28965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002333_YDR300C-MONOMER_GLUTKIN-RXN_controller_SGD_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,6 +1101,38 @@
           <http://model.geneontology.org/YDR300C-MONOMER_GLUTKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60039> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pro" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROSYN-PWYSmallMolecule28965> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000825> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "delta 1-pyrroline-5-carboxylate reductase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROSYN-PWYProtein29003> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/CHEBI_57783_GLUTSEMIALDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,7 +1237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1279,7 +1279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,7 +1398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1432,7 +1432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1484,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PROUT-PWY-PROUT-PWY.ttl
+++ b/models/PROUT-PWY-PROUT-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,13 +32,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903_SGD_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_a261f9c4-2995-4396-b87a-2c5baab8dcef_RXN-14903_SGD_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903_SGD_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,7 +57,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a261f9c4-2995-4396-b87a-2c5baab8dcef_RXN-14903>
+          <http://model.geneontology.org/cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -55,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -94,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -136,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,21 +298,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_SPONTPRO-RXN>
 ] .
-
-<http://model.geneontology.org/bfb8f8ca-c701-4021-a854-b719c38f733f_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004132>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -314,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +381,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_886f3918-a905-42db-a095-d01135e21610_RXN-14903_SGD_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -624,11 +631,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_bfb8f8ca-c701-4021-a854-b719c38f733f_RXN-14903_SGD_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_886f3918-a905-42db-a095-d01135e21610_RXN-14903_SGD_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,19 +643,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bfb8f8ca-c701-4021-a854-b719c38f733f_RXN-14903>
+          <http://model.geneontology.org/886f3918-a905-42db-a095-d01135e21610_RXN-14903>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_bfb8f8ca-c701-4021-a854-b719c38f733f_RXN-14903_SGD_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -658,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -761,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -812,28 +808,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29111> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -841,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,16 +831,22 @@
           <http://model.geneontology.org/CHEBI_60039_RXN-14903>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_a261f9c4-2995-4396-b87a-2c5baab8dcef_RXN-14903_SGD_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29111> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -869,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,7 +947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,21 +958,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-14116>
 ] .
 
-<http://model.geneontology.org/a261f9c4-2995-4396-b87a-2c5baab8dcef_RXN-14903>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29059> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN-14903>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -997,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,9 +984,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/bfb8f8ca-c701-4021-a854-b719c38f733f_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
+                <http://model.geneontology.org/886f3918-a905-42db-a095-d01135e21610_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> , <http://model.geneontology.org/a261f9c4-2995-4396-b87a-2c5baab8dcef_RXN-14903> ;
+                <http://model.geneontology.org/cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1024,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1044,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,6 +1055,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-14116>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1094,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,24 +1083,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,6 +1099,21 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
 ] .
+
+<http://model.geneontology.org/886f3918-a905-42db-a095-d01135e21610_RXN-14903>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SPONTPRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -1147,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,8 +1145,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29059> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PRPP-PWY-1-PRPP-PWY-1.ttl
+++ b/models/PRPP-PWY-1-PRPP-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11,19 +11,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_RXN-9929_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9929>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -31,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -53,27 +70,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/AIRS-RXN>
 ] .
 
 <http://model.geneontology.org/YCL030C-MONOMER_HISTOLDEHYD-RXN_controller>
@@ -83,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,19 +151,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/GDPREDUCT-RXN>
@@ -166,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,19 +195,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001550>
@@ -199,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -221,19 +240,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57595_HISTALDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
@@ -245,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,19 +300,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_HISTCYCLOHYD-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -301,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,27 +385,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
+          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/AIRS-RXN>
@@ -408,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,53 +467,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROTPDECARB-RXN>
+          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58443>
@@ -503,19 +524,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -526,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -547,13 +568,13 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanylate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,19 +584,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
+          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PRPP-PWY-1>
@@ -583,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,19 +632,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
@@ -635,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -678,22 +699,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HISTALDEHYD-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
@@ -705,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,19 +751,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57766_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57766_HISTAMINOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_64802_HISTALDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -752,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -781,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -855,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -863,19 +882,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57980_HISTIDPHOS-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_PRPP-PWY-1>
@@ -883,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -955,19 +974,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
@@ -982,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1012,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,22 +1055,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-12002>
+          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
@@ -1063,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1135,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1143,19 +1160,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_PRIBFAICARPISOM-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58435_PRIBFAICARPISOM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_37563>
@@ -1163,30 +1180,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001664>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1197,19 +1225,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DGDPKIN-RXN>
+          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1220,29 +1248,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58359_GLUTAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -1250,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1263,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1277,7 +1303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1304,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1315,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,53 +1391,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller>
-] .
-
-<http://model.geneontology.org/d27e1835-a73d-4e13-95d3-a32329ac0b17_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57699_HISTOLDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HISTIDPHOS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_137981_AIRCARBOXY-RXN_SGD_PRPP-PWY-1>
@@ -1419,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1433,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1444,19 +1455,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCL030C-MONOMER_HISTPRATPHYD-RXN_controller>
+          <http://model.geneontology.org/CHEBI_64802_HISTOLDEHYD-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1465,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1514,22 +1525,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PRPP-PWY-1>
@@ -1537,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1548,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1604,56 +1613,58 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PRPPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN-12002>
+          <http://model.geneontology.org/YBL068W-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1>
@@ -1661,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1672,36 +1683,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PRPP-PWY-1>
@@ -1709,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1717,19 +1728,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' 'null' 'D-erythro-imidazole-glycerol-phosphate &rarr; imidazole acetol-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_null_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -1737,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1752,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,19 +1792,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTCYCLOHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YFR025C-MONOMER_HISTIDPHOS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_59457_HISTCYCLOHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1>
@@ -1782,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1793,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1808,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,27 +1854,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_HISTPRATPHYD-RXN>
+          <http://model.geneontology.org/reaction_HISTOLDEHYD-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
@@ -1856,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1873,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1886,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1897,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,19 +1956,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002411_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_29888_HISTPRATPHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1>
@@ -1944,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1962,7 +1994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1989,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1997,36 +2029,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' 'null' 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_61429>
@@ -2038,7 +2072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2054,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2065,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2073,19 +2107,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002411_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ATPPHOSPHORIBOSYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PRPPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PRPP-PWY-1>
@@ -2093,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2108,7 +2142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2128,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2138,19 +2172,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_RXN-9929>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -2158,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2169,14 +2203,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/HISTALDEHYD-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004636> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "histidinal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-histidine + NADH + 2 H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2192,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2205,29 +2239,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -2235,7 +2267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2250,7 +2282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2260,19 +2292,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29985_GLUTAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
@@ -2287,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2297,38 +2329,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
+          <http://model.geneontology.org/CHEBI_30839_RXN-9929>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
@@ -2340,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2357,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2374,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,19 +2414,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -2404,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2415,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2426,7 +2456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2437,29 +2467,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57464>
@@ -2472,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2485,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2496,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2507,36 +2535,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_57766_IMIDPHOSDEHYD-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
+          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2545,7 +2575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2558,19 +2588,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
@@ -2582,7 +2612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2596,7 +2626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2627,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2640,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2653,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2666,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2677,19 +2707,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_RXN-12002>
+          <http://model.geneontology.org/YKL181W-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_null_PRPP-PWY-1>
@@ -2697,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2709,7 +2739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2729,7 +2759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2746,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2762,7 +2792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2770,19 +2800,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -2794,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2811,7 +2841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2821,19 +2851,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
@@ -2845,7 +2875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2858,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2873,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2886,7 +2916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2899,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2909,19 +2939,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
 ] .
 
 <http://model.geneontology.org/YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller>
@@ -2931,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2941,30 +2971,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
+          <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58426>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2979,11 +3026,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39881> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2994,7 +3058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3007,7 +3071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3015,19 +3079,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_AICARTRANSFORM-RXN_null_PRPP-PWY-1>
@@ -3035,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3046,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3057,7 +3121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3068,7 +3132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3076,19 +3140,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004574>
@@ -3096,19 +3160,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002411_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1>
@@ -3116,7 +3180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3127,7 +3191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3135,19 +3199,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -3155,7 +3219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3166,7 +3230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3181,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3194,7 +3258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3205,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3217,7 +3281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3240,7 +3304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3253,7 +3317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3265,7 +3329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3281,7 +3345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3292,19 +3356,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
@@ -3316,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,7 +3394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3343,19 +3407,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_AICARSYN-RXN_SGD_PRPP-PWY-1>
@@ -3363,7 +3427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3374,35 +3438,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1Complex40157> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/AICARSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3413,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3423,19 +3508,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
+          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1>
@@ -3443,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3454,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3465,29 +3550,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FGAMSYN-RXN>
+          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -3498,7 +3581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3509,7 +3592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3524,7 +3607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3551,7 +3634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3564,9 +3647,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3575,7 +3667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3586,46 +3678,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_HISTALDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PRPP-PWY-1>
@@ -3633,7 +3723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3654,7 +3744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3663,22 +3753,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
 ] .
 
 <http://model.geneontology.org/OROPRIBTRANS-RXN>
@@ -3700,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3714,7 +3802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3737,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of histidine, purine, and pyrimidine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3750,9 +3838,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3762,7 +3859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3785,7 +3882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3795,19 +3892,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PRPP-PWY-1>
@@ -3815,7 +3912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3827,7 +3924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3840,19 +3937,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
+          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PRPP-PWY-1>
@@ -3860,7 +3957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3868,39 +3965,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_1990663>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
+          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1>
@@ -3908,7 +4007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3923,7 +4022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3937,7 +4036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3949,37 +4048,39 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_8ce54c48-c80b-46e2-94ce-7acd757a6844_GART-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8ce54c48-c80b-46e2-94ce-7acd757a6844_GART-RXN>
+          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
@@ -3990,7 +4091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4004,29 +4105,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-746>
+          <http://model.geneontology.org/cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
@@ -4038,7 +4137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4055,7 +4154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4072,7 +4171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4085,7 +4184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4093,39 +4192,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58525_GLUTAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58228>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_PRPP-PWY-1>
@@ -4133,7 +4234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4144,7 +4245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4155,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4166,7 +4267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4177,19 +4278,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_HISTAMINOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57540_HISTALDEHYD-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4198,7 +4299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4209,6 +4310,17 @@
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4218,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4237,7 +4349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4250,7 +4362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4260,19 +4372,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002411_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_HISTIDPHOS-RXN>
+          <http://model.geneontology.org/HISTIDPHOS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004550>
@@ -4287,7 +4399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4297,19 +4409,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCL030C-MONOMER_HISTOLDEHYD-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57699_HISTIDPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_PRPP-PWY-1>
@@ -4317,7 +4429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4329,7 +4441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4341,20 +4453,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/HISTAMINOTRANS-RXN>
@@ -4376,7 +4490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4389,7 +4503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4401,7 +4515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4417,7 +4531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4432,7 +4546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4442,19 +4556,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -4462,7 +4576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4477,7 +4591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4492,7 +4606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4505,7 +4619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4519,7 +4633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4535,44 +4649,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
+          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1>
@@ -4580,7 +4698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4598,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4608,19 +4726,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER099C-MONOMER_PRPPSYN-RXN_controller>
+          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004643>
@@ -4628,19 +4746,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58223>
@@ -4655,7 +4773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4672,7 +4790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4689,7 +4807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4698,20 +4816,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
@@ -4726,7 +4846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4740,7 +4860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4756,7 +4876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4767,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4778,7 +4898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4789,7 +4909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4797,19 +4917,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
+          <http://model.geneontology.org/CHEBI_16810_HISTAMINOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PRPP-PWY-1>
@@ -4817,7 +4937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4832,7 +4952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4848,19 +4968,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_HISTOLDEHYD-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -4868,7 +4988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4883,7 +5003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4893,19 +5013,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59457_HISTPRATPHYD-RXN>
+          <http://model.geneontology.org/CHEBI_57945_HISTOLDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1>
@@ -4913,7 +5033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4928,7 +5048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4946,7 +5066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4963,7 +5083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4979,7 +5099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4990,7 +5110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4998,27 +5118,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5029,22 +5160,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5052,7 +5189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5072,7 +5209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5085,7 +5222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5096,19 +5233,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_78346_PRPPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PRPP-PWY-1>
@@ -5116,7 +5253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5127,29 +5264,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58017_PRPPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
@@ -5157,19 +5292,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58278_GLUTAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_null_PRPP-PWY-1>
@@ -5177,7 +5312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5192,7 +5327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5202,36 +5337,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_AICARTRANSFORM-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004424>
@@ -5246,7 +5400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5259,7 +5413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5284,7 +5438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5297,7 +5451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5308,7 +5462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5318,22 +5472,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HISTPRATPHYD-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
@@ -5344,7 +5496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5357,7 +5509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5365,27 +5517,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_HISTALDEHYD-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_HISTPRATPHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PRPP-PWY-1>
@@ -5393,7 +5545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5408,7 +5560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5416,13 +5568,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_15377_ADPREDUCT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5438,7 +5601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5446,21 +5609,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
@@ -5474,7 +5637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5490,27 +5653,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL061W-MONOMER_PRPPSYN-RXN_controller>
+          <http://model.geneontology.org/reaction_PRPPSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
@@ -5522,7 +5687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5530,13 +5695,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5556,7 +5732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5565,39 +5741,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002411_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PRPP-PWY-1>
@@ -5605,7 +5779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5613,29 +5787,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GLUTAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "carbamoyl phosphate synthetase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component> , <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5645,19 +5821,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+          <http://model.geneontology.org/CHEBI_30031_RXN-9929>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PRPP-PWY-1>
@@ -5665,7 +5841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5676,7 +5852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5684,19 +5860,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PRPP-PWY-1>
@@ -5704,7 +5880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5715,7 +5891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5723,19 +5899,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN>
@@ -5747,7 +5923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5760,7 +5936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5772,24 +5948,37 @@
 <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58278>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' 'null' 'histidinal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-histidine + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/HISTALDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_PRPP-PWY-1>
@@ -5797,7 +5986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5808,7 +5997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5828,19 +6017,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_15377_IMIDPHOSDEHYD-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003203>
@@ -5851,7 +6040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5869,7 +6058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5879,19 +6068,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5902,7 +6091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5915,19 +6104,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -5935,7 +6124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5950,7 +6139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5964,7 +6153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5980,7 +6169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6005,7 +6194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6018,7 +6207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6029,7 +6218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6037,19 +6226,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN-12002>
+          <http://model.geneontology.org/YHL011C-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
@@ -6061,7 +6250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6075,7 +6264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6091,7 +6280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6099,38 +6288,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
+          <http://model.geneontology.org/UDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6141,7 +6330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6157,7 +6346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6172,7 +6361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6189,7 +6378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6199,19 +6388,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
+          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PRPP-PWY-1>
@@ -6219,7 +6408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6232,7 +6421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6241,22 +6430,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_32814>
@@ -6281,7 +6468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6293,20 +6480,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1>
@@ -6314,7 +6503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6325,7 +6514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6333,19 +6522,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_RXN-9929_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9929>
+          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
@@ -6357,7 +6546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6374,9 +6563,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/8ce54c48-c80b-46e2-94ce-7acd757a6844_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/af3b1486-9018-49b0-b7b9-9e3614ab0c80_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6384,7 +6573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6393,22 +6582,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AIRS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PRPP-PWY-1>
@@ -6416,7 +6603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6427,7 +6614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6442,7 +6629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6459,7 +6646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6472,7 +6659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6485,7 +6672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6495,19 +6682,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -6519,7 +6706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6529,19 +6716,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_PRPP-PWY-1>
@@ -6549,7 +6736,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6564,7 +6762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6577,7 +6775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6585,19 +6783,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001259>
@@ -6608,27 +6806,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6637,7 +6837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6653,7 +6853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6666,7 +6866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6682,7 +6882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6698,7 +6898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6713,7 +6913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6722,22 +6922,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002411_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
@@ -6752,7 +6950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6766,7 +6964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6782,7 +6980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6793,7 +6991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6801,36 +6999,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DADPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PRPP-PWY-1>
@@ -6838,27 +7036,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
+          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
@@ -6870,7 +7070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6878,24 +7078,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+] .
+
 <http://identifiers.org/sgd/S000003864>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -6910,7 +7127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6920,19 +7137,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/FGAMSYN-RXN>
@@ -6954,7 +7171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6971,7 +7188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6987,7 +7204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7001,7 +7218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7012,7 +7229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7023,7 +7240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7041,7 +7258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7051,19 +7268,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/YHL011C-MONOMER_PRPPSYN-RXN_controller>
@@ -7073,7 +7290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7096,7 +7313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7123,7 +7340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7133,19 +7350,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64802_HISTALDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_PRPP-PWY-1>
@@ -7153,7 +7370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7164,7 +7381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7189,7 +7406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7202,19 +7419,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_57945_HISTALDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PRPP-PWY-1>
@@ -7222,7 +7439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7235,7 +7452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7249,7 +7466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7265,7 +7482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7280,7 +7497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7298,7 +7515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7328,7 +7545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7342,7 +7559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7358,7 +7575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7366,19 +7583,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
+          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_RXN0-746>
@@ -7390,7 +7607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7407,7 +7624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7417,19 +7634,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PRPP-PWY-1>
@@ -7437,7 +7654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7449,7 +7666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7462,19 +7679,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_PRIBFAICARPISOM-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58435_PRIBFAICARPISOM-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1>
@@ -7482,7 +7699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7493,7 +7710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7501,19 +7718,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
+          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -7535,7 +7752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7555,7 +7772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7565,19 +7782,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58467>
@@ -7592,7 +7809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7609,7 +7826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7622,7 +7839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7633,7 +7850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7644,7 +7861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7655,27 +7872,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_GLUTAMIDOTRANS-RXN>
+          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
@@ -7687,7 +7906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7700,7 +7919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7715,7 +7934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7728,7 +7947,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7739,7 +7969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7747,19 +7977,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_HISTALDEHYD-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005164>
@@ -7771,7 +8001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7791,7 +8021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7818,7 +8048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7831,29 +8061,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HISTIDPHOS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_PRPP-PWY-1>
@@ -7861,7 +8089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7875,7 +8103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7886,7 +8114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7897,11 +8125,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_46398>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_HISTIDPHOS-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -7912,7 +8160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7920,32 +8168,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64802_HISTOLDEHYD-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_46398>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7956,7 +8184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7970,7 +8198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7993,7 +8221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8006,7 +8234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8018,7 +8246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8034,7 +8262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8042,27 +8270,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8077,7 +8316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8091,7 +8330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8110,38 +8349,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PRPP-PWY-1>
@@ -8149,7 +8386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8160,7 +8397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8168,19 +8405,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL068W-MONOMER_PRPPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004642>
@@ -8191,7 +8428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8202,7 +8439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8210,19 +8447,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58475>
@@ -8237,7 +8474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8254,7 +8491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8267,29 +8504,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' 'null' 'D-erythro-imidazole-glycerol-phosphate &rarr; imidazole acetol-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/RXN0-746>
@@ -8307,7 +8542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8322,7 +8557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8335,7 +8570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8349,7 +8584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8369,13 +8604,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_null_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CTPSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8386,7 +8640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8403,7 +8657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8416,29 +8670,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003666>
@@ -8453,7 +8705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8465,20 +8717,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTCYCLOHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59457_HISTCYCLOHYD-RXN>
+          <http://model.geneontology.org/reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_HISTPRATPHYD-RXN>
@@ -8490,7 +8744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8506,7 +8760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8521,7 +8775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8531,21 +8785,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' 'null' '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HISTOLDEHYD-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57699>
@@ -8556,7 +8810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8569,7 +8823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8582,7 +8836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8596,7 +8850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8610,19 +8864,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_HISTPRATPHYD-RXN>
+          <http://model.geneontology.org/CHEBI_15378_HISTOLDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PRPP-PWY-1>
@@ -8630,7 +8884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8645,7 +8899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8665,7 +8919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8674,42 +8928,42 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-ATP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57766>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' 'null' 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8718,7 +8972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8734,19 +8988,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PRPPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
@@ -8758,7 +9012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8768,11 +9022,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_83100fbb-c368-4826-88d4-014d89ac6311_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8780,7 +9034,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/83100fbb-c368-4826-88d4-014d89ac6311_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_null_PRPP-PWY-1>
@@ -8788,7 +9042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8796,19 +9050,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_456215_PRPPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
@@ -8816,53 +9070,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GLUTAMIDOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_RXN-9929>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12002> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57865_RXN-12002>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_AMPSYN-RXN_SGD_PRPP-PWY-1>
@@ -8870,7 +9124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8879,6 +9133,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_17544>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003864> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -8886,7 +9159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8896,19 +9169,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -8919,44 +9192,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/af3b1486-9018-49b0-b7b9-9e3614ab0c80_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -8964,7 +9220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8978,7 +9234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8993,7 +9249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9002,20 +9258,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-histidinol phosphate + H<sub>2</sub>O &rarr; histidinol + phosphate' 'null' 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/HISTOLDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
@@ -9027,7 +9285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9040,7 +9298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9048,19 +9306,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57766_IMIDPHOSDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_73200_HISTPRATPHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PRPP-PWY-1>
@@ -9068,7 +9326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9083,7 +9341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9096,7 +9354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9107,7 +9365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9118,7 +9376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9132,7 +9390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9145,19 +9403,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004044>
@@ -9170,7 +9428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9187,7 +9445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9200,19 +9458,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL181W-MONOMER_PRPPSYN-RXN_controller>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1>
@@ -9220,7 +9478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9235,7 +9493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9249,7 +9507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9269,7 +9527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9282,19 +9540,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002411_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000747>
@@ -9305,7 +9563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9319,7 +9577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9335,7 +9593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9346,36 +9604,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_RXN-9929_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+          <http://model.geneontology.org/CHEBI_30864_RXN-9929>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
@@ -9386,7 +9644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9400,7 +9658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9411,7 +9669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9424,7 +9682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9434,19 +9692,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
@@ -9458,7 +9716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9485,7 +9743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9498,7 +9756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9509,7 +9767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9522,7 +9780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9535,7 +9793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9546,7 +9804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9557,7 +9815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9572,7 +9830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9585,7 +9843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9593,19 +9851,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_58278_IMIDPHOSDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/CTPSYN-RXN>
@@ -9625,7 +9883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9638,44 +9896,57 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/GART-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -9683,7 +9954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9694,7 +9965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9705,7 +9976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9716,7 +9987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9728,7 +9999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9751,7 +10022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9765,7 +10036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9785,7 +10056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9795,19 +10066,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -9818,7 +10089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9829,7 +10100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9844,7 +10115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9858,7 +10129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9871,19 +10142,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004385>
@@ -9891,55 +10162,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AICARSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -9947,7 +10216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9962,7 +10231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9971,20 +10240,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
+          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58525_GLUTAMIDOTRANS-RXN>
@@ -9996,7 +10267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10009,7 +10280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10020,7 +10291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10028,19 +10299,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
@@ -10050,7 +10321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10059,22 +10330,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PRPP-PWY-1>
@@ -10082,7 +10351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10090,19 +10359,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/YOR128C-MONOMER_AIRCARBOXY-RXN_controller>
@@ -10112,7 +10381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10129,7 +10398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10139,19 +10408,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
+          <http://model.geneontology.org/GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
@@ -10162,7 +10431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10174,7 +10443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10190,7 +10459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10201,14 +10470,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/HISTOLDEHYD-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004636> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -10226,7 +10495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10253,7 +10522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10267,7 +10536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10287,7 +10556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10300,7 +10569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10311,19 +10580,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
 ] .
 
 <http://model.geneontology.org/reaction_HISTOLDEHYD-RXN_location_lociGO_0005829>
@@ -10335,7 +10604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10355,7 +10624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10368,7 +10637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10383,7 +10652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10396,7 +10665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10414,7 +10683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10427,19 +10696,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_PRPP-PWY-1>
@@ -10447,29 +10716,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -10480,7 +10747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10500,7 +10767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10509,22 +10776,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1>
@@ -10532,7 +10797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10547,9 +10812,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/83100fbb-c368-4826-88d4-014d89ac6311_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d27e1835-a73d-4e13-95d3-a32329ac0b17_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -10557,7 +10822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10567,19 +10832,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
 ] .
 
 <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
@@ -10589,7 +10871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10607,7 +10889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10617,19 +10899,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_af3b1486-9018-49b0-b7b9-9e3614ab0c80_GART-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/af3b1486-9018-49b0-b7b9-9e3614ab0c80_GART-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PRPP-PWY-1>
@@ -10637,7 +10919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10648,7 +10930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10656,19 +10938,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
@@ -10680,7 +10962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10689,22 +10971,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58053>
@@ -10715,7 +10995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10730,7 +11010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10740,19 +11020,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_HISTALDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58525>
@@ -10767,7 +11047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10780,19 +11060,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002411_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HISTIDPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_57595_HISTALDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PRPP-PWY-1>
@@ -10800,7 +11080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10811,7 +11091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10819,19 +11099,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57699_HISTIDPHOS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_HISTCYCLOHYD-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58017_PRPPSYN-RXN>
@@ -10843,13 +11123,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39634> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10859,7 +11150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10882,7 +11173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10897,7 +11188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10910,9 +11201,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -10921,7 +11221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10936,7 +11236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10956,7 +11256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10966,19 +11266,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_RXN0-745>
@@ -10990,7 +11290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11003,7 +11303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11014,7 +11314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11022,19 +11322,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
@@ -11045,29 +11345,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/OROTPDECARB-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11076,7 +11374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11092,7 +11390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11103,7 +11401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11120,46 +11418,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+          <http://model.geneontology.org/YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_AIRS-RXN>
@@ -11171,7 +11467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11188,7 +11484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11205,7 +11501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11218,7 +11514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11235,7 +11531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11243,19 +11539,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
@@ -11270,7 +11566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11285,7 +11581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11302,7 +11598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11311,23 +11607,32 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -11338,7 +11643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11351,7 +11656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11364,7 +11669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11373,20 +11678,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_HISTAMINOTRANS-RXN>
+          <http://model.geneontology.org/reaction_HISTALDEHYD-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11395,7 +11702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11411,7 +11718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11424,7 +11731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11441,7 +11748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11454,7 +11761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11479,7 +11786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11489,19 +11796,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57766_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_57766_HISTAMINOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1>
@@ -11509,7 +11816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11520,7 +11827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11531,7 +11838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11539,19 +11846,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_HISTOLDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_57980_HISTIDPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PRPP-PWY-1>
@@ -11559,7 +11866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11574,7 +11881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11587,7 +11894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11599,7 +11906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11619,7 +11926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11629,19 +11936,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -11649,7 +11956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11661,7 +11968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11672,24 +11979,35 @@
           <http://model.geneontology.org/CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003937>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/RXN-12002>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PRPP-PWY-1>
@@ -11697,7 +12015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11712,7 +12030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11725,19 +12043,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRPPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -11745,7 +12063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11758,7 +12076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11774,7 +12092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11782,19 +12100,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/AMPSYN-RXN>
@@ -11816,7 +12134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11843,7 +12161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11860,7 +12178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11873,7 +12191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11883,22 +12201,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_AICARTRANSFORM-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/RXN0-745>
@@ -11916,7 +12232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11929,11 +12245,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -11941,7 +12260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11950,6 +12269,23 @@
           <http://model.geneontology.org/ADENYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
@@ -11961,7 +12297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11974,27 +12310,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_137981_AIRCARBOXY-RXN>
@@ -12006,7 +12344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12023,7 +12361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12031,12 +12369,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12051,7 +12392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12064,19 +12405,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
@@ -12088,7 +12429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12106,7 +12447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12123,7 +12464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12136,7 +12477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12147,7 +12488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12155,19 +12496,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_HISTPRATPHYD-RXN>
+          <http://model.geneontology.org/CHEBI_57699_HISTOLDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456215_PRPPSYN-RXN>
@@ -12179,7 +12520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12193,7 +12534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12205,23 +12546,24 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YCL030C-MONOMER_HISTPRATPHYD-RXN_controller>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -12229,7 +12571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12244,19 +12586,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRPPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -12265,7 +12607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12278,19 +12620,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002411_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PRPPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
@@ -12302,7 +12644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12319,7 +12661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12337,7 +12679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12350,7 +12692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12375,7 +12717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12385,53 +12727,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLUTAMIDOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_RXN-9929>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12002> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_RXN-12002>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -12439,7 +12781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12447,19 +12789,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -12467,7 +12809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12475,19 +12817,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1>
@@ -12495,7 +12837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12506,7 +12848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12517,7 +12859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12532,7 +12874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12540,23 +12882,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' 'null' 'histidinal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-histidine + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HISTALDEHYD-RXN>
+          <http://model.geneontology.org/YFR025C-MONOMER_HISTIDPHOS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
@@ -12568,7 +12911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12581,7 +12924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12589,19 +12932,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMIDPHOSDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_15377_HISTPRATPHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -12609,7 +12952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12620,7 +12963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12636,7 +12979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12650,7 +12993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12663,19 +13006,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002411_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1>
@@ -12683,7 +13026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12692,30 +13035,13 @@
 <http://purl.obolibrary.org/obo/GO_0004590>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/8ce54c48-c80b-46e2-94ce-7acd757a6844_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12727,22 +13053,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_59457>
@@ -12750,19 +13074,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHL011C-MONOMER_PRPPSYN-RXN_controller>
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -12770,7 +13094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12785,7 +13109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12801,7 +13125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12817,7 +13141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12840,7 +13164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12849,22 +13173,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002411_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/UDPKIN-RXN>
+          <http://model.geneontology.org/ATPPHOSPHORIBOSYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_PRPP-PWY-1>
@@ -12872,7 +13194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12884,7 +13206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12900,7 +13222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12915,7 +13237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12923,24 +13245,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_af3b1486-9018-49b0-b7b9-9e3614ab0c80_GART-RXN_SGD_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12956,7 +13267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12964,19 +13275,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
+          <http://model.geneontology.org/CHEBI_29806_RXN-9929>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PRPP-PWY-1>
@@ -12984,7 +13295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12995,27 +13306,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
+          <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_PRPPSYN-RXN>
@@ -13027,7 +13340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13042,22 +13355,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
@@ -13069,7 +13380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13078,20 +13389,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
+          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PRPP-PWY-1>
@@ -13099,7 +13412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13110,7 +13423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13125,28 +13438,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40656> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/83100fbb-c368-4826-88d4-014d89ac6311_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -13159,7 +13455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13172,7 +13468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13180,19 +13476,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PRPP-PWY-1>
@@ -13200,7 +13496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13215,7 +13511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13228,7 +13524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13243,7 +13539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13252,20 +13548,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57865_RXN-12002>
@@ -13277,7 +13575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13294,7 +13592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13311,7 +13609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13321,19 +13619,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
@@ -13347,7 +13645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13355,19 +13653,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PRPP-PWY-1>
@@ -13375,7 +13673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13386,7 +13684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13401,7 +13699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13410,31 +13708,29 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPKIN-RXN>
+          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_d27e1835-a73d-4e13-95d3-a32329ac0b17_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13442,7 +13738,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d27e1835-a73d-4e13-95d3-a32329ac0b17_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1>
@@ -13450,7 +13746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13461,7 +13757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13486,7 +13782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13499,7 +13795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13513,7 +13809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13529,7 +13825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13544,7 +13840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13554,19 +13850,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002411_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58223_RXN-12002>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
@@ -13581,7 +13877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13594,7 +13890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13606,7 +13902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13622,7 +13918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13630,19 +13926,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
 <http://model.geneontology.org/CHEBI_57766_HISTAMINOTRANS-RXN>
@@ -13654,7 +13950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13667,19 +13963,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
@@ -13687,7 +13983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13710,7 +14006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13720,36 +14016,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PRPP-PWY-1>
@@ -13757,7 +14053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13772,7 +14068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13785,7 +14081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13796,7 +14092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13807,7 +14103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13815,19 +14111,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PRPP-PWY-1>
@@ -13835,7 +14131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13850,7 +14146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13858,12 +14154,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13874,27 +14181,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PRPP-PWY-1>
@@ -13902,7 +14218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13930,7 +14246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13938,32 +14254,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
-
-<http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13974,7 +14290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13992,7 +14308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14012,7 +14328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14027,7 +14343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14037,20 +14353,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_HISTALDEHYD-RXN>
+          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57567_AMPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57567> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -14061,7 +14388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14074,7 +14401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14089,7 +14416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14106,7 +14433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14119,7 +14446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14133,7 +14460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14152,7 +14479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14164,7 +14491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14188,7 +14515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14205,7 +14532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14215,19 +14542,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_null_PRPP-PWY-1>
@@ -14235,7 +14562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14246,7 +14573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14257,7 +14584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14269,7 +14596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14282,19 +14609,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1>
@@ -14302,7 +14629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14312,39 +14639,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
 ] .
 
 <http://model.geneontology.org/HISTIDPHOS-RXN>
@@ -14366,7 +14691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14382,7 +14707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14397,7 +14722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14414,7 +14739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14429,7 +14754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14439,19 +14764,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
+          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58457>
@@ -14465,21 +14790,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_PRPPSYN-RXN>
@@ -14491,7 +14816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14508,7 +14833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14521,7 +14846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14546,7 +14871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14563,7 +14888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14580,7 +14905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14589,20 +14914,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_HISTALDEHYD-RXN>
+          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/GUANYL-KIN-RXN>
@@ -14626,7 +14953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14639,7 +14966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14647,19 +14974,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_HISTALDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
@@ -14671,7 +14998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14684,27 +15011,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_HISTIDPHOS-RXN>
+          <http://model.geneontology.org/reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PRPP-PWY-1>
@@ -14712,7 +15041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14727,7 +15056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14741,7 +15070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14757,7 +15086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14772,7 +15101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14785,7 +15114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14800,7 +15129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14813,19 +15142,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/DADPKIN-RXN>
@@ -14845,7 +15174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14853,23 +15182,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000003563>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
@@ -14881,7 +15211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14895,7 +15225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14908,19 +15238,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -14928,7 +15258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14939,7 +15269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14964,13 +15294,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1BiochemicalReaction39989> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -14981,7 +15314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14991,19 +15324,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
@@ -15011,19 +15344,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PRPP-PWY-1>
@@ -15031,7 +15364,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15039,19 +15383,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
+          <http://model.geneontology.org/6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
@@ -15063,7 +15407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15072,20 +15416,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/RXN0-746>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_HISTOLDEHYD-RXN>
@@ -15097,7 +15443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15114,7 +15460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15141,7 +15487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15151,19 +15497,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58525_GLUTAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -15175,7 +15521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15184,22 +15530,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
@@ -15211,7 +15555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15225,7 +15569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15244,29 +15588,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' 'null' '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+          <http://model.geneontology.org/HISTAMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN>
+          <http://model.geneontology.org/CHEBI_29985_HISTAMINOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PRPP-PWY-1>
@@ -15274,7 +15616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15289,7 +15631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15302,7 +15644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15310,19 +15652,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_HISTOLDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_15377_HISTIDPHOS-RXN>
 ] .
 
 <http://model.geneontology.org/AIRCARBOXY-RXN>
@@ -15344,7 +15686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15357,7 +15699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15372,7 +15714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15389,7 +15731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15398,22 +15740,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-ATP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN>
+          <http://model.geneontology.org/YCL030C-MONOMER_HISTOLDEHYD-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
@@ -15425,7 +15765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15452,7 +15792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15466,7 +15806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15479,19 +15819,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -15500,7 +15840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15516,11 +15856,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58426_GART-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58426> ;
@@ -15531,7 +15888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15541,19 +15898,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -15562,7 +15919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15578,19 +15935,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_PRPPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
@@ -15602,7 +15959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15615,7 +15972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15623,36 +15980,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_RXN-12002>
+          <http://model.geneontology.org/YER099C-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004400>
@@ -15660,19 +16017,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_PRPP-PWY-1>
@@ -15680,7 +16037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15688,19 +16045,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -15708,40 +16065,55 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GART-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/YBL068W-MONOMER_PRPPSYN-RXN_controller>
@@ -15751,7 +16123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15770,7 +16142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15785,7 +16157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15797,10 +16169,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15808,23 +16182,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://identifiers.org/sgd/S000002862>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-histidinol phosphate + H<sub>2</sub>O &rarr; histidinol + phosphate' 'null' 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTIDPHOS-RXN> ;
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HISTOLDEHYD-RXN>
+          <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PRPP-PWY-1>
@@ -15832,7 +16207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15840,19 +16215,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+          <http://model.geneontology.org/HISTOLDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_73200_HISTPRATPHYD-RXN>
+          <http://model.geneontology.org/CHEBI_57540_HISTOLDEHYD-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
@@ -15863,18 +16238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_83100fbb-c368-4826-88d4-014d89ac6311_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15888,7 +16252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15903,7 +16267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15917,7 +16281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15930,19 +16294,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/CHEBI_59457_HISTPRATPHYD-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -15953,7 +16317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15965,7 +16329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15983,7 +16347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15996,7 +16360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16009,7 +16373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16022,7 +16386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16035,7 +16399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -16052,7 +16416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16062,17 +16426,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPSYN-RXN> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
@@ -16084,7 +16448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16100,7 +16464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16113,19 +16477,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002411_OROPRIBTRANS-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_78346_PRPPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PRPP-PWY-1>
@@ -16133,7 +16497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16144,27 +16508,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_RXN-9929_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_RXN-9929>
+          <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1>
@@ -16172,7 +16538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16180,19 +16546,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1>
@@ -16200,7 +16566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16211,7 +16577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16222,7 +16588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16230,19 +16596,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GLUTAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58278_GLUTAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1>
@@ -16250,7 +16616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16258,19 +16624,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004127>
@@ -16281,7 +16647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16292,7 +16658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16303,18 +16669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_d27e1835-a73d-4e13-95d3-a32329ac0b17_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16325,27 +16680,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58278_IMIDPHOSDEHYD-RXN>
+          <http://model.geneontology.org/reaction_HISTPRATPHYD-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_IMIDPHOSDEHYD-RXN_SGD_PRPP-PWY-1>
@@ -16353,7 +16710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16371,7 +16728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16381,19 +16738,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
 ] .
 
 <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
@@ -16403,7 +16760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16423,7 +16780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16439,7 +16796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16454,7 +16811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16466,21 +16823,32 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_HISTALDEHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -16491,7 +16859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16504,7 +16872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16516,7 +16884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16532,7 +16900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16540,19 +16908,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/PRPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
+          <http://model.geneontology.org/YOL061W-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PRPP-PWY-1>
@@ -16560,7 +16928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16571,7 +16939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16582,7 +16950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16594,7 +16962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16614,7 +16982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16623,20 +16991,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
+          <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_PRPP-PWY-1>
@@ -16644,7 +17014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16659,7 +17029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16669,19 +17039,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
@@ -16689,7 +17059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16700,36 +17070,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57865>
@@ -16740,7 +17110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16758,7 +17128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16771,7 +17141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16782,7 +17152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16795,7 +17165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16808,41 +17178,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_8ce54c48-c80b-46e2-94ce-7acd757a6844_GART-RXN_SGD_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004727>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -16854,7 +17211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16867,7 +17224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16875,19 +17232,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/IMIDPHOSDEHYD-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
 <http://identifiers.org/sgd/S000002816>
@@ -16895,19 +17252,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
@@ -16918,7 +17275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16926,19 +17283,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58595>
@@ -16949,7 +17306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16964,7 +17321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16974,19 +17331,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -16995,7 +17352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17014,7 +17371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17025,7 +17382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17036,7 +17393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17047,7 +17404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17058,7 +17415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17086,7 +17443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17100,7 +17457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17116,7 +17473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17127,7 +17484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17142,7 +17499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17152,19 +17509,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
+          <http://model.geneontology.org/CHEBI_456216_RXN-12002>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58115>
@@ -17179,7 +17536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17192,7 +17549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17203,7 +17560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17215,7 +17572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17233,7 +17590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17242,37 +17599,42 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
+          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
+
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
@@ -17284,7 +17646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17298,7 +17660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17311,19 +17673,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_PRPP-PWY-1>
@@ -17331,27 +17693,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58435>
@@ -17362,7 +17726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-1801-1-PWY-1801-1.ttl
+++ b/models/PWY-1801-1-PWY-1801-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,7 +119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,12 +130,12 @@
           <http://model.geneontology.org/CHEBI_57540_1.2.1.2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_57925_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -146,18 +146,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_57925_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -467,14 +467,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0051903>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PWY-1801-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -485,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "formaldehyde oxidation II (glutathione-dependent) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -510,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -665,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -678,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,17 +832,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-2962_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0018738> ;
@@ -866,13 +852,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1BiochemicalReaction62268> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -883,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,7 +889,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-2962>
-        a       <http://purl.obolibrary.org/obo/GO_0051903> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-(hydroxymethyl)glutathione + NAD(P)<sup>+</sup> &rarr; <i>S</i>-formylglutathione + NAD(P)H + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -910,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1030,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1043,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1063,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,6 +1094,9 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/YDL168W-MONOMER_RXN-2962_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002327> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,7 +1160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1227,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1295,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,7 +1474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-2201-PWY-2201.ttl
+++ b/models/PWY-2201-PWY-2201.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_b8fb80a6-3f3c-448a-9cf0-f9a7d2c736bc_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5061> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b8fb80a6-3f3c-448a-9cf0-f9a7d2c736bc_RXN-5061>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000003093>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -34,20 +34,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.20-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -57,28 +74,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/d5f62dfd-c1d9-47cd-ab0e-46f71b65acd0_HOMOCYSMETB12-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,59 +98,87 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFDEFORMYL-RXN_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
-] .
+<http://model.geneontology.org/717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_17437_2.1.1.19-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
+          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN>
@@ -162,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,21 +198,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -195,121 +234,104 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/b8fb80a6-3f3c-448a-9cf0-f9a7d2c736bc_RXN-5061>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_96391e5a-df2e-41c7-8fa0-e780eda61492_FORMATETHFLIG-RXN_SGD_PWY-2201>
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57945_1.5.1.20-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
+] .
 
 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.1.1.19-RXN>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
-] .
-
-<http://model.geneontology.org/455011e0-5c55-4352-ba61-264a4a92d2ad_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -322,28 +344,64 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -353,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -361,19 +419,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY-2201>
@@ -381,11 +439,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004801>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -396,11 +457,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67378> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -409,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -417,19 +495,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Apo-Ferredoxins_RXN-5061_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
+          <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_null_PWY-2201>
@@ -437,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,20 +551,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_24a0d1fb-8446-4890-a145-9f5983aa3978_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/24a0d1fb-8446-4890-a145-9f5983aa3978_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061>
@@ -498,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -522,36 +602,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15740_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_17437_2.1.1.19-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 <http://model.geneontology.org/RXN-5061>
@@ -563,15 +643,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b8fb80a6-3f3c-448a-9cf0-f9a7d2c736bc_RXN-5061> , <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> ;
+                <http://model.geneontology.org/a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061> , <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-5061> , <http://model.geneontology.org/f4712c0d-5b55-4ed2-ae56-ab725605deac_RXN-5061> , <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-5061> , <http://model.geneontology.org/d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061> , <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/HOMOCYSMETB12-RXN> , <http://model.geneontology.org/2.1.1.19-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,36 +659,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_5e42d639-333b-449d-8dd4-dafd2ecac6aa_1.5.1.15-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_b8fb80a6-3f3c-448a-9cf0-f9a7d2c736bc_RXN-5061_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
+        a       <http://identifiers.org/sgd/S000001788> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -617,36 +684,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57945_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/PWY-2201>
@@ -658,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate transformations I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -666,34 +733,60 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
@@ -708,13 +801,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67378> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -723,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -731,43 +827,68 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0004487>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,44 +922,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.20-RXN>
+          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ee6c0091-f4e7-421d-9a39-892b9d6d50d3_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -849,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -860,11 +975,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -875,24 +1007,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67665> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_9d8260e0-c810-464a-aae5-b1ed12fa24fe_FORMATETHFLIG-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
@@ -903,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -935,98 +1056,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Apo-Ferredoxins_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5061> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_f42ec330-1e2a-4e41-926b-54705b6684dd_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_null_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_1b7cff0b-6d59-4543-b5f2-9b2f9f0df43c_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/9c5abe8f-8058-4f80-8c21-8f185f70dc3d_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1034,13 +1094,92 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN>
+] .
 
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
@@ -1051,9 +1190,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/96391e5a-df2e-41c7-8fa0-e780eda61492_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/9d8260e0-c810-464a-aae5-b1ed12fa24fe_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1063,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1076,7 +1215,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1117,39 +1267,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000066_reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY-2201>
@@ -1157,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1174,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1182,19 +1313,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_389e5503-7295-4bf7-a0ab-2e779adab736_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/389e5503-7295-4bf7-a0ab-2e779adab736_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -1206,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1223,7 +1354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1247,27 +1378,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>' 'null' 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9ed11264-35c4-4233-8cdd-b079fac27c45_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002413_GLYOHMETRANS-RXN_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9ed11264-35c4-4233-8cdd-b079fac27c45_GCVMULTI-RXN>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY-2201>
@@ -1275,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1292,63 +1425,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
+          <http://model.geneontology.org/36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
-
-<http://model.geneontology.org/4ba06029-b652-449a-ba43-bfdae5107b6e_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1359,7 +1473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1367,26 +1481,26 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004329> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1394,9 +1508,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/50df8ac6-c883-4698-92fe-a150288347de_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/48d2cf3d-0b50-4058-a0bc-48bfc029d4b2_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1404,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,48 +1528,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
+
+<http://model.geneontology.org/90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/9d8260e0-c810-464a-aae5-b1ed12fa24fe_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1466,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1505,43 +1619,63 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
-] .
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_CHEBI_15378_RXN-5061_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5061> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN-5061>
+] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1551,110 +1685,114 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_9ec5bb71-b57e-4f09-8cb5-39c05bcc8519_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000066_reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9ec5bb71-b57e-4f09-8cb5-39c05bcc8519_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_ec18b557-380c-4633-aca0-a2117806d04f_2.1.1.19-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000066_reaction_2.1.1.19-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ec18b557-380c-4633-aca0-a2117806d04f_2.1.1.19-RXN>
+          <http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_d5f62dfd-c1d9-47cd-ab0e-46f71b65acd0_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5061> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d5f62dfd-c1d9-47cd-ab0e-46f71b65acd0_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>' 'null' 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002413_GLYOHMETRANS-RXN_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
@@ -1662,18 +1800,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_389e5503-7295-4bf7-a0ab-2e779adab736_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1681,19 +1819,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_ee6c0091-f4e7-421d-9a39-892b9d6d50d3_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_null_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ee6c0091-f4e7-421d-9a39-892b9d6d50d3_1.5.1.20-RXN>
+          <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY-2201>
@@ -1701,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1716,15 +1873,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/389e5503-7295-4bf7-a0ab-2e779adab736_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/1b7cff0b-6d59-4543-b5f2-9b2f9f0df43c_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1734,19 +1891,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_15378_1.5.1.20-RXN_SGD_PWY-2201>
@@ -1754,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1762,19 +1919,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_9d8260e0-c810-464a-aae5-b1ed12fa24fe_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9d8260e0-c810-464a-aae5-b1ed12fa24fe_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY-2201>
@@ -1782,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1790,6 +1947,17 @@
 
 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1799,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1807,37 +1975,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/94dc99fb-6d18-4ce8-966f-de86dded4e20_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1847,27 +1998,55 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_CHEBI_15378_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-5061>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN>
@@ -1879,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,44 +2067,40 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.15-RXN>
+          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000066_reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
@@ -1933,11 +2108,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1948,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1964,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1972,53 +2150,58 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-homocysteine + a 5-methyltetrahydrofolate &rarr; L-methionine + a tetrahydrofolate' 'null' 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002413_FORMATETHFLIG-RXN_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Apo-Ferredoxins_RXN-5061_SGD_PWY-2201>
@@ -2026,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2037,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2048,37 +2231,54 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_455011e0-5c55-4352-ba61-264a4a92d2ad_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/455011e0-5c55-4352-ba61-264a4a92d2ad_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
+
+<http://model.geneontology.org/7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2087,22 +2287,20 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000066_reaction_2.1.1.19-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000000985>
@@ -2110,64 +2308,111 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+] .
+
+<http://model.geneontology.org/286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
+<http://model.geneontology.org/c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_4ba06029-b652-449a-ba43-bfdae5107b6e_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4ba06029-b652-449a-ba43-bfdae5107b6e_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_ec18b557-380c-4633-aca0-a2117806d04f_2.1.1.19-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2182,15 +2427,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/455011e0-5c55-4352-ba61-264a4a92d2ad_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bd5b99d4-211a-444c-bf01-da013337e935_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2207,7 +2452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2224,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2232,29 +2477,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/9ec5bb71-b57e-4f09-8cb5-39c05bcc8519_FORMYLTHFDEFORMYL-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2265,48 +2504,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_17434_2.1.1.19-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_94dc99fb-6d18-4ce8-966f-de86dded4e20_1.5.1.15-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/94dc99fb-6d18-4ce8-966f-de86dded4e20_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_455011e0-5c55-4352-ba61-264a4a92d2ad_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5061> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN>
+] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2315,7 +2543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2328,50 +2556,50 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-homocysteine + a 5-methyltetrahydrofolate &rarr; L-methionine + a tetrahydrofolate' 'null' 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002413_FORMATETHFLIG-RXN_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000066_reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/50df8ac6-c883-4698-92fe-a150288347de_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2381,36 +2609,79 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
+          <http://model.geneontology.org/7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN>
+] .
+
+<http://model.geneontology.org/233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000004801> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN>
 ] .
 
 <http://model.geneontology.org/GLYOHMETRANS-RXN>
@@ -2422,9 +2693,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3fcee578-d966-4e4c-b5e1-ff135348ba27_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/4ba06029-b652-449a-ba43-bfdae5107b6e_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2434,7 +2705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2451,7 +2722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2461,19 +2732,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_50df8ac6-c883-4698-92fe-a150288347de_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/50df8ac6-c883-4698-92fe-a150288347de_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
 <http://model.geneontology.org/HOMOCYSMETB12-RXN>
@@ -2485,15 +2756,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/24a0d1fb-8446-4890-a145-9f5983aa3978_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> ;
+                <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/d5f62dfd-c1d9-47cd-ab0e-46f71b65acd0_HOMOCYSMETB12-RXN> ;
+                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,91 +2774,89 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004489>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_f4712c0d-5b55-4ed2-ae56-ab725605deac_RXN-5061_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_94dc99fb-6d18-4ce8-966f-de86dded4e20_1.5.1.15-RXN_SGD_PWY-2201>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/GO_0004489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/9ed11264-35c4-4233-8cdd-b079fac27c45_GCVMULTI-RXN>
+<http://model.geneontology.org/9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+] .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2601,69 +2870,71 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_f4712c0d-5b55-4ed2-ae56-ab725605deac_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000066_reaction_RXN-5061_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f4712c0d-5b55-4ed2-ae56-ab725605deac_RXN-5061>
+          <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/bd5b99d4-211a-444c-bf01-da013337e935_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
+] .
+
+<http://model.geneontology.org/d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
-] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2678,7 +2949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2688,19 +2959,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
@@ -2712,7 +2983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2720,46 +2991,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_50df8ac6-c883-4698-92fe-a150288347de_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2770,28 +3039,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67622> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/9f037588-28e3-4ebc-9078-180903d5500b_2.1.1.19-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2800,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2808,23 +3060,60 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_1b7cff0b-6d59-4543-b5f2-9b2f9f0df43c_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1b7cff0b-6d59-4543-b5f2-9b2f9f0df43c_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003093> ;
@@ -2833,7 +3122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2842,37 +3131,39 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/1.5.1.15-RXN>
@@ -2884,9 +3175,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/94dc99fb-6d18-4ce8-966f-de86dded4e20_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5e42d639-333b-449d-8dd4-dafd2ecac6aa_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2894,7 +3185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2904,53 +3195,64 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_17434_2.1.1.19-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN>
+          <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5061> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
+          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
@@ -2961,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2974,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2984,19 +3286,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000066_reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829_null_PWY-2201>
@@ -3004,20 +3306,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_9c5abe8f-8058-4f80-8c21-8f185f70dc3d_GCVMULTI-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3026,7 +3317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3037,29 +3328,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000066_reaction_RXN-5061_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5061> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829>
+          <http://model.geneontology.org/e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -3069,7 +3358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3082,7 +3371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3091,21 +3380,24 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000001788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
@@ -3113,7 +3405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3121,19 +3413,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
+          <http://model.geneontology.org/717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY-2201>
@@ -3141,7 +3433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3152,7 +3444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3167,7 +3459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3175,89 +3467,61 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_9ec5bb71-b57e-4f09-8cb5-39c05bcc8519_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_2.1.1.19-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
+          <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GCVMULTI-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
+          <http://model.geneontology.org/2.1.1.19-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/48d2cf3d-0b50-4058-a0bc-48bfc029d4b2_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
+          <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
@@ -3275,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3288,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3299,82 +3563,64 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15378_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_d5f62dfd-c1d9-47cd-ab0e-46f71b65acd0_HOMOCYSMETB12-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c4f8e5fd-dc95-4e1d-8c3a-e7450a5dc934_1.5.1.20-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_9f037588-28e3-4ebc-9078-180903d5500b_2.1.1.19-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
+          <http://model.geneontology.org/c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3382,44 +3628,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
-
-<http://model.geneontology.org/f42ec330-1e2a-4e41-926b-54705b6684dd_FORMYLTHFDEFORMYL-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3427,19 +3656,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
@@ -3448,35 +3677,24 @@
 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_bd5b99d4-211a-444c-bf01-da013337e935_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0008705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_Reduced-ferredoxins_RXN-5061_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000066_reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829_null_PWY-2201>
@@ -3484,7 +3702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3499,7 +3717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3508,23 +3726,32 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000066_reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-5061>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000467> ;
@@ -3533,7 +3760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3541,23 +3768,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_24a0d1fb-8446-4890-a145-9f5983aa3978_HOMOCYSMETB12-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3565,36 +3792,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_f42ec330-1e2a-4e41-926b-54705b6684dd_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f42ec330-1e2a-4e41-926b-54705b6684dd_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_9f037588-28e3-4ebc-9078-180903d5500b_2.1.1.19-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9f037588-28e3-4ebc-9078-180903d5500b_2.1.1.19-RXN>
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201>
@@ -3602,35 +3829,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ec18b557-380c-4633-aca0-a2117806d04f_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002413_GLYOHMETRANS-RXN_null_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3638,39 +3848,52 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN>
+          <http://model.geneontology.org/6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17437>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY-2201>
@@ -3678,7 +3901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3692,36 +3915,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57945_1.5.1.20-RXN_SGD_PWY-2201>
@@ -3729,27 +3952,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_96391e5a-df2e-41c7-8fa0-e780eda61492_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/96391e5a-df2e-41c7-8fa0-e780eda61492_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201>
@@ -3757,7 +3997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3772,7 +4012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3788,7 +4028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3799,7 +4039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3810,7 +4050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3825,7 +4065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3842,7 +4082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3853,28 +4093,6 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_ee6c0091-f4e7-421d-9a39-892b9d6d50d3_1.5.1.20-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9ed11264-35c4-4233-8cdd-b079fac27c45_GCVMULTI-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/GCVMULTI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3884,9 +4102,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/9ed11264-35c4-4233-8cdd-b079fac27c45_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/9c5abe8f-8058-4f80-8c21-8f185f70dc3d_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3894,7 +4112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3904,31 +4122,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_Reduced-ferredoxins_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5061> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_4ba06029-b652-449a-ba43-bfdae5107b6e_GLYOHMETRANS-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/2.1.1.19-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0047147> ;
@@ -3939,15 +4146,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9f037588-28e3-4ebc-9078-180903d5500b_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ec18b557-380c-4633-aca0-a2117806d04f_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> , <http://model.geneontology.org/8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/GCVMULTI-RXN> , <http://model.geneontology.org/FORMATETHFLIG-RXN> , <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3962,7 +4169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3975,7 +4182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3983,39 +4190,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-5061>
+          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_2.1.1.19-RXN_SGD_PWY-2201>
@@ -4023,7 +4247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4038,7 +4262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4055,7 +4279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4065,36 +4289,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_15378_2.1.1.19-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_5e42d639-333b-449d-8dd4-dafd2ecac6aa_1.5.1.15-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5e42d639-333b-449d-8dd4-dafd2ecac6aa_1.5.1.15-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY-2201>
@@ -4102,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4112,22 +4336,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_PWY-2201>
@@ -4135,7 +4357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4143,37 +4365,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15740_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN>
 ] .
-
-<http://model.geneontology.org/389e5503-7295-4bf7-a0ab-2e779adab736_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57844> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4184,7 +4389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4198,46 +4403,55 @@
 <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/24a0d1fb-8446-4890-a145-9f5983aa3978_HOMOCYSMETB12-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_15378_1.5.1.20-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_48d2cf3d-0b50-4058-a0bc-48bfc029d4b2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4252,9 +4466,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c4f8e5fd-dc95-4e1d-8c3a-e7450a5dc934_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/ee6c0091-f4e7-421d-9a39-892b9d6d50d3_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4262,7 +4476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4275,7 +4489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4283,19 +4497,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_48d2cf3d-0b50-4058-a0bc-48bfc029d4b2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/48d2cf3d-0b50-4058-a0bc-48bfc029d4b2_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
@@ -4305,7 +4519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4320,7 +4534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4336,7 +4550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4351,15 +4565,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/f42ec330-1e2a-4e41-926b-54705b6684dd_FORMYLTHFDEFORMYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/9ec5bb71-b57e-4f09-8cb5-39c05bcc8519_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4371,10 +4585,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4387,7 +4603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4395,44 +4611,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_3fcee578-d966-4e4c-b5e1-ff135348ba27_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3fcee578-d966-4e4c-b5e1-ff135348ba27_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/5e42d639-333b-449d-8dd4-dafd2ecac6aa_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4444,40 +4654,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/3fcee578-d966-4e4c-b5e1-ff135348ba27_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/f4712c0d-5b55-4ed2-ae56-ab725605deac_RXN-5061>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4486,44 +4662,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/1b7cff0b-6d59-4543-b5f2-9b2f9f0df43c_METHENYLTHFCYCLOHYDRO-RXN>
+<http://model.geneontology.org/6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_2.1.1.19-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.1.1.19-RXN>
+          <http://model.geneontology.org/a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-5061>
@@ -4535,7 +4711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4548,7 +4724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4562,7 +4738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4570,34 +4746,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_3fcee578-d966-4e4c-b5e1-ff135348ba27_GLYOHMETRANS-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFDEFORMYL-RXN_null_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -4608,7 +4803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4618,36 +4813,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15378_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_15378_2.1.1.19-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN>
+          <http://model.geneontology.org/2.1.1.19-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY-2201>
@@ -4655,27 +4833,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c4f8e5fd-dc95-4e1d-8c3a-e7450a5dc934_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c4f8e5fd-dc95-4e1d-8c3a-e7450a5dc934_1.5.1.20-RXN>
+          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
@@ -4683,7 +4878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4694,7 +4889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4705,7 +4900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4720,7 +4915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4733,70 +4928,94 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_15378_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_9c5abe8f-8058-4f80-8c21-8f185f70dc3d_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9c5abe8f-8058-4f80-8c21-8f185f70dc3d_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_bd5b99d4-211a-444c-bf01-da013337e935_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000066_reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829_null_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bd5b99d4-211a-444c-bf01-da013337e935_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_PWY-2201>
@@ -4804,7 +5023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4815,7 +5034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4826,29 +5045,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-2201/PWY-2201>
+          <http://model.geneontology.org/c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "NAD-dependent 5,10-methylenetetrahydrafolate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4868,7 +5089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4878,19 +5099,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002413_FORMATETHFLIG-RXN_null_PWY-2201>
@@ -4898,7 +5119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4913,7 +5134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4923,35 +5144,35 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
+          <http://model.geneontology.org/233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/c4f8e5fd-dc95-4e1d-8c3a-e7450a5dc934_1.5.1.20-RXN>
+<http://model.geneontology.org/36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4964,27 +5185,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67709> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/96391e5a-df2e-41c7-8fa0-e780eda61492_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PWY-2301-PWY-2301.ttl
+++ b/models/PWY-2301-PWY-2301.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -45,19 +45,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002333_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_SGD_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY-2301> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
@@ -68,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,7 +116,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://purl.obolibrary.org/obo/GO_0008934>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#note>
@@ -116,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -138,11 +161,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,24 +173,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller>
+          <http://model.geneontology.org/MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002233_CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829>
@@ -191,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,20 +252,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829_null_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
+          <http://model.geneontology.org/reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
@@ -253,19 +278,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301>
@@ -273,27 +298,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002233_CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002413_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_null_PWY-2301>
@@ -301,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -330,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,154 +419,12 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829_null_PWY-2301> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-2301> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_4170>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_4170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "D-glucopyranose 6-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301SmallMolecule29810> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY-2301>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/PWY-2301>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "<i>myo</i>-inositol biosynthesis - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "inositol monophosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301Protein29794> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-myo-inositol-1-phosphate synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301Complex29822> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://purl.obolibrary.org/obo/GO_0004512>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000050_PWY-2301/PWY-2301_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,50 +435,13 @@
           <http://model.geneontology.org/PWY-2301/PWY-2301>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17268> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<I>myo</I>-inositol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301SmallMolecule29786> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY-2301>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,6 +468,205 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY-2301/PWY-2301>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_4170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_4170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "D-glucopyranose 6-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301SmallMolecule29810> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY-2301>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "<i>myo</i>-inositol biosynthesis - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "inositol monophosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301Protein29794> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-myo-inositol-1-phosphate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003689_CPLX3O-29_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301Complex29822> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://purl.obolibrary.org/obo/GO_0004512>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &rarr; 1D-<i>myo</i>-inositol 3-monophosphate' 'null' '1D-<i>myo</i>-inositol 3-monophosphate + H<sub>2</sub>O &rarr; <I>myo</I>-inositol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002413_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_null_PWY-2301> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
+] .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17268> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<I>myo</I>-inositol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301SmallMolecule29786> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000003689_CPLX3O-29_component_SGD_PWY-2301>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_58401_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58401_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000003689_CPLX3O-29_component_SGD_PWY-2301> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003689_CPLX3O-29_component>
+] .
+
+<http://identifiers.org/sgd/S000003689>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000003689_CPLX3O-29_component>
+        a       <http://identifiers.org/sgd/S000003689> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -634,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -664,29 +711,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &rarr; 1D-<i>myo</i>-inositol 3-monophosphate' 'null' '1D-<i>myo</i>-inositol 3-monophosphate + H<sub>2</sub>O &rarr; <I>myo</I>-inositol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002413_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_null_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002333_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
+          <http://model.geneontology.org/CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000050_PWY-2301/PWY-2301_SGD_PWY-2301>
@@ -694,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -705,11 +750,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_58401_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,7 +762,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58401_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>

--- a/models/PWY-3322-PWY-3322.ttl
+++ b/models/PWY-3322-PWY-3322.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -173,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation IX - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-46-PWY-46.ttl
+++ b/models/PWY-46-PWY-46.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "putrescine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-5041-PWY-5041.ttl
+++ b/models/PWY-5041-PWY-5041.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,11 +304,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -318,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,15 +332,23 @@
           <http://model.geneontology.org/RXN-7605>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605_SGD_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_null_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -389,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -404,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -449,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -523,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -569,15 +580,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7605_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1fba843a-bdf9-4b1d-92ad-2a44b9c173cf_RXN-7605> , <http://model.geneontology.org/CHEBI_59789_RXN-7605> ;
+                <http://model.geneontology.org/CHEBI_59789_RXN-7605> , <http://model.geneontology.org/95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b00ef54e-e2cb-46a3-bb7d-4d7c41266648_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
+                <http://model.geneontology.org/c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/ADENOSYLHOMOCYSTEINASE-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -679,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -768,41 +779,13 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/1fba843a-bdf9-4b1d-92ad-2a44b9c173cf_RXN-7605>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a demethylated methyl donor" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30372> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_1fba843a-bdf9-4b1d-92ad-2a44b9c173cf_RXN-7605_SGD_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_1fba843a-bdf9-4b1d-92ad-2a44b9c173cf_RXN-7605_SGD_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605_SGD_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,19 +793,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1fba843a-bdf9-4b1d-92ad-2a44b9c173cf_RXN-7605>
+          <http://model.geneontology.org/95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605>
 ] .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -833,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,18 +821,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_b00ef54e-e2cb-46a3-bb7d-4d7c41266648_RXN-7605_SGD_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -885,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,12 +912,15 @@
           <http://model.geneontology.org/HOMOCYSMET-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000002910>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002333_YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller_SGD_PWY-5041>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,6 +974,23 @@
           <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
 ] .
 
+<http://model.geneontology.org/95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a demethylated methyl donor" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30372> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1007,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>S</i>-adenosyl-L-methionine cycle II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,8 +1070,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/b00ef54e-e2cb-46a3-bb7d-4d7c41266648_RXN-7605>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1087,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,9 +1167,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0004013>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1185,13 +1174,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002910> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "S-adenosylmethionine synthetase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1205,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1265,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1295,7 +1284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1379,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1420,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1437,7 +1426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1470,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1490,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1506,20 +1495,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_null_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1529,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,6 +1518,17 @@
           <http://model.geneontology.org/CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_null_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1549,7 +1538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1624,11 +1613,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_b00ef54e-e2cb-46a3-bb7d-4d7c41266648_RXN-7605_SGD_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605_SGD_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,18 +1625,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b00ef54e-e2cb-46a3-bb7d-4d7c41266648_RXN-7605>
+          <http://model.geneontology.org/c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605_SGD_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5080-1-PWY-5080-1.ttl
+++ b/models/PWY-5080-1-PWY-5080-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814_SGD_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -40,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,18 +67,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 3-hydroxyacyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000066_reaction_RXN3O-9812_location_lociGO_0005829_null_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -79,7 +107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +186,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57783_RXN3O-9812> , <http://model.geneontology.org/CHEBI_15489_RXN3O-9812> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> , <http://model.geneontology.org/d3b5baa3-8472-4e97-8866-520f0fc2653a_RXN3O-9812> ;
+                <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> , <http://model.geneontology.org/16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-79_RXN3O-9812_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -166,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,23 +202,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_745577d5-d804-4801-ada6-286e41f6e51c_RXN3O-9813_SGD_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000050_PWY-5080-1/PWY-5080-1_SGD_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -201,23 +218,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000003633>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_RXN3O-9814_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/MONOMER3O-70_RXN3O-9811_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004364> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "3-ketoacyl-CoA synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,11 +247,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_12ae44c6-3136-4543-9dbb-a76f92e76139_RXN3O-9813_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +259,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/12ae44c6-3136-4543-9dbb-a76f92e76139_RXN3O-9813>
+          <http://model.geneontology.org/86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_RXN3O-9812>
@@ -251,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,19 +299,19 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002333_MONOMER3O-85_RXN3O-9813_controller_SGD_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -301,29 +321,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_d3b5baa3-8472-4e97-8866-520f0fc2653a_RXN3O-9812_SGD_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://identifiers.org/sgd/S000000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,13 +406,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-85_RXN3O-9813_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000003633> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "3-hydroxyacyl-CoA dehydratase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -414,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -615,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,16 +638,22 @@
           <http://model.geneontology.org/YCR034W-MONOMER_RXN3O-9811_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_8659140a-00b0-4c8b-9b40-5ad4294ee956_RXN3O-9814_SGD_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -646,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,6 +675,9 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9812>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_16526_RXN3O-9811>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -666,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,16 +695,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15489>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,12 +751,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812_SGD_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000050_PWY-5080-1/PWY-5080-1_SGD_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,20 +809,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-79_RXN3O-9812_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000363> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "beta-ketoacyl reductase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,11 +847,22 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9814>
 ] .
 
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813_SGD_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -830,7 +870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,11 +909,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004364>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -883,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -950,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,16 +1021,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_12ae44c6-3136-4543-9dbb-a76f92e76139_RXN3O-9813_SGD_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -997,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1026,7 +1075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1056,11 +1105,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_d3b5baa3-8472-4e97-8866-520f0fc2653a_RXN3O-9812_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,25 +1117,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9812> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d3b5baa3-8472-4e97-8866-520f0fc2653a_RXN3O-9812>
+          <http://model.geneontology.org/16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812>
 ] .
-
-<http://model.geneontology.org/d3b5baa3-8472-4e97-8866-520f0fc2653a_RXN3O-9812>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 3-hydroxyacyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1094,7 +1126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1118,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1129,6 +1161,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 3-hydroxyacyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/RXN3O-9814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102758> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1138,7 +1187,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9814_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> , <http://model.geneontology.org/8659140a-00b0-4c8b-9b40-5ad4294ee956_RXN3O-9814> ;
+                <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9814> , <http://model.geneontology.org/CHEBI_33184_RXN3O-9814> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1146,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1182,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,11 +1261,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_745577d5-d804-4801-ada6-286e41f6e51c_RXN3O-9813_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1273,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/745577d5-d804-4801-ada6-286e41f6e51c_RXN3O-9813>
+          <http://model.geneontology.org/ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1239,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1284,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,6 +1344,17 @@
 <http://model.geneontology.org/reaction_RXN3O-9811_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813_SGD_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1303,28 +1363,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/8659140a-00b0-4c8b-9b40-5ad4294ee956_RXN3O-9814>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1334,11 +1377,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_8659140a-00b0-4c8b-9b40-5ad4294ee956_RXN3O-9814_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,32 +1389,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8659140a-00b0-4c8b-9b40-5ad4294ee956_RXN3O-9814>
+          <http://model.geneontology.org/af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814>
 ] .
-
-<http://model.geneontology.org/12ae44c6-3136-4543-9dbb-a76f92e76139_RXN3O-9813>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 3-hydroxyacyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000066_reaction_RXN3O-9813_location_lociGO_0005829_null_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1385,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1397,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1408,30 +1434,13 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9812>
 ] .
 
-<http://model.geneontology.org/745577d5-d804-4801-ada6-286e41f6e51c_RXN3O-9813>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_16526_RXN3O-9811_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1464,7 +1473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1475,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1486,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1501,9 +1510,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9813_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/12ae44c6-3136-4543-9dbb-a76f92e76139_RXN3O-9813> ;
+                <http://model.geneontology.org/86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> , <http://model.geneontology.org/745577d5-d804-4801-ada6-286e41f6e51c_RXN3O-9813> ;
+                <http://model.geneontology.org/ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-85_RXN3O-9813_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1511,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1528,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "very long chain fatty acid biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1544,7 +1553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1575,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1598,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5084-PWY-5084.ttl
+++ b/models/PWY-5084-PWY-5084.ttl
@@ -1,35 +1,66 @@
+<http://identifiers.org/sgd/S000002555>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_48c749ea-dff9-4d70-a720-b96fb639eb93_RXN0-1147_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/48c749ea-dff9-4d70-a720-b96fb639eb93_RXN0-1147>
+          <http://model.geneontology.org/58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_15378_RXN-7716_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-7716>
+          <http://model.geneontology.org/CHEBI_57540_RXN-7716>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002411_RXN0-1147_SGD_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN0-1147>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -38,29 +69,12 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/4dade2ff-17fe-453f-9dad-0de28a57df4f_2OXOGLUTDECARB-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002333_CPLX3O-16_RXN0-1147_controller_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,13 +100,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_4dade2ff-17fe-453f-9dad-0de28a57df4f_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_15378_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,7 +117,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4dade2ff-17fe-453f-9dad-0de28a57df4f_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/2OXOGLUTDECARB-RXN>
@@ -112,9 +129,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4dade2ff-17fe-453f-9dad-0de28a57df4f_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/b811645b-97e1-42ba-a291-53d19d6368b4_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -122,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -158,17 +175,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_4dade2ff-17fe-453f-9dad-0de28a57df4f_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -177,11 +183,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147_SGD_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller>
         a       <http://identifiers.org/sgd/S000001876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -190,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,8 +218,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_null_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7716> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -210,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,55 +256,77 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57287_RXN0-1147_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_CHEBI_57292_RXN0-1147_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1147> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN0-1147>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_4b261dcc-210e-4661-bb28-129d323a69ad_RXN-7716_SGD_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7716> ;
+          <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4b261dcc-210e-4661-bb28-129d323a69ad_RXN-7716>
+          <http://model.geneontology.org/CHEBI_57292_RXN0-1147>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147_SGD_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716_SGD_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_null_PWY-5084>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -288,18 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_4b261dcc-210e-4661-bb28-129d323a69ad_RXN-7716_SGD_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "2-oxoglutarate decarboxylation to succinyl-CoA - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -325,44 +372,46 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.obolibrary.org/obo/GO_0004149>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/b811645b-97e1-42ba-a291-53d19d6368b4_2OXOGLUTDECARB-RXN>
+<http://model.geneontology.org/67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004149>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000066_reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829_null_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000066_reaction_RXN0-1147_location_lociGO_0005829_null_PWY-5084>
@@ -370,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -385,9 +434,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57292_RXN0-1147> , <http://model.geneontology.org/6425c4b1-f3b8-4365-b40e-f3a5ab7fd69e_RXN0-1147> ;
+                <http://model.geneontology.org/CHEBI_57292_RXN0-1147> , <http://model.geneontology.org/58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/48c749ea-dff9-4d70-a720-b96fb639eb93_RXN0-1147> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-16_RXN0-1147_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -395,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,6 +455,26 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-1147> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-7716>
+] .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/PWY-5084/PWY-5084>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -413,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -421,81 +490,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000066_reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829_null_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + NAD<sup>+</sup> &rarr; a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + NADH + H<SUP>+</SUP>' 'null' '2-oxoglutarate + a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + H<SUP>+</SUP> &rarr; a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002413_2OXOGLUTDECARB-RXN_null_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_48c749ea-dff9-4d70-a720-b96fb639eb93_RXN0-1147_SGD_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/4b261dcc-210e-4661-bb28-129d323a69ad_RXN-7716>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_PWY-5084>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -510,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -534,64 +551,100 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_6425c4b1-f3b8-4365-b40e-f3a5ab7fd69e_RXN0-1147_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000066_reaction_RXN0-1147_location_lociGO_0005829_null_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6425c4b1-f3b8-4365-b40e-f3a5ab7fd69e_RXN0-1147>
+          <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000050_PWY-5084/PWY-5084_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN-7716>
+          <http://model.geneontology.org/PWY-5084/PWY-5084>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002411_RXN0-1147_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-1147>
+          <http://model.geneontology.org/e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
@@ -608,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -617,21 +670,35 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000001387>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-16_RXN0-1147_controller_BFO_0000051_SGD_S000002555_CPLX3O-16_component_SGD_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_15378_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000050_PWY-5084/PWY-5084_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/PWY-5084/PWY-5084>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_PWY-5084>
@@ -639,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -651,112 +718,50 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/c91525d6-66c5-41ad-b6c3-dababee62fc2_RXN-7716>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000050_PWY-5084/PWY-5084_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002333_CPLX3O-16_RXN0-1147_controller_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5084/PWY-5084>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002333_YFL018C-MONOMER_RXN-7716_controller_SGD_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7716> ;
+          <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller>
+          <http://model.geneontology.org/CPLX3O-16_RXN0-1147_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_6425c4b1-f3b8-4365-b40e-f3a5ab7fd69e_RXN0-1147_SGD_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7716> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_RXN-7716>
+] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000066_reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829_null_PWY-5084>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/48c749ea-dff9-4d70-a720-b96fb639eb93_RXN0-1147>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_CHEBI_57292_RXN0-1147_SGD_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1147> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57292_RXN0-1147>
-] .
 
 <http://model.geneontology.org/CHEBI_57540_RXN-7716>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -767,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,65 +780,69 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000050_PWY-5084/PWY-5084_SGD_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-1147> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-5084/PWY-5084>
+] .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_null_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-16_RXN0-1147_controller_BFO_0000051_SGD_S000002555_CPLX3O-16_component_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7716> ;
+          <http://model.geneontology.org/CPLX3O-16_RXN0-1147_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000002555_CPLX3O-16_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_b811645b-97e1-42ba-a291-53d19d6368b4_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_CHEBI_16526_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_PWY-5084>
@@ -841,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -862,9 +871,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/4b261dcc-210e-4661-bb28-129d323a69ad_RXN-7716> ;
+                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/c91525d6-66c5-41ad-b6c3-dababee62fc2_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
+                <http://model.geneontology.org/67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716> , <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -872,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,10 +896,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydrolipoyl transsuccinylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002555_CPLX3O-16_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -917,28 +928,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-7716>
+          <http://model.geneontology.org/34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147>
 ] .
+
+<http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001387> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_c91525d6-66c5-41ad-b6c3-dababee62fc2_RXN-7716_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_15378_RXN-7716_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,11 +966,20 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c91525d6-66c5-41ad-b6c3-dababee62fc2_RXN-7716>
+          <http://model.geneontology.org/CHEBI_15378_RXN-7716>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/SGD_S000002555_CPLX3O-16_component>
+        a       <http://identifiers.org/sgd/S000002555> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -962,10 +991,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2-ketoglutarate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -982,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,22 +1022,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000066_reaction_RXN0-1147_location_lociGO_0005829_null_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1147> ;
+          <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + NAD<sup>+</sup> &rarr; a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + NADH + H<SUP>+</SUP>' 'null' '2-oxoglutarate + a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + H<SUP>+</SUP> &rarr; a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002413_2OXOGLUTDECARB-RXN_null_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7716> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2OXOGLUTDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_RXN0-1147>
@@ -1018,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1043,56 +1091,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000050_PWY-5084/PWY-5084_SGD_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7716> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5084/PWY-5084>
-] .
-
-<http://model.geneontology.org/6425c4b1-f3b8-4365-b40e-f3a5ab7fd69e_RXN0-1147>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_b811645b-97e1-42ba-a291-53d19d6368b4_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b811645b-97e1-42ba-a291-53d19d6368b4_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN>
 ] .
+
+<http://model.geneontology.org/34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1105,11 +1147,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1119,44 +1178,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002333_CPLX3O-16_RXN0-1147_controller_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57287_RXN0-1147_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1147> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-16_RXN0-1147_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7716> ;
+          <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN-7716>
+          <http://model.geneontology.org/CHEBI_57287_RXN0-1147>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_c91525d6-66c5-41ad-b6c3-dababee62fc2_RXN-7716_SGD_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716_SGD_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7716> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1171,11 +1230,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17075> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1185,12 +1261,23 @@
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716_SGD_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57287_RXN0-1147_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1198,19 +1285,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000050_PWY-5084/PWY-5084_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002333_YFL018C-MONOMER_RXN-7716_controller_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1147> ;
+          <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5084/PWY-5084>
+          <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -1221,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1229,17 +1316,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_CHEBI_16526_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN>
 ] .

--- a/models/PWY-5123-PWY-5123.ttl
+++ b/models/PWY-5123-PWY-5123.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>trans, trans</i>-farnesyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -370,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -938,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5177-PWY-5177.ttl
+++ b/models/PWY-5177-PWY-5177.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -251,7 +251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutaryl-CoA degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -350,25 +350,25 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002413_GLUTACONYL-COA-DECARBOXYLASE-RXN_null_PWY-5177>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,28 +528,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43639> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_57286_RXN-11662>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57286> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoacetyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43611> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -561,25 +544,42 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000066_reaction_RXN-11662_location_lociGO_0005829_null_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/CHEBI_57286_RXN-11662>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57286> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoacetyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43611> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -774,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1160,7 +1160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1294,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1373,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1387,7 +1387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5194-1-PWY-5194-1.ttl
+++ b/models/PWY-5194-1-PWY-5194-1.ttl
@@ -9,7 +9,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,23 +479,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/CHEBI_29033_SIROHEME-FERROCHELAT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29033> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Fe<SUP>2+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41759> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SIROHEME-FERROCHELAT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0051266> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -514,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,12 +505,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/CHEBI_29033_SIROHEME-FERROCHELAT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29033> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Fe<SUP>2+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41759> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -922,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -1041,23 +1041,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_58827_RXN-13403>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58827> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "ferrochelatase / precorrin-2 dehydrogenase" ;
+                "precorrin-2" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1Protein41778> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41712> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/DIMETHUROPORDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043115> ;
@@ -1078,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,28 +1149,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_58827_RXN-13403>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58827> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "precorrin-2" ;
+                "ferrochelatase / precorrin-2 dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41712> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1Protein41778> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_58827_DIMETHUROPORDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58827> ;
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,7 +1196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5340-PWY-5340.ttl
+++ b/models/PWY-5340-PWY-5340.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate activation (for sulfonation) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,28 +742,13 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003771> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP sulfurylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5340Protein20668> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,13 +759,28 @@
           <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003771> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP sulfurylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5340Protein20668> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5344-PWY-5344.ttl
+++ b/models/PWY-5344-PWY-5344.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -22,7 +22,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,6 +157,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16136_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16136> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -166,24 +177,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5344SmallMolecule31879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY-5344>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -793,7 +793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homocysteine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5651-PWY-5651.ttl
+++ b/models/PWY-5651-PWY-5651.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,13 +280,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000002836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "Arylformamidase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,13 +495,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651SmallMolecule74075> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000002836>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_36559>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -511,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -642,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan degradation to 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -800,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -906,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1088,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,14 +1178,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1395,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1619,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1642,7 +1642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1673,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1685,7 +1685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,7 +1707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1735,7 +1735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1758,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1794,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,7 +1834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1895,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1924,7 +1924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1959,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1988,7 +1988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5653-PWY-5653.ttl
+++ b/models/PWY-5653-PWY-5653.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD biosynthesis from 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,7 +870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -989,14 +989,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1004,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1042,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1114,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,13 +1123,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glutamine-dependent NAD synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1219,7 +1216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1294,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1334,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1419,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1449,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1472,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1486,7 +1483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,11 +1499,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001116>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004515> ;
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1606,7 +1606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1701,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1718,7 +1718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1786,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5669-PWY-5669.ttl
+++ b/models/PWY-5669-PWY-5669.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,30 +37,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY-5669>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylethanolamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -119,12 +119,29 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -141,42 +158,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/4e0d78ef-76e8-42b0-8a4a-1d83f81a70a0_PHOSPHASERSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -184,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,13 +184,24 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,6 +241,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN_SGD_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -250,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +292,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/4e0d78ef-76e8-42b0-8a4a-1d83f81a70a0_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -291,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -308,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,24 +384,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21629> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_4e0d78ef-76e8-42b0-8a4a-1d83f81a70a0_PHOSPHASERSYN-RXN_SGD_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -510,11 +510,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_4e0d78ef-76e8-42b0-8a4a-1d83f81a70a0_PHOSPHASERSYN-RXN_SGD_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN_SGD_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4e0d78ef-76e8-42b0-8a4a-1d83f81a70a0_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -533,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -564,6 +564,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_11750>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY-5669>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a CDP-diacylglycerol + L-serine &harr; CMP + a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP>' 'null' 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -572,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,17 +593,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PHOSPHASERDECARB-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY-5669>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_60377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -606,7 +606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -638,31 +638,13 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylserine decarboxylase, mitochondria" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669Protein21652> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,13 +655,31 @@
           <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylserine decarboxylase, mitochondria" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669Protein21652> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_PWY-5669/PWY-5669_SGD_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5670-1-PWY-5670-1.ttl
+++ b/models/PWY-5670-1-PWY-5670-1.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "epoxysqualene biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,13 +50,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_57310>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN3O-9816_SGD_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,23 +78,12 @@
           <http://model.geneontology.org/CHEBI_15441_RXN3O-9816>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN3O-9816_SGD_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_null_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,7 +265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -873,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -918,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5686-1-PWY-5686-1.ttl
+++ b/models/PWY-5686-1-PWY-5686-1.ttl
@@ -1,35 +1,37 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
+          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -41,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -79,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -91,6 +93,42 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY-5686-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9929> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PWY-5686-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32814> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -100,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,30 +155,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule71048> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
-] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57865>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -150,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,19 +239,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
+          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -239,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,31 +274,33 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "carbamoyl phosphate synthetase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component> , <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1Complex71114> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -287,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,16 +345,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule71062> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
         a       <http://identifiers.org/sgd/S000004412> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -340,13 +360,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1Protein70977> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -356,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,60 +406,62 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_RXN-9929_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_null_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_RXN-9929>
+          <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
 ] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY-5686-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY-5686-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
+] .
 
 <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -446,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -476,19 +501,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/OROPRIBTRANS-RXN>
@@ -510,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,41 +602,39 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003666>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -623,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -662,21 +685,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
+          <http://model.geneontology.org/CHEBI_30031_RXN-9929>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -691,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,22 +734,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_RXN-9929_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9929>
 ] .
 
 <http://identifiers.org/sgd/S000004412>
@@ -730,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -757,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -771,19 +803,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
+          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -792,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -826,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -839,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,29 +961,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_null_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
+          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004590>
@@ -959,27 +989,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002411_DIHYDROOROT-RXN_SGD_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -990,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1011,13 +1041,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002411_DIHYDROOROT-RXN_SGD_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,17 +1069,6 @@
           <http://model.geneontology.org/YJL130C-MONOMER_ASPCARBTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
         a       <http://identifiers.org/sgd/S000001699> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1046,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1142,6 +1172,23 @@
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002411_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9929> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1152,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,19 +1209,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1183,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1233,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1243,20 +1290,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
+          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY-5686-1>
@@ -1264,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1278,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1309,7 +1358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,12 +1378,15 @@
 <http://identifiers.org/sgd/S000001699>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1373,36 +1425,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9929> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29806_RXN-9929>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_RXN-9929>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_RXN-9929_SGD_PWY-5686-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9929>
+          <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1414,7 +1466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1430,9 +1482,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1441,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1459,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,19 +1530,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1490,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1537,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1550,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1565,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1578,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1618,19 +1679,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1>
@@ -1638,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1649,19 +1710,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY-5686-1>
@@ -1669,7 +1730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1684,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1720,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1745,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1753,44 +1814,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002411_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_30839_RXN-9929>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1802,7 +1874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1850,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1885,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UMP biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1931,22 +2003,20 @@
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/OROTPDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1>
@@ -1954,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +2036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1986,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2016,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2027,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2052,7 +2122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2060,24 +2130,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://purl.obolibrary.org/obo/GO_1990663>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_RXN-9929>
+          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PWY-5686-1>
@@ -2085,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2093,19 +2166,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58228_ASPCARBTRANS-RXN>
@@ -2117,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2130,7 +2203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2142,7 +2215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2179,24 +2252,27 @@
 <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_30864>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2205,7 +2281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2247,19 +2323,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17544>
@@ -2267,19 +2343,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
+          <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
 <http://model.geneontology.org/YJL130C-MONOMER_ASPCARBTRANS-RXN_controller>
@@ -2289,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2303,7 +2379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2355,7 +2431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2368,7 +2444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2379,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,38 +2478,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_RXN-9929_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_RXN-9929>
+          <http://model.geneontology.org/CHEBI_30864_RXN-9929>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PWY-5686-1/PWY-5686-1_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5686-1/PWY-5686-1>
+          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29806>
@@ -2447,7 +2532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2481,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2498,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2508,19 +2593,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROTPDECARB-RXN>
+          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2529,7 +2614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2548,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5694-PWY-5694.ttl
+++ b/models/PWY-5694-PWY-5694.ttl
@@ -8,7 +8,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to glyoxylate I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -900,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,7 +975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5697-PWY-5697.ttl
+++ b/models/PWY-5697-PWY-5697.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to ureidoglycolate I (urea producing) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5697" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5703-PWY-5703.ttl
+++ b/models/PWY-5703-PWY-5703.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "urea degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5703" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5760-1-PWY-5760-1.ttl
+++ b/models/PWY-5760-1-PWY-5760-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "&beta;-alanine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,7 +669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5971-1-PWY-5971-1.ttl
+++ b/models/PWY-5971-1-PWY-5971-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,7 +29,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9535>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004321> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a dodecanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxotetradecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9538_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,24 +202,13 @@
           <http://model.geneontology.org/reaction_RXN-9518_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9538_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_CHEBI_57783_RXN-9536_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -751,7 +751,7 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/RXN-9530>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-dec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a decanoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1091,30 +1091,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33050> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9537> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Tetradec-2-enoyl-ACPs_RXN-9537>
-] .
 
 <http://model.geneontology.org/ACP_RXN-9520>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1125,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1133,12 +1116,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9537> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Tetradec-2-enoyl-ACPs_RXN-9537>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9527_SGD_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1173,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-8214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a myristoyl-[acp] + coenzyme A &rarr; acyl-carrier protein + myristoyl-CoA" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1395,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,7 +1560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,7 +1580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1617,7 +1617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,7 +1637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,9 +1648,6 @@
           <http://model.geneontology.org/3-oxo-myristoyl-ACPs_RXN-9536>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0008659>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1659,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1687,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1699,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,7 +1713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,7 +1738,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002333_YPL231W-MONOMER_RXN-9527_controller_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1750,24 +1758,13 @@
 <http://model.geneontology.org/reaction_RXN-9533_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002333_YPL231W-MONOMER_RXN-9527_controller_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_15378_RXN-9526_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,7 +1805,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000066_reaction_RXN-9524_location_lociGO_0005829_null_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1822,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,17 +1841,6 @@
           <http://model.geneontology.org/RXN-9521>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000066_reaction_RXN-9524_location_lociGO_0005829_null_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_RXN-9516>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1853,7 +1850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1883,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1917,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1929,7 +1926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,7 +1962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1998,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2010,7 +2007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2027,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2060,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2074,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2085,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2116,7 +2113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2132,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2143,7 +2140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2154,14 +2151,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9531>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004321> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a decanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxododecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2179,13 +2176,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1BiochemicalReaction33186> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58349_RXN-9526>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2196,7 +2196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,31 +2206,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9655> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
-] .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2241,12 +2221,32 @@
           <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
 ] .
 
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9655> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_15378_RXN-9526_SGD_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2260,28 +2260,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_CHEBI_15378_RXN-9524_SGD_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9524> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9524>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2291,7 +2274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,12 +2285,29 @@
           <http://model.geneontology.org/reaction_RXN-9536_location_lociGO_0005829>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_CHEBI_15378_RXN-9524_SGD_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9524> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9524>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_null_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2318,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2329,7 +2329,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2341,7 +2352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2352,24 +2363,13 @@
           <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_CHEBI_57783_RXN-9532_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,7 +2388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2408,7 +2408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2436,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2461,7 +2461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2472,13 +2472,24 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9524>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000066_reaction_RXN-9528_location_lociGO_0005829_null_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_CHEBI_57385_RXN3O-8214_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2489,17 +2500,6 @@
           <http://model.geneontology.org/CHEBI_57385_RXN3O-8214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000066_reaction_RXN-9528_location_lociGO_0005829_null_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9523_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2507,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2523,7 +2523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2540,7 +2540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2563,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2576,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2587,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2599,7 +2599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2616,7 +2616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2632,32 +2632,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-9534_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_15378_RXN-9626_SGD_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2668,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2680,7 +2680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,7 +2700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2728,7 +2728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2747,7 +2747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2767,7 +2767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2784,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2815,7 +2815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2835,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2848,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2859,7 +2859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2870,7 +2870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2883,7 +2883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2913,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2925,7 +2925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2937,7 +2937,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9537>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxytetradecanoyl-[acp] &rarr; a (2<i>E</i>)-tetradec-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2955,7 +2955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2969,7 +2969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2988,7 +2988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3021,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3050,7 +3050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3067,7 +3067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3083,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3097,7 +3097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3109,7 +3109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3125,7 +3125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3137,7 +3137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3154,7 +3154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3181,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3196,7 +3196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3209,7 +3209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3224,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3237,7 +3237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3249,7 +3249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3303,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3311,41 +3311,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_CHEBI_15378_RXN-9518_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9521> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_Dodec-2-enoyl-ACPs_RXN-9533_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3356,6 +3328,34 @@
           <http://model.geneontology.org/Dodec-2-enoyl-ACPs_RXN-9533>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9521> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_CHEBI_15378_RXN-9518_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ACP_RXN-9527>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3365,7 +3365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3397,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3414,7 +3414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3431,7 +3431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3443,7 +3443,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9520>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyhexanoyl-[acp] &rarr; a (2<i>E</i>)-hex-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3461,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3475,7 +3475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3491,7 +3491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3502,7 +3502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3513,7 +3513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3525,7 +3525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3542,7 +3542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3561,7 +3561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3572,7 +3572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3583,7 +3583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3595,7 +3595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3612,7 +3612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3628,7 +3628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3642,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3671,7 +3671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3684,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3699,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3712,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3726,7 +3726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3742,7 +3742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3757,7 +3757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3771,7 +3771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3791,7 +3791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3805,7 +3805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3822,7 +3822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3842,7 +3842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3859,7 +3859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3872,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3884,7 +3884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3901,7 +3901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3921,7 +3921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3934,7 +3934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3945,7 +3945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3957,7 +3957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,7 +3976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3996,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4009,14 +4009,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004321>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9538>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4027,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4040,7 +4037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4052,7 +4049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4069,7 +4066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4085,7 +4082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4098,7 +4095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4114,7 +4111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4126,7 +4123,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9526>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-oct-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; an octanoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -4144,7 +4141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4158,7 +4155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4174,7 +4171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4185,7 +4182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4200,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4214,7 +4211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4231,7 +4228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4247,7 +4244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4260,7 +4257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4273,7 +4270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4284,7 +4281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4298,7 +4295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4313,7 +4310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4329,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4340,7 +4337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4352,7 +4349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4367,7 +4364,7 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/RXN-9538>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-tetradec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a myristoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -4385,7 +4382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4398,7 +4395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4410,7 +4407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4433,7 +4430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4446,7 +4443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4458,7 +4455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4478,7 +4475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4491,7 +4488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4506,7 +4503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4519,7 +4516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4533,7 +4530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4552,7 +4549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4568,7 +4565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4579,7 +4576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4591,7 +4588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4610,7 +4607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4626,7 +4623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4640,7 +4637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4657,7 +4654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4674,7 +4671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4690,7 +4687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4704,7 +4701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4716,7 +4713,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9521>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-hex-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a hexanoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -4734,7 +4731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4748,7 +4745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4764,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4779,7 +4776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4793,7 +4790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4810,7 +4807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4830,7 +4827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4843,7 +4840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4855,7 +4852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4874,7 +4871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4890,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4901,7 +4898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4912,7 +4909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4923,7 +4920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4938,7 +4935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4955,7 +4952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4969,7 +4966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4981,7 +4978,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9533>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (<i>3R</i>)-3-hydroxydodecanoyl-[acp] &rarr; a (2<i>E</i>)-dodec-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -4999,7 +4996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5012,7 +5009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5026,7 +5023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5044,7 +5041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5058,7 +5055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5074,7 +5071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5089,7 +5086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5103,7 +5100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5119,7 +5116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5131,7 +5128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5148,7 +5145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5164,7 +5161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5179,7 +5176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5195,7 +5192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5210,7 +5207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5227,7 +5224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5243,7 +5240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5254,7 +5251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5269,7 +5266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5286,7 +5283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5303,7 +5300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5315,7 +5312,7 @@
 ] .
 
 <http://model.geneontology.org/4.2.1.59-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyoctanoyl-[acp] &rarr; a (2<i>E</i>)-oct-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -5333,7 +5330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5349,7 +5346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5372,7 +5369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5389,7 +5386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5406,7 +5403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5426,7 +5423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5439,7 +5436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5450,7 +5447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5465,7 +5462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5478,7 +5475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5490,7 +5487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5506,7 +5503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5518,7 +5515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5538,7 +5535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5554,14 +5551,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9527>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "an octanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxodecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -5579,7 +5576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5592,7 +5589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5606,7 +5603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5626,7 +5623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5640,7 +5637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5656,7 +5653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5668,7 +5665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5689,7 +5686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5706,7 +5703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5719,7 +5716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5730,7 +5727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5743,7 +5740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5757,7 +5754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5774,7 +5771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5790,7 +5787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5805,7 +5802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5821,7 +5818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5838,7 +5835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5854,7 +5851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5865,7 +5862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5876,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5888,7 +5885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5905,7 +5902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5921,7 +5918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5932,7 +5929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5944,7 +5941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5961,7 +5958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5977,7 +5974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5989,7 +5986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6006,7 +6003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6029,7 +6026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6042,7 +6039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6057,7 +6054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6074,7 +6071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6088,7 +6085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6107,7 +6104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6123,7 +6120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6134,7 +6131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6149,7 +6146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6165,7 +6162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6182,7 +6179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6202,7 +6199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6218,7 +6215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6233,7 +6230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6250,7 +6247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6263,7 +6260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6275,7 +6272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6291,7 +6288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6308,7 +6305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6319,7 +6316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6330,7 +6327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6341,7 +6338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6352,7 +6349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6364,7 +6361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6384,7 +6381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6393,7 +6390,7 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RXN-9534>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-dodec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a dodecanoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -6411,7 +6408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6428,7 +6425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "myristate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6442,7 +6439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6459,7 +6456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6477,7 +6474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6493,7 +6490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6505,7 +6502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6522,7 +6519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6542,7 +6539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6555,7 +6552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6570,7 +6567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6584,7 +6581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6601,7 +6598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6617,7 +6614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6635,7 +6632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6647,7 +6644,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9516>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004321> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a butanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxohexanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -6665,7 +6662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6679,7 +6676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6695,7 +6692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6706,7 +6703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6718,7 +6715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6737,7 +6734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6757,7 +6754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6770,7 +6767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6791,7 +6788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6805,7 +6802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6822,7 +6819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6838,7 +6835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6849,7 +6846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6860,7 +6857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6872,7 +6869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6888,7 +6885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6911,7 +6908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6926,7 +6923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6943,13 +6940,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000066_reaction_RXN-9537_location_lociGO_0005829_null_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9521_controller>
         a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6958,7 +6966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6966,24 +6974,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000066_reaction_RXN-9537_location_lociGO_0005829_null_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7003,7 +7000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7020,7 +7017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7037,7 +7034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7050,7 +7047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7061,14 +7058,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9655>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxydecanoyl-[acp] &rarr; a (2<i>E</i>)-dec-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -7086,7 +7083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7097,12 +7094,12 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002411_RXN-9655_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7113,18 +7110,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002411_RXN-9655_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7135,7 +7132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7150,7 +7147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7158,12 +7155,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7178,7 +7175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7186,35 +7183,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_null_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9528_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7225,13 +7200,35 @@
           <http://model.geneontology.org/3-oxo-decanoyl-ACPs_RXN-9528>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_null_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_30807_RXN-9626_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7251,7 +7248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7264,7 +7261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7275,7 +7272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7287,7 +7284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7304,7 +7301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7320,7 +7317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7331,7 +7328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7343,7 +7340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7360,7 +7357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7376,7 +7373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7391,7 +7388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7406,7 +7403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7419,7 +7416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7434,7 +7431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7450,7 +7447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7467,7 +7464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7487,7 +7484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7501,7 +7498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7518,7 +7515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7534,7 +7531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7549,7 +7546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7563,7 +7560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7580,7 +7577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7597,7 +7594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7617,7 +7614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7630,7 +7627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7641,7 +7638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7655,7 +7652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7667,7 +7664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7687,7 +7684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7696,7 +7693,7 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RXN-9523>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a hexanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -7714,7 +7711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7728,7 +7725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7745,7 +7742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7765,13 +7762,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32976> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ACP_RXN-9531>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a malonyl-[acp]" , "acyl-carrier protein" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33125> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33145> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/reaction_RXN-9626_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -7784,7 +7798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7802,28 +7816,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32987> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ACP_RXN-9531>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a malonyl-[acp]" , "acyl-carrier protein" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33125> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33145> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -7836,7 +7833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7853,7 +7850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7873,7 +7870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7889,7 +7886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7902,7 +7899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6074-1-PWY-6074-1.ttl
+++ b/models/PWY-6074-1-PWY-6074-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -29,13 +29,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_17813>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318_SGD_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +82,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -404,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -480,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -490,31 +501,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_null_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-318> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,29 +517,31 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9821>
 ] .
 
-<http://model.geneontology.org/17cb1fdf-8e7b-46e1-8426-e8d44d12ce31_RXN66-318>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_null_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-318> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_RXN3O-9820_SGD_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -665,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,11 +754,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_573d7171-f20d-4f62-a1e4-7486ff7ffac6_RXN3O-9825_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +766,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/573d7171-f20d-4f62-a1e4-7486ff7ffac6_RXN3O-9825>
+          <http://model.geneontology.org/3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825>
 ] .
 
 <http://model.geneontology.org/CHEBI_136486_RXN66-314>
@@ -784,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -960,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -977,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -994,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1032,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1067,7 +1061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1128,13 +1122,24 @@
 <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1188,7 +1193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,23 +1302,23 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN3O-9824_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN3O-9824_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1346,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1374,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1388,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1419,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1452,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1464,7 +1469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1491,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1503,7 +1508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,7 +1559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1586,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1645,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1656,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1701,7 +1706,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/54818d89-f691-45e3-9ecc-628b2fab41db_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1709,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,7 +1728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,6 +1759,23 @@
 <http://identifiers.org/sgd/S000005224>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9823>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1763,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1777,7 +1799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1793,7 +1815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1862,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1875,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1890,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,18 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_a7f96689-8f2a-499f-975a-9c80c6606415_RXN3O-9826_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1958,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1985,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1996,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2010,7 +2021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2101,7 +2112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2118,7 +2129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2151,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2167,7 +2178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2181,7 +2192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2209,7 +2220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2225,7 +2236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2239,7 +2250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2250,11 +2261,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_a7f96689-8f2a-499f-975a-9c80c6606415_RXN3O-9826_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2273,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a7f96689-8f2a-499f-975a-9c80c6606415_RXN3O-9826>
+          <http://model.geneontology.org/536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2271,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2304,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2318,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2332,7 +2343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2340,11 +2351,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_17cb1fdf-8e7b-46e1-8426-e8d44d12ce31_RXN66-318_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2352,25 +2363,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/17cb1fdf-8e7b-46e1-8426-e8d44d12ce31_RXN66-318>
+          <http://model.geneontology.org/d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318>
 ] .
-
-<http://model.geneontology.org/a7f96689-8f2a-499f-975a-9c80c6606415_RXN3O-9826>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2378,7 +2372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2407,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2420,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2428,11 +2422,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_54818d89-f691-45e3-9ecc-628b2fab41db_RXN3O-9824_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2440,7 +2434,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/54818d89-f691-45e3-9ecc-628b2fab41db_RXN3O-9824>
+          <http://model.geneontology.org/be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_RXN66-306>
@@ -2452,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2466,7 +2460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,7 +2480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,9 +2497,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/5db80736-d2a0-4a88-8dd0-8fdfe17adaa3_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/573d7171-f20d-4f62-a1e4-7486ff7ffac6_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2513,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2527,7 +2521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2546,7 +2540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2566,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2582,7 +2576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2599,7 +2593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,7 +2609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2626,7 +2620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2640,7 +2634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2656,7 +2650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2671,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2684,28 +2678,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/573d7171-f20d-4f62-a1e4-7486ff7ffac6_RXN3O-9825>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_87289_RXN3O-9822>
         a       <http://purl.obolibrary.org/obo/CHEBI_87289> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2716,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2731,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2750,9 +2727,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825_SGD_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2765,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2784,7 +2772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2830,7 +2818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,12 +2829,23 @@
           <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825_SGD_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002413_RXN3O-9825_null_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2858,7 +2857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2878,7 +2877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2889,23 +2888,6 @@
           <http://model.geneontology.org/CHEBI_13392_RXN66-313>
 ] .
 
-<http://model.geneontology.org/5db80736-d2a0-4a88-8dd0-8fdfe17adaa3_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/RXN66-318>
         a       <http://purl.obolibrary.org/obo/GO_0103067> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2915,7 +2897,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/17cb1fdf-8e7b-46e1-8426-e8d44d12ce31_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
+                <http://model.geneontology.org/d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2925,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2938,7 +2920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2950,7 +2932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2961,6 +2943,17 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826_SGD_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9821>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2970,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2997,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3010,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3021,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3033,7 +3026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3052,7 +3045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,7 +3061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3080,7 +3073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,7 +3090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3131,7 +3124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3151,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3164,7 +3157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3173,24 +3166,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_573d7171-f20d-4f62-a1e4-7486ff7ffac6_RXN3O-9825_SGD_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3207,7 +3189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3223,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3232,13 +3214,30 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3254,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3265,7 +3264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3276,7 +3275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3289,7 +3288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3303,7 +3302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3323,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "zymosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3336,7 +3335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3347,7 +3346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3358,7 +3357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3370,7 +3369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3387,7 +3386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3420,13 +3419,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1BiochemicalReaction75177> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3437,7 +3453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3448,19 +3464,19 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_null_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3470,7 +3486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3486,7 +3502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3504,11 +3520,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75037> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3521,9 +3554,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a7f96689-8f2a-499f-975a-9c80c6606415_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> ;
+                <http://model.geneontology.org/536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/feb85b6a-183f-4ab8-9d40-1b9f7c36ffc8_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3531,7 +3564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3547,7 +3580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3559,7 +3592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3576,7 +3609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3590,6 +3623,17 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824_SGD_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9825>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3599,7 +3643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3607,29 +3651,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9826> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6074-1/PWY-6074-1>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3642,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3650,12 +3677,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9826> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-6074-1/PWY-6074-1>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3666,7 +3710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3681,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3696,7 +3740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3710,7 +3754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3726,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3741,7 +3785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3755,7 +3799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3771,7 +3815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3782,7 +3826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3794,7 +3838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3805,24 +3849,13 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9824>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_54818d89-f691-45e3-9ecc-628b2fab41db_RXN3O-9824_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3839,7 +3872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3855,7 +3888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3866,7 +3899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3878,7 +3911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3909,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3919,11 +3952,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_5db80736-d2a0-4a88-8dd0-8fdfe17adaa3_RXN3O-9825_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3931,25 +3964,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5db80736-d2a0-4a88-8dd0-8fdfe17adaa3_RXN3O-9825>
+          <http://model.geneontology.org/768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825>
 ] .
-
-<http://model.geneontology.org/feb85b6a-183f-4ab8-9d40-1b9f7c36ffc8_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9822>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3960,7 +3976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3973,7 +3989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3998,7 +4014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4008,28 +4024,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9822> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN3O-9822>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4040,6 +4039,40 @@
           <http://model.geneontology.org/CHEBI_18252_RXN66-319>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9822> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_13390_RXN3O-9822>
+] .
+
+<http://model.geneontology.org/d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004090> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4047,7 +4080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4062,7 +4095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4070,24 +4103,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_feb85b6a-183f-4ab8-9d40-1b9f7c36ffc8_RXN3O-9826_SGD_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_RXN3O-9820_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4107,7 +4129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4127,7 +4149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4138,16 +4160,20 @@
 <http://purl.obolibrary.org/obo/CHEBI_87289>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002969> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "C-3 sterol dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1Protein75174> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9822>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4158,7 +4184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4166,40 +4192,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002969> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-3 sterol dehydrogenase" ;
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1Protein75174> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_null_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_5db80736-d2a0-4a88-8dd0-8fdfe17adaa3_RXN3O-9825_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4212,7 +4223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4223,17 +4234,6 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_17cb1fdf-8e7b-46e1-8426-e8d44d12ce31_RXN66-318_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_18252_RXN66-319>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18252> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4243,7 +4243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4253,11 +4253,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_feb85b6a-183f-4ab8-9d40-1b9f7c36ffc8_RXN3O-9826_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4265,7 +4265,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/feb85b6a-183f-4ab8-9d40-1b9f7c36ffc8_RXN3O-9826>
+          <http://model.geneontology.org/48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_58349_RXN66-314_SGD_PWY-6074-1>
@@ -4273,7 +4273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4285,7 +4285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4305,7 +4305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4325,7 +4325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4339,7 +4339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4356,7 +4356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4373,7 +4373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4406,7 +4406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4422,7 +4422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4439,7 +4439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4450,6 +4450,23 @@
           <http://model.geneontology.org/RXN3O-9825>
 ] .
 
+<http://model.geneontology.org/be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_1949>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4458,7 +4475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4470,7 +4487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4486,7 +4503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4497,7 +4514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4508,7 +4525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4519,7 +4536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4531,7 +4548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4551,7 +4568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4567,7 +4584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4587,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4603,7 +4620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4623,7 +4640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4640,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4657,7 +4674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4670,7 +4687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4685,7 +4702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4701,7 +4718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4712,7 +4729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4724,7 +4741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4740,7 +4757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4751,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4763,7 +4780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4780,7 +4797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4796,7 +4813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4807,7 +4824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4819,7 +4836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4839,7 +4856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4856,7 +4873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4876,7 +4893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4905,7 +4922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4913,30 +4930,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/54818d89-f691-45e3-9ecc-628b2fab41db_RXN3O-9824>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4956,7 +4956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4970,7 +4970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4987,7 +4987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5007,7 +5007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5024,7 +5024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5044,7 +5044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5064,7 +5064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5081,7 +5081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5095,7 +5095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5111,7 +5111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -5122,7 +5122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -5134,7 +5134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5154,7 +5154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5171,7 +5171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5194,7 +5194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5207,7 +5207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6075-1-PWY-6075-1.ttl
+++ b/models/PWY-6075-1-PWY-6075-1.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,13 +74,13 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/MONOMER3O-188_RXN3O-178_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004467> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "SAM:C-24 sterol methyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,13 +362,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-232_RXN3O-9828_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004617> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "C-22 sterol desaturase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,13 +439,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6075-1SmallMolecule75305> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0050046>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -455,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,12 +472,6 @@
           <http://model.geneontology.org/reaction_RXN3O-9827_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0050046>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -502,22 +502,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_null_PWY-6075-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004617>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -525,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -669,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -858,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -888,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -995,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1108,7 +1114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,16 +1125,13 @@
           <http://model.geneontology.org/CHEBI_52972_RXN3O-9828>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_PWY-6075-1/PWY-6075-1_SGD_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1208,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,7 +1262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1311,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1368,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1447,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1459,7 +1462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,7 +1535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1582,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1594,7 +1597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1613,7 +1616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1657,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1672,7 +1675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1688,7 +1691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1717,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1731,7 +1734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,7 +1794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1807,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1872,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1883,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1895,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1914,7 +1917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1930,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1955,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1983,13 +1986,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN> , <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN> , <http://model.geneontology.org/CHEBI_57783_1.3.1.71-RXN> , <http://model.geneontology.org/CHEBI_18249_1.3.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN> , <http://model.geneontology.org/CHEBI_18249_1.3.1.71-RXN> , <http://model.geneontology.org/CHEBI_57783_1.3.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2003,7 +2006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2023,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2043,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2063,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2093,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6122-1-PWY-6122-1.ttl
+++ b/models/PWY-6122-1-PWY-6122-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -481,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,29 +495,12 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/f7d9dd27-7995-430c-93d0-2dae792cd14a_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -616,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -702,26 +685,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002816> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glycinamide ribotide transformylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1Protein71773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_18413_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18413> ;
@@ -732,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,16 +728,20 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_f7d9dd27-7995-430c-93d0-2dae792cd14a_GART-RXN_SGD_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002816> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glycinamide ribotide transformylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1Protein71773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -779,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -826,17 +798,17 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -844,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -937,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -971,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1038,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1074,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1098,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,28 +1083,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0cb31f84-709b-4ed8-87b4-c9dd56ff1af1_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1145,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1162,7 +1117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,7 +1198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1291,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1308,7 +1263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1324,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1364,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1384,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,24 +1353,13 @@
 <http://identifiers.org/sgd/S000002816>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_0cb31f84-709b-4ed8-87b4-c9dd56ff1af1_GART-RXN_SGD_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1439,11 +1383,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_0cb31f84-709b-4ed8-87b4-c9dd56ff1af1_GART-RXN_SGD_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN_SGD_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1395,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0cb31f84-709b-4ed8-87b4-c9dd56ff1af1_GART-RXN>
+          <http://model.geneontology.org/4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY-6122-1>
@@ -1459,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1509,7 +1453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1554,7 +1498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1570,7 +1514,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN_SGD_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1581,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1595,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,7 +1595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1702,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1715,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1733,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1767,7 +1722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,13 +1736,30 @@
 <http://purl.obolibrary.org/obo/GO_0004044>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_f7d9dd27-7995-430c-93d0-2dae792cd14a_GART-RXN_SGD_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN_SGD_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1767,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f7d9dd27-7995-430c-93d0-2dae792cd14a_GART-RXN>
+          <http://model.geneontology.org/c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_PWY-6122-1>
@@ -1803,7 +1775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,13 +1820,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1BiochemicalReaction71907> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1868,7 +1857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1920,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1931,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1943,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,9 +1955,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/0cb31f84-709b-4ed8-87b4-c9dd56ff1af1_GART-RXN> ;
+                <http://model.geneontology.org/4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/f7d9dd27-7995-430c-93d0-2dae792cd14a_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1976,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2003,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2028,7 +2017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2044,7 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2058,7 +2047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2074,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2106,7 +2095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2126,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2143,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2157,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2223,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "5-aminoimidazole ribonucleotide biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2236,7 +2225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2251,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2259,13 +2248,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN_SGD_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2357,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2374,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2391,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2404,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2419,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6123-1-PWY-6123-1.ttl
+++ b/models/PWY-6123-1-PWY-6123-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,9 +65,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -76,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -108,9 +119,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> , <http://model.geneontology.org/4432f5ec-f83e-4992-b7a4-783280c12f02_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/3b042fea-99e3-498c-ad2a-f136ca184562_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -118,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,17 +165,6 @@
           <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4432f5ec-f83e-4992-b7a4-783280c12f02_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58475> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,6 +279,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -287,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,20 +387,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_3b042fea-99e3-498c-ad2a-f136ca184562_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -392,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -404,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,8 +471,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/3b042fea-99e3-498c-ad2a-f136ca184562_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -474,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -634,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -748,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -776,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -913,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -990,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1063,7 +1069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1096,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1107,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1118,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1132,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,7 +1176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1219,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1227,29 +1233,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/4432f5ec-f83e-4992-b7a4-783280c12f02_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002411_SAICARSYN-RXN_SGD_PWY-6123-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,11 +1263,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_3b042fea-99e3-498c-ad2a-f136ca184562_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1275,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3b042fea-99e3-498c-ad2a-f136ca184562_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000070>
@@ -1297,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1312,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,13 +1342,24 @@
           <http://model.geneontology.org/AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_137981_AIRCARBOXY-RXN_SGD_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1392,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1503,7 +1503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,7 +1593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1653,7 +1653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1716,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1745,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,11 +1761,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4432f5ec-f83e-4992-b7a4-783280c12f02_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,7 +1773,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4432f5ec-f83e-4992-b7a4-783280c12f02_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0043727>
@@ -1784,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1795,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1810,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inosine-5'-phosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1852,7 +1852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1868,7 +1868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1880,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1924,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1937,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1965,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6125-PWY-6125.ttl
+++ b/models/PWY-6125-PWY-6125.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GDPREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,19 +37,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY-6125>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -96,19 +96,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003938>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -136,54 +136,69 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_15740>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -194,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -218,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -238,17 +253,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15740>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -261,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,10 +307,10 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY-6125>
@@ -297,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -305,19 +326,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
 <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
@@ -329,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,58 +360,59 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000002862>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
@@ -402,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -436,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -454,20 +476,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
@@ -479,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,19 +513,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_37565>
@@ -516,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,63 +595,57 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
+          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -638,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -663,29 +681,46 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6125/PWY-6125>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY-6125> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanylate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,22 +746,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -734,19 +767,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
+          <http://model.geneontology.org/PWY-6125/PWY-6125>
 ] .
 
 <http://model.geneontology.org/GDPREDUCT-RXN>
@@ -766,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,9 +812,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -794,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,19 +846,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_PWY-6125>
@@ -824,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -835,36 +877,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
+          <http://model.geneontology.org/PWY-6125/PWY-6125>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
@@ -875,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -886,53 +928,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+          <http://model.geneontology.org/PWY-6125/PWY-6125>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/PWY-6125/PWY-6125>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/PWY-6125/PWY-6125>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125>
@@ -940,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -995,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,37 +1066,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/PWY-6125/PWY-6125>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY-6125>
@@ -1062,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1073,27 +1117,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6125/PWY-6125>
+          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
@@ -1105,13 +1158,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29540> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1121,48 +1177,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY-6125>
@@ -1170,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1188,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1197,22 +1249,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-746>
+          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004748>
@@ -1237,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1267,19 +1317,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY-6125>
@@ -1287,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1295,19 +1345,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
@@ -1319,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1329,19 +1379,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1352,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1360,19 +1410,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
@@ -1384,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1401,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1417,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,12 +1511,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1477,19 +1538,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1500,19 +1561,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
@@ -1520,19 +1581,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
@@ -1544,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1577,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1642,53 +1703,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
+          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
+          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125>
@@ -1696,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1711,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1742,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1757,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1782,12 +1843,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1798,57 +1873,61 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-6125> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125>
@@ -1856,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1867,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1878,27 +1957,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
+          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -1909,11 +1990,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1924,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1934,19 +2018,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY-6125>
@@ -1954,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1962,11 +2046,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,7 +2058,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
@@ -1986,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1994,21 +2078,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
+          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_PWY-6125>
@@ -2016,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2027,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2053,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2067,7 +2164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2077,37 +2174,41 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PWY-6125>
@@ -2115,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2126,27 +2227,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
+          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY-6125>
@@ -2154,7 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2165,18 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2184,20 +2276,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6125/PWY-6125>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58595> ;
@@ -2208,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2225,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2242,13 +2345,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29349> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/PWY-6125/PWY-6125>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2257,13 +2363,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "PWY-6125" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
@@ -2274,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2287,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2295,39 +2412,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/PWY-6125/PWY-6125>
 ] .
 
 <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-746>
@@ -2339,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2348,22 +2467,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
@@ -2375,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2392,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2405,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2413,19 +2530,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6125/PWY-6125>
+          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/IMP-DEHYDROG-RXN>
@@ -2447,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2460,7 +2577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2468,36 +2585,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6125/PWY-6125>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6125/PWY-6125>
+          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY-6125>
@@ -2505,7 +2622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2520,6 +2637,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -2528,29 +2656,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-746> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY-6125> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004424>
@@ -2558,19 +2701,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6125/PWY-6125>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125>
@@ -2578,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2586,19 +2729,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
@@ -2620,7 +2763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2633,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2644,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2659,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2669,19 +2812,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_PWY-6125>
@@ -2689,7 +2832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2697,36 +2840,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_PWY-6125> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY-6125> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125>
@@ -2734,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2745,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2756,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2781,7 +2924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2800,7 +2943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2810,20 +2953,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY-6125>
@@ -2831,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2842,44 +2987,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+          <http://model.geneontology.org/RXN0-746>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58053>
@@ -2890,7 +3039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2901,7 +3050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2916,7 +3065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of guanosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2929,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2942,7 +3091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2955,31 +3104,50 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY-6125> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-746> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6126-1-PWY-6126-1.ttl
+++ b/models/PWY-6126-1-PWY-6126-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of adenosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -16,20 +16,22 @@
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -38,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,13 +117,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30171> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -131,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,6 +184,15 @@
 <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -171,12 +202,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000003563>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -184,19 +218,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6126-1/PWY-6126-1>
+          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY-6126-1>
@@ -204,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -307,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,12 +378,29 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
+] .
+
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,17 +431,6 @@
 <http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_null_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/PWY-6126-1/PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -398,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -406,12 +446,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_null_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -461,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -494,19 +556,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -518,7 +580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,19 +675,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
+          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -634,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,12 +730,21 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -712,11 +783,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
+] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -727,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,27 +920,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
+          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY-6126-1>
@@ -860,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,19 +1006,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -937,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -948,6 +1038,15 @@
           <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -957,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,11 +1144,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ADPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1070,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1112,19 +1214,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6126-1/PWY-6126-1>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1133,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1197,22 +1299,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1224,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1260,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1283,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1313,6 +1413,23 @@
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_61404>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1326,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,6 +1471,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1362,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,17 +1501,6 @@
           <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57667> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1393,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1415,21 +1532,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_null_PWY-6126-1>
@@ -1437,20 +1565,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1463,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,11 +1610,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_61404_RXN0-745>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61404> ;
@@ -1508,7 +1628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,10 +1640,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,19 +1655,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
+          <http://model.geneontology.org/PWY-6126-1/PWY-6126-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1554,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1591,12 +1713,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1618,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,7 +1772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1678,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1686,19 +1811,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1709,7 +1834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1726,7 +1851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1757,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1782,12 +1907,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1798,19 +1926,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002411_DADPKIN-RXN_SGD_PWY-6126-1>
@@ -1818,7 +1946,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1830,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1861,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,12 +2026,23 @@
           <http://model.geneontology.org/PWY-6126-1/PWY-6126-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_456216_ADPREDUCT-RXN_SGD_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1917,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1926,22 +2076,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -1952,7 +2100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +2112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1980,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2004,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2017,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2028,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2053,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2070,7 +2218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,19 +2228,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
+          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2101,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2121,7 +2269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2138,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2154,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2162,11 +2310,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2206,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2219,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2230,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2244,7 +2409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2255,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2263,19 +2428,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
+          <http://model.geneontology.org/PWY-6126-1/PWY-6126-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2286,7 +2451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2316,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6132-PWY-6132.ttl
+++ b/models/PWY-6132-PWY-6132.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lanosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6147-PWY-6147.ttl
+++ b/models/PWY-6147-PWY-6147.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,7 +691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "6-hydroxymethyl-dihydropterin diphosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -951,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1181,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1407,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1456,7 +1456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1624,7 +1624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1668,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1694,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1711,7 +1711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6482-1-PWY-6482-1.ttl
+++ b/models/PWY-6482-1-PWY-6482-1.ttl
@@ -1,35 +1,54 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a diphthine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002413_RXN-11373_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
+          <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
+          <http://model.geneontology.org/RXN-11373>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17509_RXN-11371>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
@@ -41,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,11 +76,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_f046f729-4719-44ab-bf70-072c5851beae_RXN-11373_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +88,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f046f729-4719-44ab-bf70-072c5851beae_RXN-11373>
+          <http://model.geneontology.org/CHEBI_15378_RXN-11373>
 ] .
 
 <http://model.geneontology.org/CHEBI_57856_RXN-11373>
@@ -81,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -90,20 +109,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11370>
+          <http://model.geneontology.org/reaction_RXN-11370_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -114,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -123,23 +144,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_67b421c5-b4cd-44e9-802c-ef4ac7e15f1f_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,53 +174,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_RXN-11374>
-] .
-
-<http://model.geneontology.org/1ad1ebd1-32cb-4ac8-b8ac-ed6942b91c7d_RXN-11371>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an L-histidine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43400> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11374> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11374>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11371>
+          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY-6482-1>
@@ -218,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,40 +238,21 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component>
 ] .
-
-<http://model.geneontology.org/ffd4d56c-f054-4ddf-834f-e43f4f8dd786_RXN-11374>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-11371>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -289,7 +263,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1ad1ebd1-32cb-4ac8-b8ac-ed6942b91c7d_RXN-11371> , <http://model.geneontology.org/CHEBI_59789_RXN-11371> ;
+                <http://model.geneontology.org/CHEBI_59789_RXN-11371> , <http://model.geneontology.org/2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17509_RXN-11371> , <http://model.geneontology.org/CHEBI_15378_RXN-11371> , <http://model.geneontology.org/CHEBI_58031_RXN-11371> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -299,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -338,6 +312,15 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -345,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -355,21 +338,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
+          <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-11370>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002413_RXN-11373_null_PWY-6482-1>
@@ -377,9 +360,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -387,10 +381,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "RRT2" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,11 +399,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -421,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,7 +447,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -442,19 +466,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
+          <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
+          <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -462,11 +486,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,18 +498,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_RXN-11370>
+          <http://model.geneontology.org/CHEBI_15378_RXN-11370>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,53 +548,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a diphthine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002413_RXN-11373_null_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-11373>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17509_RXN-11371>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/03a374e6-1b78-4510-8108-f84c236f4f82_RXN-11373>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -567,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,16 +571,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_ffd4d56c-f054-4ddf-834f-e43f4f8dd786_RXN-11374_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374_SGD_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11374> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371_SGD_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_59789_RXN-11374>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -595,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,11 +627,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_67b421c5-b4cd-44e9-802c-ef4ac7e15f1f_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +639,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/67b421c5-b4cd-44e9-802c-ef4ac7e15f1f_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/RXN-11374>
@@ -631,7 +653,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_59789_RXN-11374> , <http://model.geneontology.org/CHEBI_57784_RXN-11374> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/ffd4d56c-f054-4ddf-834f-e43f4f8dd786_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> , <http://model.geneontology.org/9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -639,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,60 +672,41 @@
 <http://purl.obolibrary.org/obo/CHEBI_57784>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/f046f729-4719-44ab-bf70-072c5851beae_RXN-11373>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphthine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-11373>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11373>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11370> ;
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-11370_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY-6482-1>
@@ -711,18 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_1ad1ebd1-32cb-4ac8-b8ac-ed6942b91c7d_RXN-11371_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -760,45 +752,58 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11374>
+          <http://model.geneontology.org/reaction_RXN-11374_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
+          <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
+          <http://model.geneontology.org/MONOMER-15582_RXN-11370_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -808,31 +813,29 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-11370>
+          <http://model.geneontology.org/CHEBI_58031_RXN-11371>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,46 +843,69 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_f046f729-4719-44ab-bf70-072c5851beae_RXN-11373_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller>
+          <http://model.geneontology.org/CHEBI_57856_RXN-11373>
 ] .
+
+<http://model.geneontology.org/2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an L-histidine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43400> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphthine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,19 +947,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11370_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-11370>
+          <http://model.geneontology.org/CHEBI_58031_RXN-11370>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
@@ -941,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -966,17 +992,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_03a374e6-1b78-4510-8108-f84c236f4f82_RXN-11373_SGD_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -990,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1025,11 +1040,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_ffd4d56c-f054-4ddf-834f-e43f4f8dd786_RXN-11374_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,27 +1052,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ffd4d56c-f054-4ddf-834f-e43f4f8dd786_RXN-11374>
+          <http://model.geneontology.org/CHEBI_15378_RXN-11374>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_1ad1ebd1-32cb-4ac8-b8ac-ed6942b91c7d_RXN-11371_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1ad1ebd1-32cb-4ac8-b8ac-ed6942b91c7d_RXN-11371>
+          <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY-6482-1>
@@ -1065,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1084,19 +1101,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
@@ -1107,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1138,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1146,19 +1163,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11373>
+          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1169,19 +1186,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_PWY-6482-1>
@@ -1189,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1218,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1226,38 +1243,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a diphthine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' 'a diphthine-[translation elongation factor 2] + ammonium + ATP &rarr; a diphthamide-[translation elongation factor 2] + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002413_DIPHTINE--AMMONIA-LIGASE-RXN_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
+          <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-11374_location_lociGO_0005829>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER-15582_RXN-11370_controller>
+          <http://model.geneontology.org/CHEBI_57784_RXN-11370>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58031>
@@ -1268,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1276,11 +1293,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11374> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_15378_RXN-11371_SGD_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1322,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58031_RXN-11371>
+          <http://model.geneontology.org/CHEBI_15378_RXN-11371>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-11370_location_lociGO_0005829>
@@ -1299,19 +1333,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_PWY-6482-1>
@@ -1319,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1334,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1354,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1387,31 +1421,44 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_RXN-11373>
+          <http://model.geneontology.org/da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373>
 ] .
 
 <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-histidien:S-adenosyl-L-methionine 3-amino-3-carboxypropyl transferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1428,7 +1475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1438,19 +1485,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11370_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58031_RXN-11370>
+          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_null_PWY-6482-1>
@@ -1458,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1466,6 +1513,15 @@
 
 <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component>
+        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1475,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1490,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1500,38 +1556,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11374_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-11374>
+          <http://model.geneontology.org/CHEBI_57784_RXN-11374>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
+          <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-11374>
 ] .
 
 <http://model.geneontology.org/CHEBI_59789_RXN-11370>
@@ -1543,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,19 +1609,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+          <http://model.geneontology.org/CPLX-8046_RXN-11371_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_null_PWY-6482-1>
@@ -1573,7 +1629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1598,13 +1654,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1BiochemicalReaction43381> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0017178> ;
@@ -1615,7 +1674,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/67b421c5-b4cd-44e9-802c-ef4ac7e15f1f_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1623,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1631,47 +1690,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/67b421c5-b4cd-44e9-802c-ef4ac7e15f1f_DIPHTINE--AMMONIA-LIGASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphthine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
+          <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
+          <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1679,7 +1721,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY-6482-1>
@@ -1687,7 +1729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1698,46 +1740,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a diphthine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' 'a diphthine-[translation elongation factor 2] + ammonium + ATP &rarr; a diphthamide-[translation elongation factor 2] + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002413_DIPHTINE--AMMONIA-LIGASE-RXN_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11373> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57784_RXN-11370>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11370>
 ] .
 
 <http://model.geneontology.org/CHEBI_58031_RXN-11371>
@@ -1749,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1769,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diphthamide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1794,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1822,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1833,19 +1873,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller>
+          <http://model.geneontology.org/CHEBI_57856_RXN-11374>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY-6482-1>
@@ -1853,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1861,36 +1901,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_15378_RXN-11371_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-11371>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11371>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_null_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_59789_RXN-11373>
@@ -1902,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1915,11 +1957,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphthine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-11373>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1930,9 +2000,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_RXN-11373> , <http://model.geneontology.org/03a374e6-1b78-4510-8108-f84c236f4f82_RXN-11373> ;
+                <http://model.geneontology.org/da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373> , <http://model.geneontology.org/CHEBI_59789_RXN-11373> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/f046f729-4719-44ab-bf70-072c5851beae_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> , <http://model.geneontology.org/03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1940,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1948,12 +2018,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1974,20 +2044,22 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_03a374e6-1b78-4510-8108-f84c236f4f82_RXN-11373_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_null_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/03a374e6-1b78-4510-8108-f84c236f4f82_RXN-11373>
+          <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11374_SGD_PWY-6482-1>
@@ -1995,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2010,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,36 +2092,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11370> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11374_SGD_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57784_RXN-11374>
+          <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
@@ -2061,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2070,22 +2142,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_null_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-11374>
+          <http://model.geneontology.org/CHEBI_57856_RXN-11370>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_null_PWY-6482-1>
@@ -2093,9 +2163,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2106,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2121,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6543-PWY-6543.ttl
+++ b/models/PWY-6543-PWY-6543.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,13 +197,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "aminodeoxychorismate lyase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,6 +374,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -387,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,9 +618,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6614-PWY-6614.ttl
+++ b/models/PWY-6614-PWY-6614.ttl
@@ -9,7 +9,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -50,24 +50,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57451>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_86c84019-258c-4f70-88b1-1579951b7fbb_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrahydrofolate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -182,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -215,6 +204,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -231,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,12 +248,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,8 +279,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -279,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,11 +309,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_86c84019-258c-4f70-88b1-1579951b7fbb_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +321,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/86c84019-258c-4f70-88b1-1579951b7fbb_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008841>
@@ -318,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -451,13 +468,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/GO_0004156>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,9 +488,6 @@
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004156>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -480,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -511,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -597,15 +614,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/86c84019-258c-4f70-88b1-1579951b7fbb_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7bb0f6f8-94a8-4959-801e-e1e5eae66ef6_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -622,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,6 +696,23 @@
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY-6614> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
@@ -690,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,36 +732,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY-6614> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
-] .
-
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY-6614/PWY-6614_SGD_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -735,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,12 +752,23 @@
           <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY-6614/PWY-6614_SGD_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,23 +876,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64312> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57451> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,49 +893,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/86c84019-258c-4f70-88b1-1579951b7fbb_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64312> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/7bb0f6f8-94a8-4959-801e-e1e5eae66ef6_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_null_PWY-6614>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -950,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,7 +950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -991,11 +974,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_7bb0f6f8-94a8-4959-801e-e1e5eae66ef6_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,7 +986,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7bb0f6f8-94a8-4959-801e-e1e5eae66ef6_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -1014,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1023,16 +1006,25 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_7bb0f6f8-94a8-4959-801e-e1e5eae66ef6_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1040,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,15 +1043,23 @@
           <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1216,7 +1216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1266,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-7176-PWY-7176.ttl
+++ b/models/PWY-7176-PWY-7176.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UTP and CTP <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -284,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,6 +681,34 @@
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY-7176> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
@@ -692,41 +720,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7176SmallMolecule70534> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY-7176> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003864> ;
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -840,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,7 +1067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-7219-PWY-7219.ttl
+++ b/models/PWY-7219-PWY-7219.ttl
@@ -8,7 +8,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,13 +317,30 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "adenylo-succinate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72348> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,30 +351,13 @@
           <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "adenylo-succinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72348> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1083,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-7220-1-PWY-7220-1.ttl
+++ b/models/PWY-7220-1-PWY-7220-1.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,13 +37,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7220-1BiochemicalReaction73426> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-745>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -54,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,20 +66,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
+          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/DADPKIN-RXN>
@@ -98,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,12 +145,29 @@
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY-7220-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+] .
+
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY-7220-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -187,27 +209,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-7220-1/PWY-7220-1_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
+          <http://model.geneontology.org/PWY-7220-1/PWY-7220-1>
 ] .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
@@ -217,13 +242,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7220-1Protein73423> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -237,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -286,19 +320,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PWY-7220-1/PWY-7220-1_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
+          <http://model.geneontology.org/PWY-7220-1/PWY-7220-1>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004748>
@@ -310,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,10 +355,33 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY-7220-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+] .
+
 <http://purl.obolibrary.org/obo/CHEBI_61404>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://identifiers.org/sgd/S000003412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
@@ -336,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,8 +401,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004550>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -355,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -366,19 +431,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002411_RXN0-745_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
+          <http://model.geneontology.org/RXN0-745>
 ] .
 
 <http://model.geneontology.org/RXN0-745>
@@ -396,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -453,22 +518,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -479,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -524,19 +587,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_null_PWY-7220-1>
@@ -544,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,6 +628,23 @@
           <http://model.geneontology.org/ADPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY-7220-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -577,10 +657,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,12 +670,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY-7220-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -601,19 +692,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
+          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/PWY-7220-1/PWY-7220-1>
@@ -623,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -642,19 +733,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-7220-1/PWY-7220-1_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-7220-1/PWY-7220-1>
+          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
@@ -666,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -749,19 +840,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
@@ -773,13 +864,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7220-1SmallMolecule73398> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -789,7 +889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -813,19 +913,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -836,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -847,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -858,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -889,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -903,19 +1003,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002411_RXN0-745_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-745>
+          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -924,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +1041,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000872>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
@@ -953,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -977,29 +1100,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1008,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,22 +1142,25 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1053,20 +1177,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1074,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,6 +1218,23 @@
           <http://model.geneontology.org/ADPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_ADPREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY-7220-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
 <http://model.geneontology.org/CHEBI_61404_RXN0-745>
@@ -1094,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1276,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1135,19 +1298,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PWY-7220-1/PWY-7220-1_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-7220-1/PWY-7220-1>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -1158,27 +1321,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-7220-1/PWY-7220-1_SGD_PWY-7220-1>
@@ -1186,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-7221-PWY-7221.ttl
+++ b/models/PWY-7221-PWY-7221.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -270,11 +270,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002862>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -287,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -523,13 +526,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanylate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -600,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -644,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -749,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,9 +998,6 @@
           <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1265,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1434,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1545,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1637,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1666,7 +1666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1752,7 +1752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1766,7 +1766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1830,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1844,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,7 +1861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1893,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-7222-1-PWY-7222-1.ttl
+++ b/models/PWY-7222-1-PWY-7222-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -12,12 +12,15 @@
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY-7222-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -59,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,36 +72,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PWY-7222-1/PWY-7222-1_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-7222-1/PWY-7222-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -107,21 +127,35 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PWY-7222-1/PWY-7222-1_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+          <http://model.geneontology.org/PWY-7222-1/PWY-7222-1>
 ] .
 
 <http://model.geneontology.org/RXN0-746>
@@ -139,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,13 +207,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7222-1SmallMolecule73176> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -192,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,27 +266,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
+          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
@@ -254,30 +299,50 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-746> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002411_RXN0-746_SGD_PWY-7222-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -301,7 +366,7 @@
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004550>
+<http://identifiers.org/sgd/S000003412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -312,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,19 +433,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
+          <http://model.geneontology.org/DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY-7222-1>
@@ -388,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -423,22 +488,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
@@ -453,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,19 +526,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PWY-7222-1/PWY-7222-1_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-7222-1/PWY-7222-1>
+          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58595>
@@ -486,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -508,19 +571,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PWY-7222-1/PWY-7222-1_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/PWY-7222-1/PWY-7222-1>
 ] .
 
 <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
@@ -531,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,19 +602,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
@@ -561,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,12 +632,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-746> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+] .
+
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY-7222-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -588,20 +668,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/CHEBI_61429>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -609,24 +694,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/CHEBI_61429>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_PWY-7222-1>
@@ -634,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -645,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -662,20 +764,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PWY-7222-1/PWY-7222-1_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-7222-1/PWY-7222-1>
+          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -683,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,21 +824,30 @@
           <http://model.geneontology.org/RXN0-746>
 ] .
 
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/PWY-7222-1>
@@ -720,32 +859,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PWY-7222-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -756,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,19 +886,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PWY-7222-1>
@@ -786,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -844,36 +964,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DGDPKIN-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -885,6 +1005,18 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_16526_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -894,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -932,56 +1064,70 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PWY-7222-1/PWY-7222-1_SGD_PWY-7222-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-7222-1/PWY-7222-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY-7222-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -996,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1043,19 +1189,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY-7222-1>
@@ -1063,27 +1209,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY-7222-1>
@@ -1091,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1115,42 +1280,42 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY-7222-1>
@@ -1158,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1173,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-781-PWY-781.ttl
+++ b/models/PWY-781-PWY-781.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -14,19 +14,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_17359_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_17359_SULFITE-REDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,15 +99,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -116,11 +116,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-781>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,21 +169,26 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_null_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
 ] .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003771> ;
@@ -192,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,9 +224,6 @@
           <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -231,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,19 +252,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_15378_1.8.4.8-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_PWY-781/PWY-781_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
+          <http://model.geneontology.org/PWY-781/PWY-781>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_15378_1.8.4.8-RXN_SGD_PWY-781>
@@ -270,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -302,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -351,19 +353,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
@@ -373,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -412,21 +431,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_58343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_17359_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17359_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -441,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate assimilation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,11 +543,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,24 +555,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
+          <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_PWY-781/PWY-781_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/PWY-781/PWY-781>
 ] .
 
 <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
@@ -564,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,21 +635,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_null_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_null_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
 ] .
 
 <http://model.geneontology.org/1.8.4.8-RXN>
@@ -641,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -665,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -676,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -701,27 +731,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
+        a       <http://identifiers.org/sgd/S000003898> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_PWY-781/PWY-781_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-781/PWY-781>
+          <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY-781>
@@ -729,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,19 +862,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58339_1.8.4.8-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58339_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_ADENYLYLSULFKIN-RXN_SGD_PWY-781>
@@ -843,27 +882,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001926> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
@@ -875,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -914,18 +962,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003898>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY-781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -947,11 +998,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +1010,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -970,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -985,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1044,47 +1095,60 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_PWY-781/PWY-781_SGD_PWY-781> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-781/PWY-781>
-] .
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_null_PWY-781> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
+          <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_17359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
@@ -1099,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1112,7 +1176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1133,22 +1197,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_null_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
@@ -1160,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,11 +1266,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1278,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781>
@@ -1207,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,36 +1320,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58339_1.8.4.8-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58339_1.8.4.8-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_null_PWY-781> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
@@ -1285,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1321,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1340,19 +1421,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_PWY-781/PWY-781_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/PWY-781/PWY-781>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1361,7 +1442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,6 +1473,9 @@
 <http://identifiers.org/sgd/S000001484>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://purl.obolibrary.org/obo/GO_0004783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1399,23 +1483,24 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_null_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
 ] .
+
+<http://identifiers.org/sgd/S000001926>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1425,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,19 +1523,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
@@ -1462,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,19 +1557,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -1495,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1516,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1526,19 +1611,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1547,7 +1632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1579,7 +1664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,11 +1674,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_15378_1.8.4.8-RXN_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1686,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
+          <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
@@ -1613,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1622,22 +1707,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_null_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58339_1.8.4.8-RXN_SGD_PWY-781>
@@ -1645,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1659,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1670,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1681,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1708,10 +1791,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "sulfite reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component> , <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,19 +1806,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_PWY-781/PWY-781_SGD_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-781/PWY-781>
+          <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_PWY-781/PWY-781_SGD_PWY-781>
@@ -1741,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-821-1-PWY-821-1.ttl
+++ b/models/PWY-821-1-PWY-821-1.ttl
@@ -3,29 +3,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' 'null' 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMET-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
 ] .
 
 <http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
@@ -35,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,29 +44,12 @@
 <http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/f05d5bf6-7109-43f8-b651-5263c5c3dff3_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFITE-REDUCT-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -76,19 +57,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16134_CYSTAGLY-RXN>
+          <http://model.geneontology.org/CHEBI_15377_CYSTAGLY-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
@@ -96,17 +77,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57716_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57716> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -117,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,11 +104,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31038> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -150,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,38 +148,32 @@
           <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31023> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002411_ACETYLHOMOSER-CYS-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
+          <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
 ] .
 
 <http://geneontology.org/lego/evidence>
@@ -203,18 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -222,19 +192,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
+          <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
@@ -244,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,29 +239,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -283,33 +264,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_537519>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller>
-] .
-
 <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN>
+] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -324,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,13 +339,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31155> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN>
+] .
 
 <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -375,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,36 +414,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
+          <http://model.geneontology.org/CHEBI_30089_RXN-721>
 ] .
 
 <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
@@ -467,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,21 +495,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1>
@@ -519,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,22 +578,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
+          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY-821-1>
@@ -586,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -601,9 +614,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/5676466b-fbc8-43b5-8d77-c22817978cad_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/f05d5bf6-7109-43f8-b651-5263c5c3dff3_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -611,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,10 +656,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "sulfite reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component> , <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -701,19 +716,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_HOMOSERDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_null_PWY-821-1>
@@ -721,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -740,30 +755,30 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' 'null' 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
+          <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-721>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +786,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
@@ -784,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,27 +829,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
+          <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58343>
@@ -849,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,12 +874,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
+        a       <http://identifiers.org/sgd/S000003898> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,19 +913,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58339_1.8.4.8-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58339_1.8.4.8-RXN>
+          <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-821-1>
@@ -907,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -918,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -943,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -951,38 +977,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' 'null' '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-721> ;
+          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
+          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
@@ -994,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1033,19 +1059,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57716>
@@ -1060,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,7 +1105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1095,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1140,19 +1166,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
@@ -1164,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1185,19 +1211,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
+          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY-821-1>
@@ -1205,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,19 +1262,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTAGLY-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
+          <http://model.geneontology.org/CHEBI_58161_CYSTAGLY-RXN>
 ] .
 
 <http://model.geneontology.org/PWY-821-1/PWY-821-1>
@@ -1258,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1271,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1283,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,19 +1322,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ASPARTATEKIN-RXN>
@@ -1330,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1343,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1357,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1368,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1379,36 +1405,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HOMOCYSMET-RXN>
+          <http://model.geneontology.org/7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
@@ -1420,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1447,29 +1475,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' 'null' 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_null_PWY-821-1>
@@ -1477,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1506,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1537,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1551,6 +1577,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000893> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1558,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1586,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1622,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1631,22 +1668,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CYSTAGLY-RXN>
+          <http://model.geneontology.org/CHEBI_58161_RXN-721>
 ] .
 
 <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
@@ -1658,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1674,7 +1709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1704,18 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1723,27 +1747,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMET-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58199_HOMOCYSMET-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_null_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1784,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1799,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,19 +1861,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_PWY-821-1>
@@ -1846,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1878,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1887,13 +1922,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002910> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "S-adenosylmethionine synthetase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1906,11 +1941,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_537519_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1918,7 +1953,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_537519_HOMOSERDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY-821-1>
@@ -1926,7 +1961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1947,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1957,36 +1992,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
@@ -2003,7 +2038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2016,11 +2051,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_5676466b-fbc8-43b5-8d77-c22817978cad_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,24 +2063,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5676466b-fbc8-43b5-8d77-c22817978cad_RXN3O-22>
+          <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_HOMOSERDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY-821-1>
@@ -2053,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2068,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,27 +2116,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-LYASE-RXN>
+          <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2110,7 +2147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2123,15 +2160,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2147,13 +2184,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31230> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/1.8.4.8-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004604> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2174,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2187,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2201,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2209,19 +2257,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_RXN-721_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35235_RXN-721>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_58339_1.8.4.8-RXN>
@@ -2233,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2243,19 +2291,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57844_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
@@ -2267,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2280,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2291,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2302,19 +2350,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_null_PWY-821-1>
@@ -2322,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2347,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2361,7 +2409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2381,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2397,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2423,33 +2471,42 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30089_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30089> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2460,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2468,16 +2525,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001484> ;
@@ -2486,7 +2549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2513,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2523,21 +2586,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' 'null' 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
+          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1>
@@ -2545,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2560,7 +2623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2577,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,7 +2653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2598,11 +2661,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2610,7 +2673,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35235_CYSTAGLY-RXN>
+          <http://model.geneontology.org/CHEBI_16134_CYSTAGLY-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
@@ -2622,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2635,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2646,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2655,24 +2718,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_ADENYLYLSULFKIN-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2683,34 +2735,43 @@
           <http://model.geneontology.org/CHEBI_58243_ADENYLYLSULFKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002411_ACETYLHOMOSER-CYS-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY-821-1>
@@ -2718,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2732,7 +2793,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2743,7 +2815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2751,19 +2823,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+          <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
@@ -2775,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2785,31 +2857,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -2833,7 +2897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2850,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2863,7 +2927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2871,36 +2935,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_15378_1.8.4.8-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://identifiers.org/sgd/S000005767>
@@ -2911,7 +2975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2922,18 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2941,11 +2994,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/HOMOCYSMET-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57535_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2956,24 +3026,16 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_null_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57476>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2987,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3000,7 +3062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3017,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3044,22 +3106,20 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN>
+          <http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3068,7 +3128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3079,22 +3139,16 @@
           <http://model.geneontology.org/CHEBI_16136_ACETYLHOMOSER-CYS-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58207> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3105,13 +3159,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31467> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -3122,24 +3195,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/SULFITE-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3160,7 +3222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3180,7 +3242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3190,37 +3252,42 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTAGLY-RXN> ;
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
 ] .
+
+<http://identifiers.org/sgd/S000001926>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3230,7 +3297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3244,7 +3311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3256,6 +3323,17 @@
 <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58199_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3265,7 +3343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3282,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3302,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3319,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3329,19 +3407,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_17359_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17359_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1>
@@ -3349,7 +3427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3364,7 +3442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3377,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3385,36 +3463,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_537519_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_537519_HOMOSERDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1>
@@ -3422,7 +3500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3433,7 +3511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3444,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3455,7 +3533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3466,7 +3544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3474,19 +3552,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000006371>
@@ -3504,7 +3582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3517,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3528,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3542,7 +3620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3562,7 +3640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3572,19 +3650,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58339_1.8.4.8-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58339_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
@@ -3596,7 +3674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3604,12 +3682,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000002910>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3620,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3631,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3639,11 +3720,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3651,24 +3732,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57716_RXN-721>
+          <http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/S-ADENMETSYN-RXN>
@@ -3688,7 +3771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3696,34 +3779,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000003898>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CYSTAGLY-RXN>
+          <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
@@ -3737,7 +3821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3767,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3783,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3795,7 +3879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3815,7 +3899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3842,7 +3926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3858,31 +3942,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_5676466b-fbc8-43b5-8d77-c22817978cad_RXN3O-22_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004122>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3892,7 +3965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3906,7 +3979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3914,50 +3987,39 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58339>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_f05d5bf6-7109-43f8-b651-5263c5c3dff3_RXN3O-22_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAL012W-MONOMER_CYSTAGLY-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3966,7 +4028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3982,7 +4044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3993,19 +4055,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
@@ -4017,7 +4079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4030,7 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4045,7 +4107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4055,46 +4117,65 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' 'null' 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
+          <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_null_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4109,7 +4190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4123,7 +4204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4136,19 +4217,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY-821-1>
@@ -4156,7 +4237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4177,7 +4258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4186,20 +4267,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
+          <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/CYSTAGLY-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4208,7 +4291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4224,7 +4307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4232,19 +4315,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMET-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
+          <http://model.geneontology.org/CHEBI_58199_HOMOCYSMET-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_PWY-821-1>
@@ -4252,7 +4335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4263,7 +4346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4281,7 +4364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4297,7 +4380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4322,7 +4405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4332,11 +4415,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4344,26 +4427,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTAGLY-RXN> ;
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY-821-1>
@@ -4371,7 +4452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4382,7 +4463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4390,19 +4471,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMET-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
+          <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -4410,19 +4491,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_CYSTAGLY-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN>
@@ -4434,7 +4515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4442,19 +4523,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4464,7 +4559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4475,29 +4570,15 @@
           <http://model.geneontology.org/HOMOCYSMET-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
-] .
+<http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4508,36 +4589,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
+          <http://model.geneontology.org/8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/CHEBI_58161_CYSTAGLY-RXN>
@@ -4549,7 +4630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4571,7 +4652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4579,19 +4660,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN>
+          <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16134>
@@ -4606,7 +4687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4626,7 +4707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4639,19 +4720,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
@@ -4665,7 +4746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4680,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4693,7 +4774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4701,36 +4782,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_RXN-721_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30089_RXN-721>
+          <http://model.geneontology.org/CHEBI_35235_RXN-721>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1>
@@ -4738,7 +4819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4753,7 +4834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4769,29 +4850,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN>
+          <http://model.geneontology.org/YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
@@ -4803,7 +4882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4818,7 +4897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4845,7 +4924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4859,7 +4938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4875,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4883,21 +4962,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004123>
@@ -4907,20 +4986,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
+          <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN>
@@ -4932,7 +5013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4945,7 +5026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4959,7 +5040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4974,7 +5055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4987,46 +5068,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' 'null' 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-721>
+          <http://model.geneontology.org/CHEBI_35235_CYSTAGLY-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://identifiers.org/sgd/S000003152>
@@ -5041,7 +5120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5055,7 +5134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5068,21 +5147,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
+          <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_null_PWY-821-1>
@@ -5090,9 +5169,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5105,7 +5195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5113,39 +5203,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/5676466b-fbc8-43b5-8d77-c22817978cad_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001926> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -5156,7 +5238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of sulfur amino acid biosynthesis (<i>Saccharomyces cerevisiae</i>) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5169,7 +5251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5180,7 +5262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5188,28 +5270,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_15378_1.8.4.8-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5217,7 +5299,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
+          <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
@@ -5239,7 +5321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5255,27 +5337,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5284,7 +5368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5300,7 +5384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5324,7 +5408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5340,7 +5424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5355,7 +5439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5368,7 +5452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5385,7 +5469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5399,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5407,19 +5491,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1>
@@ -5427,7 +5511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5441,7 +5525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5449,36 +5533,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMET-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTAGLY-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58161_CYSTAGLY-RXN>
+          <http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_null_PWY-821-1>
@@ -5486,7 +5572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5501,7 +5587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5511,6 +5597,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -5531,7 +5639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5539,44 +5647,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_17359_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_17359_SULFITE-REDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5587,7 +5673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5600,7 +5686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5615,7 +5701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5625,11 +5711,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_f05d5bf6-7109-43f8-b651-5263c5c3dff3_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5637,26 +5723,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f05d5bf6-7109-43f8-b651-5263c5c3dff3_RXN3O-22>
+          <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
@@ -5664,7 +5748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5678,11 +5762,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5690,7 +5774,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN>
+          <http://model.geneontology.org/CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-LYASE-RXN>
@@ -5702,7 +5786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5715,7 +5799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5727,7 +5811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5738,29 +5822,12 @@
           <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5768,19 +5835,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1>
@@ -5788,7 +5872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5799,7 +5883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5807,19 +5891,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58161_RXN-721>
+          <http://model.geneontology.org/CHEBI_57716_RXN-721>
 ] .
 
 <http://model.geneontology.org/CHEBI_16134_CYSTAGLY-RXN>
@@ -5831,7 +5915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5846,20 +5930,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/CYSTAGLY-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
@@ -5871,7 +5957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5884,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5902,7 +5988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5915,7 +6001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5926,7 +6012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5939,7 +6025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5952,7 +6038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5964,7 +6050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5987,7 +6073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6010,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6020,19 +6106,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
@@ -6044,7 +6130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6059,7 +6145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6074,7 +6160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6087,36 +6173,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN> ;
+          <http://model.geneontology.org/CYSTAGLY-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/YAL012W-MONOMER_CYSTAGLY-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_537519_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
@@ -6124,7 +6212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6135,7 +6223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6153,7 +6241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6170,7 +6258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6183,19 +6271,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY-821-1>
@@ -6203,7 +6291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6214,7 +6302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6225,7 +6313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6236,29 +6324,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' 'null' '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_null_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
+          <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_null_PWY-821-1>
@@ -6266,27 +6352,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN>
+          <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
@@ -6294,7 +6382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6302,11 +6390,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6314,7 +6402,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
+          <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY-821-1>
@@ -6322,7 +6410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6335,7 +6423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6348,7 +6436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6359,7 +6447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6371,7 +6459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6384,11 +6472,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6396,24 +6484,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57844_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-721> ;
+          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+          <http://model.geneontology.org/YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004414>
@@ -6424,7 +6512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6439,7 +6527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6449,19 +6537,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
@@ -6473,7 +6561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6490,7 +6578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6506,7 +6594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6518,7 +6606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6540,7 +6628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6548,19 +6636,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1>
@@ -6568,7 +6656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6579,7 +6667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-901-PWY-901.ttl
+++ b/models/PWY-901-PWY-901.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methylglyoxal catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-922-PWY-922.ttl
+++ b/models/PWY-922-PWY-922.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1141,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1237,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,7 +1359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1409,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1550,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1659,7 +1659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1706,24 +1706,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922BiochemicalReaction74673> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_null_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_1.1.1.34-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1734,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1742,12 +1731,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_null_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY-922>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1824,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1832,24 +1843,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_15378_1.1.1.34-RXN_SGD_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,7 +1902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1942,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1959,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1996,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2011,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2031,7 +2031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2048,7 +2048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2068,7 +2068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2093,7 +2093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2109,7 +2109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2120,7 +2120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2131,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2143,7 +2143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2177,7 +2177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2207,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2223,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2234,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2266,7 +2266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,7 +2283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2326,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2346,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2359,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2373,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2384,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2399,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2433,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2463,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,7 +2480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2497,7 +2497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2511,7 +2511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2527,7 +2527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2538,7 +2538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2549,7 +2549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2566,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,7 +2601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,7 +2621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2639,7 +2639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2658,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,6 +2685,25 @@
           <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-922> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
@@ -2696,7 +2715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2704,31 +2723,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-922> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
-] .
-
 <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_null_PWY-922>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2742,7 +2742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2757,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY0-162-PWY0-162.ttl
+++ b/models/PWY0-162-PWY0-162.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_RXN-9929>
+          <http://model.geneontology.org/PWY0-162/PWY0-162>
 ] .
 
 <http://identifiers.org/sgd/S000001507>
@@ -20,19 +20,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003666>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,22 +124,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
@@ -151,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,19 +159,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY0-162/PWY0-162>
+          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -189,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,19 +197,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY0-162/PWY0-162>
+          <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
@@ -223,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,19 +237,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN-12002>
+          <http://model.geneontology.org/CHEBI_30616_RXN-12002>
 ] .
 
 <http://model.geneontology.org/PWY0-162/PWY0-162>
@@ -261,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -278,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -308,19 +306,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY0-162>
@@ -328,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,19 +352,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY0-162/PWY0-162>
+          <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY0-162>
@@ -374,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -385,27 +383,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30031>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,22 +558,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-12002>
+          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_RXN-9929_SGD_PWY0-162>
@@ -581,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,19 +615,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30839>
@@ -640,27 +638,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_RXN-9929_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_RXN-9929>
+          <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,19 +682,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -703,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,6 +716,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY0-162> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -732,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,41 +758,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/OROTPDECARB-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -786,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -881,19 +894,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_RXN-12002>
+          <http://model.geneontology.org/CHEBI_57865_RXN-12002>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY0-162>
@@ -901,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -920,19 +933,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY0-162/PWY0-162>
+          <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PWY0-162>
@@ -940,29 +953,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002411_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY0-162>
@@ -970,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1010,11 +1030,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1025,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1033,24 +1056,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
@@ -1060,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1074,7 +1094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,19 +1107,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
+          <http://model.geneontology.org/PWY0-162/PWY0-162>
 ] .
 
 <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
@@ -1107,19 +1127,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
@@ -1129,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1145,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1188,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1205,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1222,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1235,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1246,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1254,19 +1274,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY0-162/PWY0-162>
+          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
@@ -1278,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,7 +1312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,11 +1325,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,7 +1337,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
@@ -1328,7 +1348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1373,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1397,19 +1417,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_RXN-9929>
+          <http://model.geneontology.org/CHEBI_29806_RXN-9929>
 ] .
 
 <http://model.geneontology.org/RXN-9929>
@@ -1431,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1471,19 +1491,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_RXN-9929_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9929>
+          <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
@@ -1495,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1512,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1543,15 +1563,48 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_null_PWY0-162> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CTPSYN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1566,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1576,36 +1629,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
+          <http://model.geneontology.org/PWY0-162/PWY0-162>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
+          <http://model.geneontology.org/PWY0-162/PWY0-162>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY0-162>
@@ -1613,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1628,7 +1681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1666,19 +1719,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
+          <http://model.geneontology.org/CHEBI_456216_RXN-12002>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PWY0-162>
@@ -1686,7 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1697,29 +1750,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
@@ -1729,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1742,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1760,13 +1811,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162SmallMolecule61484> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004127>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000747> ;
@@ -1775,16 +1829,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162Protein61642> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0004127>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
@@ -1795,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1826,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1842,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1853,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1866,7 +1917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1883,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,37 +1943,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
+          <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29806_RXN-9929>
@@ -1934,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1947,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1959,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1975,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1986,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1997,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2034,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2045,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2053,21 +2106,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-12002>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2076,7 +2129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2092,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2100,11 +2153,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2112,7 +2165,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2137,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2152,10 +2205,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "carbamoyl phosphate synthetase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component> , <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2165,19 +2220,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_RXN-9929_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_RXN-9929>
+          <http://model.geneontology.org/CHEBI_30864_RXN-9929>
 ] .
 
 <http://identifiers.org/sgd/S000004574>
@@ -2192,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2202,19 +2257,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY0-162/PWY0-162>
+          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_32814>
@@ -2226,7 +2281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2236,6 +2291,15 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-12002>
         a       <http://purl.obolibrary.org/obo/GO_0004127> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2256,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2273,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2286,47 +2350,51 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
+          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
+          <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_null_PWY0-162>
@@ -2334,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2349,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2363,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2383,7 +2451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2396,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2407,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2432,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2441,22 +2509,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58223_RXN-12002>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY0-162>
@@ -2464,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2475,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2483,19 +2549,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/PWY0-162/PWY0-162>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY0-162>
@@ -2503,7 +2569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2521,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2531,19 +2597,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY0-162/PWY0-162>
+          <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
 ] .
 
 <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
@@ -2554,7 +2620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2569,7 +2635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2582,27 +2648,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -2614,7 +2682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2630,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2641,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2649,19 +2717,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY0-162>
@@ -2669,7 +2737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2683,19 +2751,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
@@ -2710,7 +2778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2724,7 +2792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2738,12 +2806,15 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2758,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2774,19 +2845,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN-12002>
+          <http://model.geneontology.org/PWY0-162/PWY0-162>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_null_PWY0-162>
@@ -2794,7 +2865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2805,7 +2876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2813,11 +2884,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,7 +2896,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY0-162>
@@ -2833,7 +2904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2848,7 +2919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of pyrimidine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2861,7 +2932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2876,13 +2947,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162SmallMolecule61469> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000135> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2891,7 +2965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2901,19 +2975,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
+          <http://model.geneontology.org/CHEBI_30031_RXN-9929>
 ] .
 
 <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PWY0-162>
@@ -2921,29 +2995,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_RXN-9929_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9929>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY0-162>
@@ -2951,7 +3023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2966,7 +3038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,7 +3052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2996,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3009,7 +3081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,7 +3098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3039,7 +3111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3047,19 +3119,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
@@ -3071,7 +3143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3081,11 +3153,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3093,7 +3165,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PWY0-162>
@@ -3101,7 +3173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3113,7 +3185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3135,7 +3207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3146,7 +3218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3157,21 +3229,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_null_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9929> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
+          <http://model.geneontology.org/UDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
@@ -3183,7 +3255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3196,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3207,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3215,19 +3287,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
 ] .
 
 <http://model.geneontology.org/UDPKIN-RXN>
@@ -3247,7 +3319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3277,7 +3349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3297,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3307,19 +3379,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/UDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY0-162>
@@ -3327,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3338,7 +3410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3349,35 +3421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PWY0-162> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROTPDECARB-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3385,6 +3429,34 @@
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY0-162> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_46398>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3397,7 +3469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3416,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3427,7 +3499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3441,7 +3513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3455,27 +3527,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_RXN-12002>
+          <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY0-162>
@@ -3483,7 +3557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3494,7 +3568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3505,7 +3579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3513,27 +3587,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3550,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3558,19 +3643,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002411_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_30839_RXN-9929>
 ] .
 
 <http://identifiers.org/sgd/S000001699>
@@ -3587,7 +3672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3598,19 +3683,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/PWY0-162/PWY0-162>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_PWY0-162/PWY0-162_SGD_PWY0-162>
@@ -3618,7 +3703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3630,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3646,19 +3731,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PWY0-162>
@@ -3666,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3674,11 +3759,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3686,7 +3771,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
@@ -3698,7 +3783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3715,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3728,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3739,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3747,19 +3832,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -3771,7 +3856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3787,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3795,19 +3880,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000747>
@@ -3822,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY0-662-PWY0-662.ttl
+++ b/models/PWY0-662-PWY0-662.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -154,13 +154,39 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/YOL061W-MONOMER_PRPPSYN-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005422> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphoribosylpyrophosphate synthetase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-662Protein31765> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,38 +197,12 @@
           <http://model.geneontology.org/CHEBI_78346_PRPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY0-662>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YOL061W-MONOMER_PRPPSYN-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005422> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphoribosylpyrophosphate synthetase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-662Protein31765> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY0-662>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "PRPP biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-0-PWY3O-0.ttl
+++ b/models/PWY3O-0-PWY3O-0.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,6 +427,9 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/CHEBI_57579>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/RXN-14812>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -442,16 +445,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-0BiochemicalReaction26679> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57579>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YFR053C-MONOMER_RXN3O-9790_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001949> ;
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fructose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-1-PWY3O-1.ttl
+++ b/models/PWY3O-1-PWY3O-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -862,7 +862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1043,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,13 +1121,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000002397>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1145,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1234,7 +1237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1268,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,17 +1317,6 @@
           <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456215_ADENPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1334,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,13 +1334,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_PWY3O-1/PWY3O-1_SGD_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1364,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1417,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1432,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1471,24 +1474,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_PWY3O-1/PWY3O-1_SGD_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_17368_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,12 +1491,23 @@
           <http://model.geneontology.org/CHEBI_17368_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_PWY3O-1/PWY3O-1_SGD_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1516,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1576,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1598,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1624,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1651,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1676,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1694,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1725,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1738,7 +1741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1761,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1803,7 +1806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1840,7 +1843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1874,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,7 +1894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,13 +1906,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002397> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanine deaminase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1925,7 +1928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1945,7 +1948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1956,16 +1959,13 @@
           <http://model.geneontology.org/CHEBI_15378_AMP-DEAMINASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_PWY3O-1/PWY3O-1_SGD_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,7 +1988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2057,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2068,7 +2068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2079,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2128,7 +2128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2162,7 +2162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2190,7 +2190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2206,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2240,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2265,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2288,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,7 +2302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,7 +2347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2367,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2414,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2435,7 +2435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,7 +2486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2506,7 +2506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2540,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2571,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2587,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2599,7 +2599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2619,7 +2619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2635,7 +2635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2651,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2662,7 +2662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2673,7 +2673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2684,7 +2684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2696,7 +2696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2712,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2723,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2738,7 +2738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of purines and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2751,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2763,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2782,7 +2782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2799,7 +2799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2813,19 +2813,19 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_PWY3O-1/PWY3O-1_SGD_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002849> ;
@@ -2834,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2847,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2860,7 +2860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2880,7 +2880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2893,7 +2893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2908,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2939,7 +2939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2956,7 +2956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2986,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3000,7 +3000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3020,7 +3020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3040,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3057,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3072,7 +3072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3086,7 +3086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3106,7 +3106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3123,7 +3123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3142,7 +3142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3158,7 +3158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3169,7 +3169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3182,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3202,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3218,7 +3218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,7 +3260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3295,7 +3295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3317,7 +3317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3358,7 +3358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3369,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3383,7 +3383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-10-PWY3O-10.ttl
+++ b/models/PWY3O-10-PWY3O-10.ttl
@@ -1,37 +1,35 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-10> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9515> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
+          <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY3O-10>
@@ -39,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,6 +59,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000005299>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -73,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -81,36 +82,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
+          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_15378_RXN-9514_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_58349_RXN-9514_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9514>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9514>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -121,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -168,15 +169,12 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004321>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -185,12 +183,31 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_null_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9515>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_null_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -198,11 +215,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_RXN-9515_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +227,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Crotonyl-ACPs_RXN-9515>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
 ] .
 
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-10>
@@ -218,29 +235,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+          <http://model.geneontology.org/CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -254,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,15 +394,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -399,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -407,19 +422,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
+          <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-10>
@@ -427,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -438,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -480,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -512,39 +527,39 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_57783_RXN-9514_SGD_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_null_PWY3O-10> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.2.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9514>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -556,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -590,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -643,32 +658,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9515> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -687,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,7 +716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -736,40 +751,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_58349_RXN-9514_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9514>
+          <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -779,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,23 +818,12 @@
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -824,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,22 +870,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9515>
+          <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005747>
@@ -876,19 +891,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
+          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-10>
@@ -896,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,12 +951,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
+        a       <http://identifiers.org/sgd/S000005299> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,12 +1003,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -992,44 +1033,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-10> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
-] .
+<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1044,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,15 +1115,21 @@
           <http://model.geneontology.org/CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004314>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://identifiers.org/sgd/S000004820>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1096,30 +1137,30 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9514>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_57783_RXN-9514_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,7 +1168,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9514>
+          <http://model.geneontology.org/ACP_RXN-9514>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003989>
@@ -1140,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,7 +1207,7 @@
 ] .
 
 <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004314> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1184,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1197,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1208,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1301,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1312,19 +1353,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9515>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN>
@@ -1336,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1346,19 +1387,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10>
@@ -1366,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1428,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1436,38 +1477,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1482,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1516,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1529,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1540,29 +1581,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
+          <http://model.geneontology.org/ACP_4.2.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "biotin carboxylase / acetyl-CoA carboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1579,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1603,19 +1646,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
+          <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
+          <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1624,7 +1667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,7 +1679,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9514>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1654,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1667,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1675,19 +1718,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+          <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9515>
 ] .
 
 <http://model.geneontology.org/YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller>
@@ -1697,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1710,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1718,19 +1761,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
@@ -1745,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,23 +1799,23 @@
           <http://model.geneontology.org/CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_null_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1789,14 +1832,17 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/4.2.1.58-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1814,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1823,38 +1869,33 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9514>
+          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
 ] .
-
-<http://purl.obolibrary.org/obo/GO_0008659>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1867,7 +1908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1888,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1899,6 +1940,23 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
+] .
+
 <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1908,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1917,20 +1975,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9515>
+          <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_RXN-9515_SGD_PWY3O-10>
@@ -1938,7 +1998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1946,19 +2006,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+          <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
+          <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1967,7 +2027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1983,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1998,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2011,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2026,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2034,12 +2094,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2065,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2074,42 +2137,42 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000006152>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN>
@@ -2121,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2138,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2152,7 +2215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2181,10 +2244,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetyl-coenzyme A carboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2197,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2205,36 +2270,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_4.2.1.58-RXN>
+          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_15378_RXN-9514_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9514>
 ] .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
@@ -2256,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2270,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2302,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2318,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2336,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2353,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2368,7 +2433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2385,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2395,39 +2460,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_RXN-9515_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9515>
+          <http://model.geneontology.org/Crotonyl-ACPs_RXN-9515>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17544>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2436,7 +2503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2447,12 +2514,21 @@
           <http://model.geneontology.org/CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004820> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2538,7 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acyl-carrier protein + acetyl-CoA &rarr; an acetyl-[acp] + coenzyme A" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2480,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2488,21 +2564,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-10>
@@ -2510,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2521,19 +2608,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_PWY3O-10/PWY3O-10_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN-9514>
+          <http://model.geneontology.org/PWY3O-10/PWY3O-10>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2542,7 +2629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2562,7 +2649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2579,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid biosynthesis, initial steps - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2596,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2609,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2617,19 +2704,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY3O-10>
@@ -2637,7 +2724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2645,21 +2732,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_null_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_null_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
+          <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
+          <http://model.geneontology.org/4.2.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2668,7 +2755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2680,7 +2767,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9515>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2696,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2716,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2729,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2740,7 +2827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2751,7 +2838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-103-PWY3O-103.ttl
+++ b/models/PWY3O-103-PWY3O-103.ttl
@@ -1,21 +1,10 @@
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_32b2a94f-8b58-43ba-a2a5-82696db683d3_CDPDIGLYSYN-RXN_SGD_PWY3O-103>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,30 +60,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103Protein70462> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/32b2a94f-8b58-43ba-a2a5-82696db683d3_CDPDIGLYSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -110,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,13 +181,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/32b2a94f-8b58-43ba-a2a5-82696db683d3_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -240,13 +212,30 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,12 +246,23 @@
           <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN_SGD_PWY3O-103>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY3O-103>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,11 +335,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_32b2a94f-8b58-43ba-a2a5-82696db683d3_CDPDIGLYSYN-RXN_SGD_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN_SGD_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/32b2a94f-8b58-43ba-a2a5-82696db683d3_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "CDP-diacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-1109-PWY3O-1109.ttl
+++ b/models/PWY3O-1109-PWY3O-1109.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-hydroxybenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -952,7 +952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,7 +1082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1370,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1618,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1658,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,7 +1677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1691,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1784,7 +1784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1821,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1834,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1857,7 +1857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,7 +1891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1919,7 +1919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1969,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1983,7 +1983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +2013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2063,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2074,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2103,7 +2103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,7 +2120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2139,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2151,7 +2151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2201,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2223,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2234,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2274,7 +2274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2293,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2304,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-114-PWY3O-114.ttl
+++ b/models/PWY3O-114-PWY3O-114.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61694_RXN-6601>
+          <http://model.geneontology.org/CHEBI_83813_RXN-6601>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -20,11 +20,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +32,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_61694_RXN-6622>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -105,36 +105,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6622_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6622> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35235_RXN-6622>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6622> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61694_RXN-6622>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_null_PWY3O-114> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/reaction_GLUTCYSLIG-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004363>
@@ -144,10 +146,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "DUG1" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,23 +185,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000001940>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/YJL101C-MONOMER_GLUTCYSLIG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57305_GLUTATHIONE-SYN-RXN>
@@ -209,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,22 +226,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -251,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -281,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,23 +326,32 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-6622>
+          <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601_SGD_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_35235_RXN-6622>
         a       <http://purl.obolibrary.org/obo/CHEBI_35235> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -350,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,29 +390,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' 'null' 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002413_GLUTCYSLIG-RXN_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-6622_location_lociGO_0005829>
@@ -411,19 +421,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/CHEBI_35235_GLUTCYSLIG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -439,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -452,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,27 +500,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_null_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57925_RXN-6601>
+          <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -518,11 +530,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +542,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58173_GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_GLUTATHIONE-SYN-RXN>
@@ -542,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,37 +616,41 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_null_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-6622>
+          <http://model.geneontology.org/reaction_RXN-6622_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002413_RXN-6601_null_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
+          <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
+          <http://model.geneontology.org/RXN-6601>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
@@ -649,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,11 +675,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +687,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58173_GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GLUTCYSLIG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_35235>
@@ -689,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -699,11 +715,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_85ab22aa-ad63-4e34-9b77-7f228c6600cf_RXN-6601_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,16 +727,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/85ab22aa-ad63-4e34-9b77-7f228c6600cf_RXN-6601>
+          <http://model.geneontology.org/CHEBI_61694_RXN-6601>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +744,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -739,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -775,11 +791,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,16 +803,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_RXN-6622>
+          <http://model.geneontology.org/CHEBI_35235_RXN-6622>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,8 +820,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/CHEBI_29985_GLUTCYSLIG-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -818,33 +837,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_null_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6601> ;
+          <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
+          <http://model.geneontology.org/GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114>
@@ -852,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -867,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -876,20 +905,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_null_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
@@ -904,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -928,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -939,44 +970,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_null_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6622> ;
+          <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
+          <http://model.geneontology.org/RXN-6622>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -987,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1008,12 +1041,31 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' 'null' 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002413_GLUTCYSLIG-RXN_null_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6622> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUTCYSLIG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1073,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWY3O-114>
@@ -1029,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1040,28 +1092,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/85ab22aa-ad63-4e34-9b77-7f228c6600cf_RXN-6601>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58173>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1075,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,11 +1120,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,24 +1132,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_83813_RXN-6601>
+          <http://model.geneontology.org/CHEBI_57925_RXN-6601>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_58173_GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_83813>
@@ -1135,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1193,11 +1228,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6622_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,26 +1240,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61694_RXN-6622>
+          <http://model.geneontology.org/CHEBI_15377_RXN-6622>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLUTCYSLIG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
 ] .
 
 <http://model.geneontology.org/PWY3O-114>
@@ -1236,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutathione metabolism (truncated &gamma;-glutamyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,7 +1316,7 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/RXN-6601>
-        a       <http://purl.obolibrary.org/obo/GO_0036374> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1293,7 +1326,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57925_RXN-6601> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/85ab22aa-ad63-4e34-9b77-7f228c6600cf_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
+                <http://model.geneontology.org/CHEBI_61694_RXN-6601> , <http://model.geneontology.org/cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1301,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1325,44 +1358,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL101C-MONOMER_GLUTCYSLIG-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58173_GLUTCYSLIG-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component>
+        a       <http://identifiers.org/sgd/S000001940> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
+          <http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_null_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1377,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1387,28 +1432,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
+          <http://model.geneontology.org/cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1461,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004357>
@@ -1427,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1438,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1449,28 +1494,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller>
+          <http://model.geneontology.org/CHEBI_57305_RXN-6622>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,7 +1523,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35235_GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GLUTCYSLIG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -1489,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1506,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1522,22 +1567,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
 ] .
 
 <http://model.geneontology.org/GLUTCYSLIG-RXN>
@@ -1559,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,13 +1610,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1641,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLUTATHIONE-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GLUTATHIONE-SYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114>
@@ -1589,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1611,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1626,7 +1686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,52 +1695,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_PWY3O-114/PWY3O-114_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6622_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-114/PWY3O-114>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_85ab22aa-ad63-4e34-9b77-7f228c6600cf_RXN-6601_SGD_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002413_RXN-6601_null_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-6601>
+          <http://model.geneontology.org/YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_GLUTCYSLIG-RXN_location_lociGO_0005829>
@@ -1695,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1708,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1730,11 +1775,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1787,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUTCYSLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GLUTCYSLIG-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GLUTCYSLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002413_RXN-6601_null_PWY3O-114>
@@ -1750,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1761,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1772,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1783,11 +1828,8 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0036374>
-        a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/PWY3O-123-PWY3O-123.ttl
+++ b/models/PWY3O-123-PWY3O-123.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,30 +53,13 @@
           <http://model.geneontology.org/PHOSMANMUT-RXN>
 ] .
 
-<http://model.geneontology.org/a4cd2b77-6d9f-41d8-b4ff-75d4c9449da7_2.4.1.83-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58409_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -337,11 +320,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_a4cd2b77-6d9f-41d8-b4ff-75d4c9449da7_2.4.1.83-RXN_SGD_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN_SGD_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,7 +332,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.83-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a4cd2b77-6d9f-41d8-b4ff-75d4c9449da7_2.4.1.83-RXN>
+          <http://model.geneontology.org/c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
@@ -373,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -406,13 +389,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16214_2.4.1.83-RXN> , <http://model.geneontology.org/CHEBI_57527_2.4.1.83-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a4cd2b77-6d9f-41d8-b4ff-75d4c9449da7_2.4.1.83-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> ;
+                <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> , <http://model.geneontology.org/c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR183W-MONOMER_2.4.1.83-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -449,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -480,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,17 +688,6 @@
 <http://model.geneontology.org/reaction_MANNPISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_a4cd2b77-6d9f-41d8-b4ff-75d4c9449da7_2.4.1.83-RXN_SGD_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -725,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -783,17 +755,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004582>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_MANNPGUANYLTRANGDP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
@@ -804,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,13 +773,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_48066_MANNPISOM-RXN_SGD_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,6 +904,23 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_43474_MANNPGUANYLTRANGDP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -941,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,23 +1029,23 @@
 <http://identifiers.org/sgd/S000001849>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58189_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1152,6 +1141,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN_SGD_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1277,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl phosphate D-mannose biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1292,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,7 +1306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-13-PWY3O-13.ttl
+++ b/models/PWY3O-13-PWY3O-13.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutamate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1510,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1524,7 +1524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1585,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1654,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1670,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1682,7 +1682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1776,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1869,7 +1869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,7 +1918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1938,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1972,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1992,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-15-PWY3O-15.ttl
+++ b/models/PWY3O-15-PWY3O-15.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -19,7 +19,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-1565-PWY3O-1565.ttl
+++ b/models/PWY3O-1565-PWY3O-1565.ttl
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -499,11 +499,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphoglucomutase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1565Protein28785> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -511,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,21 +536,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16214_2.4.1.117-RXN>
 ] .
-
-<http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphoglucomutase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1565Protein28785> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/GLUC1PURIDYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003983> ;
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl glucosyl phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -951,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1018,17 +1018,6 @@
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_null_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58601_PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58601> ;
@@ -1039,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,13 +1036,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_null_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1148,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-17-PWY3O-17.ttl
+++ b/models/PWY3O-17-PWY3O-17.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_15377_RXNQT-4301_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/RXNQT-4191> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXNQT-4301>
+          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -45,29 +45,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CPLX3O-362_RXN3O-401_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-362_RXN3O-401>
+          <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CPLX3O-9180_THI-P-SYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "TMP diphosphorylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000006135_CPLX3O-9180_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,19 +79,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_58354_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-80_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58354_OHMETPYRKIN-RXN>
+          <http://model.geneontology.org/SGD_S000005416_CPLX3O-80_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_58354_OHMETPYRKIN-RXN>
@@ -101,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -151,11 +153,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -166,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,18 +198,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000006179>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_15378_OHMETPYRKIN-RXN_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,30 +239,47 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000066_reaction_RXNQT-4301_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THI-P-SYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_RXNQT-4301_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004789>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_139151_RXN3O-401_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-401> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_139151_RXN3O-401>
+] .
 
 <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_456216_OHMETPYRKIN-RXN_SGD_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -248,37 +287,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002234_CHEBI_16892_RXN3O-9804_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9804> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16892_RXN3O-9804>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_58354_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58354_PYRIMSYN3-RXN>
+          <http://model.geneontology.org/CHEBI_30616_OHMETPYRKIN-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003376> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58937>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -288,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -301,10 +332,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "Thi4" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,33 +351,91 @@
 <http://purl.obolibrary.org/obo/CHEBI_18385>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9804> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57595_RXN3O-9804>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CPLX3O-362_RXN3O-401_SGD_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' 'null' '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002413_THI-P-SYN-RXN_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+          <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+          <http://model.geneontology.org/THI-P-SYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_null_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CPLX3O-10511_RXN3O-401>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Thi4" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17Complex68916> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
 
 <http://model.geneontology.org/CHEBI_29888_THI-P-SYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -355,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,94 +454,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CPLX3O-10511_RXN3O-401>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Thi4" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17Complex68916> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_null_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXNQT-4191>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_37575_RXNQT-4191_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57305_RXN3O-401_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000066_reaction_PYRIMSYN3-RXN_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_RXN3O-401>
+          <http://model.geneontology.org/reaction_PYRIMSYN3-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,22 +530,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000066_reaction_OHMETPYRKIN-RXN_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-10511_RXN3O-401_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OHMETPYRKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component>
 ] .
 
 <http://model.geneontology.org/reaction_PYRIMSYN3-RXN_location_lociGO_0005829>
@@ -521,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -571,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -579,11 +616,116 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_456215_RXNQT-4301_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002333_CPLX3O-9180_THI-P-SYN-RXN_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-9180_THI-P-SYN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_37575_RXNQT-4191_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXNQT-4191> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37575_RXNQT-4191>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-401> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+] .
+
+<http://model.geneontology.org/SGD_S000005669_CPLX3O-25_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005669> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_456215>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-82_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXNQT-4301_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_15378_RXNQT-4301_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,101 +733,48 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_RXNQT-4301>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Entity Regulation Rule 3. The relation 'thiazole synthase + glycine + NAD<sup>+</sup> &rarr; ADP-5-ethyl-4-methylthiazole-2-carboxylate + nicotinamide + thiazole synthase - dehydroalanine<sub>205</sub>' 'null' 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is the enabler of reaction 2." ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_null_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002629> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXNQT-4301>
-] .
-
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456215>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/reaction_RXNQT-4301_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_58296_THI-P-SYN-RXN_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58296_THI-P-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RXNQT-4301>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002333_CPLX3O-10511_RXN3O-401_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
-] .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller>
+          <http://model.geneontology.org/CPLX3O-10511_RXN3O-401_controller>
 ] .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_58354_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58354_OHMETPYRKIN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/OHMETPYRKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -706,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +808,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-82_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -732,10 +832,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "THI21" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000006179_CPLX3O-82_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -748,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -767,38 +869,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_15378_THI-P-SYN-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_THI-P-SYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000066_reaction_RXNQT-4301_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/RXN3O-9804> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXNQT-4301_location_lociGO_0005829>
+          <http://model.geneontology.org/MONOMER3O-9145_RXN3O-9804_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_30616_PYRIMSYN3-RXN_SGD_PWY3O-17>
@@ -806,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -814,19 +914,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_139151_RXN3O-401_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_139151_RXN3O-401>
+          <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -834,29 +934,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_15378_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-362_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-362_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-362_RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_OHMETPYRKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003376_CPLX3O-362_component>
 ] .
 
 <http://model.geneontology.org/CPLX3O-362_RXN3O-401>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "thiazole synthase - dehydroalanine<sub>205</sub>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003376_CPLX3O-362_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -880,40 +982,59 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' 'null' '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002413_THI-P-SYN-RXN_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'thiamine phosphate + H<sub>2</sub>O &rarr; thiamine + phosphate' 'null' 'thiamine + ATP &rarr; thiamine diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002413_THIAMIN-PYROPHOSPHOKINASE-RXN_null_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/RXNQT-4191> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THI-P-SYN-RXN>
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_58296_THI-P-SYN-RXN_SGD_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -921,38 +1042,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57540_RXN3O-401_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9804> ;
+          <http://model.geneontology.org/RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57595_RXN3O-9804>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-401>
 ] .
+
+<http://identifiers.org/sgd/S000006135>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000066_reaction_PYRIMSYN3-RXN_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000066_reaction_OHMETPYRKIN-RXN_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PYRIMSYN3-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_OHMETPYRKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/RXN3O-401>
@@ -976,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1003,19 +1127,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002333_CPLX3O-9180_THI-P-SYN-RXN_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_58296_RXNQT-4301_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-9180_THI-P-SYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58296_RXNQT-4301>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_OHMETPYRKIN-RXN>
@@ -1027,13 +1151,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69055> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9804> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+] .
 
 <http://model.geneontology.org/CHEBI_456215_RXNQT-4301>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456215> ;
@@ -1044,30 +1185,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69017> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_37575_RXNQT-4191_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37575_RXNQT-4191>
-] .
 
 <http://model.geneontology.org/CHEBI_58354_PYRIMSYN3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58354> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1078,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,20 +1211,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 4-amino-2-methyl-5-pyrimidinemethanol &rarr; ADP + 4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + H<SUP>+</SUP>' 'null' '4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + ATP &rarr; 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002413_PYRIMSYN3-RXN_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+          <http://model.geneontology.org/PYRIMSYN3-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_18385_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17>
@@ -1108,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1118,10 +1244,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "THI21" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000006179_CPLX3O-82_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1209,39 +1337,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN>
+          <http://model.geneontology.org/CHEBI_29888_THI-P-SYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002629>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_15378_RXNQT-4301_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/RXNQT-4191> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXNQT-4301>
+          <http://model.geneontology.org/reaction_RXNQT-4191_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58296>
@@ -1249,36 +1379,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002333_CPLX3O-10511_RXN3O-401_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-10511_RXN3O-401_controller>
+          <http://model.geneontology.org/CPLX3O-82_PYRIMSYN3-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-80_OHMETPYRKIN-RXN_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-82_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-82_OHMETPYRKIN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-80_OHMETPYRKIN-RXN_controller>
+          <http://model.geneontology.org/SGD_S000006179_CPLX3O-82_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57595>
@@ -1292,27 +1422,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_15378_THI-P-SYN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_THI-P-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1320,35 +1450,65 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_139151_RXNQT-4301_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9804> ;
+          <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-9145_RXN3O-9804_controller>
+          <http://model.geneontology.org/CHEBI_139151_RXNQT-4301>
 ] .
 
 <http://model.geneontology.org/CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "thiamin pyrophosphokinase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005669_CPLX3O-25_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17Complex69113> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-401> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17154_RXN3O-401>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16892_RXN3O-9804>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16892> ;
@@ -1359,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1369,19 +1529,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_15378_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN>
+          <http://model.geneontology.org/CHEBI_15378_OHMETPYRKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-82_OHMETPYRKIN-RXN_controller_SGD_PWY3O-17>
@@ -1389,7 +1549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1451,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1466,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,82 +1634,125 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000005416>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-80_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'thiamine phosphate + H<sub>2</sub>O &rarr; thiamine + phosphate' 'null' 'thiamine + ATP &rarr; thiamine diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002413_THIAMIN-PYROPHOSPHOKINASE-RXN_null_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_BFO_0000051_SGD_S000005669_CPLX3O-25_component_SGD_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57540_RXN3O-401_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_597326_RXN3O-9804_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/RXN3O-9804> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-401>
+          <http://model.geneontology.org/CHEBI_597326_RXN3O-9804>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_16892_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_30616_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16892_OHMETPYRKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_PYRIMSYN3-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-80_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXNQT-4301_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-10511_RXNQT-4301_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_37575_THI-P-SYN-RXN>
@@ -1561,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1577,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1588,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1599,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1610,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1635,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1652,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1663,32 +1866,60 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' 'null' 'thiamine phosphate + H<sub>2</sub>O &rarr; thiamine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002413_RXNQT-4191_null_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXNQT-4191>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000005416_CPLX3O-80_component>
+        a       <http://identifiers.org/sgd/S000005416> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_58296_RXNQT-4301_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_18385_RXNQT-4191_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/RXNQT-4191> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58296_RXNQT-4301>
+          <http://model.geneontology.org/CHEBI_18385_RXNQT-4191>
 ] .
 
 <http://model.geneontology.org/CHEBI_18385_THIAMIN-PYROPHOSPHOKINASE-RXN>
@@ -1700,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,20 +1940,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000066_reaction_RXN3O-401_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9804> ;
+          <http://model.geneontology.org/RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+          <http://model.geneontology.org/reaction_RXN3O-401_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000066_reaction_PYRIMSYN3-RXN_location_lociGO_0005829_null_PWY3O-17>
@@ -1730,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1739,26 +1972,21 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 4-amino-2-methyl-5-pyrimidinemethanol &rarr; ADP + 4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + H<SUP>+</SUP>' 'null' '4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + ATP &rarr; 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002413_PYRIMSYN3-RXN_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-9180_THI-P-SYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMSYN3-RXN>
+          <http://model.geneontology.org/SGD_S000006135_CPLX3O-9180_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_58354_PYRIMSYN3-RXN_SGD_PWY3O-17>
@@ -1766,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1802,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1834,13 +2062,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69106> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000002403>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PYRIMSYN3-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1853,7 +2084,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58354_PYRIMSYN3-RXN> , <http://model.geneontology.org/CHEBI_30616_PYRIMSYN3-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN> , <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN> ;
+                <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN> , <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-82_PYRIMSYN3-RXN_controller> , <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1861,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1878,7 +2109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1886,24 +2117,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002333_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller>
+] .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_THI-P-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXNQT-4301>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN>
@@ -1915,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1927,10 +2175,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "Thi4" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1940,21 +2190,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'thiazole synthase + glycine + NAD<sup>+</sup> &rarr; ADP-5-ethyl-4-methylthiazole-2-carboxylate + nicotinamide + thiazole synthase - dehydroalanine<sub>205</sub>' 'null' 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
+          <http://model.geneontology.org/RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXNQT-4191_location_lociGO_0005829>
+          <http://model.geneontology.org/RXNQT-4301>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17>
@@ -1962,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1973,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1981,27 +2231,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-80_OHMETPYRKIN-RXN_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-82_PYRIMSYN3-RXN_controller>
+          <http://model.geneontology.org/CPLX3O-80_OHMETPYRKIN-RXN_controller>
 ] .
+
+<http://model.geneontology.org/SGD_S000006135_CPLX3O-9180_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006135> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2019,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thiamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2027,36 +2286,55 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_null_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_THI-P-SYN-RXN_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57841_THI-P-SYN-RXN>
+] .
+
 <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "THI20" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005416_CPLX3O-80_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,37 +2343,22 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'pyridoxal 5'-phosphate + L-histidine &rarr; 4-amino-2-methyl-5-pyrimidinemethanol' 'null' 'ATP + 4-amino-2-methyl-5-pyrimidinemethanol &rarr; ADP + 4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-9804> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_139151_RXNQT-4301_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_139151_RXNQT-4301>
+          <http://model.geneontology.org/OHMETPYRKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_RXNQT-4191>
@@ -2107,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,19 +2380,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17154_RXN3O-401>
+          <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-9804_location_lociGO_0005829>
@@ -2140,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2155,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2165,19 +2428,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_456216_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-80_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-80_OHMETPYRKIN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_OHMETPYRKIN-RXN>
+          <http://model.geneontology.org/SGD_S000005416_CPLX3O-80_component>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -2185,6 +2448,15 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000003376_CPLX3O-362_component>
+        a       <http://identifiers.org/sgd/S000003376> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004788> ;
@@ -2203,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2230,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2238,35 +2510,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0004788>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_18385_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+          <http://model.geneontology.org/CHEBI_18385_THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_null_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2274,36 +2543,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_597326_RXN3O-9804_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXNQT-4301> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9804> ;
+          <http://model.geneontology.org/RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_597326_RXN3O-9804>
+          <http://model.geneontology.org/CPLX3O-10511_RXN3O-401>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_30616_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_16892_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PYRIMSYN3-RXN>
+          <http://model.geneontology.org/CHEBI_16892_OHMETPYRKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_16892_OHMETPYRKIN-RXN_SGD_PWY3O-17>
@@ -2311,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2325,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2357,13 +2646,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule68903> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000005669>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57305_RXN3O-401>
         a       <http://purl.obolibrary.org/obo/CHEBI_57305> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2374,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2387,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2401,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2412,65 +2715,63 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' 'null' 'thiamine phosphate + H<sub>2</sub>O &rarr; thiamine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002413_RXNQT-4191_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002333_CPLX3O-10511_RXNQT-4301_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXNQT-4191>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_18385_RXNQT-4191_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18385_RXNQT-4191>
+          <http://model.geneontology.org/CPLX3O-10511_RXNQT-4301_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000066_reaction_RXN3O-401_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000066_reaction_RXN3O-9804_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/RXN3O-9804> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-401_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_RXN3O-9804_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57305_RXN3O-401_SGD_PWY3O-17>
@@ -2478,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2486,20 +2787,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-10511_RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+          <http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-362_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-362_component_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXNQT-4191>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2518,7 +2830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2531,11 +2843,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_THI-P-SYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -2549,7 +2864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2559,125 +2874,140 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002333_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXNQT-4301>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'thiazole synthase + glycine + NAD<sup>+</sup> &rarr; ADP-5-ethyl-4-methylthiazole-2-carboxylate + nicotinamide + thiazole synthase - dehydroalanine<sub>205</sub>' 'null' 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_null_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXNQT-4301>
+          <http://model.geneontology.org/CHEBI_37575_THI-P-SYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-82_OHMETPYRKIN-RXN_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_15377_RXNQT-4191_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-82_OHMETPYRKIN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_THI-P-SYN-RXN_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/RXNQT-4191> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57841_THI-P-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_RXNQT-4191>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'pyridoxal 5'-phosphate + L-histidine &rarr; 4-amino-2-methyl-5-pyrimidinemethanol' 'null' 'ATP + 4-amino-2-methyl-5-pyrimidinemethanol &rarr; ADP + 4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation '4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + ATP &rarr; 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + ADP' 'null' '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9804> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN>
+          <http://model.geneontology.org/THI-P-SYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-82_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-82_PYRIMSYN3-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000006179_CPLX3O-82_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN>
+          <http://model.geneontology.org/CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_15377_RXNQT-4301_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXNQT-4301> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXNQT-4301>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CPLX3O-362_RXN3O-401_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-401> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-362_RXN3O-401>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_456216_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_OHMETPYRKIN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_OHMETPYRKIN-RXN_location_lociGO_0005829>
@@ -2701,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2709,66 +3039,68 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_18385_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18385_THIAMIN-PYROPHOSPHOKINASE-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_139151_RXNQT-4301_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+          <http://model.geneontology.org/reaction_THI-P-SYN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002234_CHEBI_16892_RXN3O-9804_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9804> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16892_RXN3O-9804>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_58354_PYRIMSYN3-RXN_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
+          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-10511_RXN3O-401>
+          <http://model.geneontology.org/CHEBI_58354_PYRIMSYN3-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000066_reaction_RXN3O-9804_location_lociGO_0005829_null_PWY3O-17>
@@ -2776,7 +3108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2787,27 +3119,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000006179_CPLX3O-82_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006179> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_BFO_0000051_SGD_S000005669_CPLX3O-25_component_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_OHMETPYRKIN-RXN>
+          <http://model.geneontology.org/SGD_S000005669_CPLX3O-25_component>
 ] .
 
 <http://model.geneontology.org/reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829>
@@ -2822,28 +3163,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule68874> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15377_RXNQT-4301>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69001> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2856,11 +3180,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69223> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15377_RXNQT-4301>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69001> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2883,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2891,12 +3232,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-17/PWY3O-17>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2904,29 +3262,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002333_CPLX3O-10511_RXNQT-4301_controller_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4301> ;
+          <http://model.geneontology.org/RXNQT-4191> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-10511_RXNQT-4301_controller>
+          <http://model.geneontology.org/CHEBI_43474_RXNQT-4191>
 ] .
 
 <http://model.geneontology.org/CPLX3O-80_OHMETPYRKIN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "THI20" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005416_CPLX3O-80_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2943,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2952,22 +3312,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000066_reaction_RXN3O-9804_location_lociGO_0005829_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57305_RXN3O-401_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9804> ;
+          <http://model.geneontology.org/RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9804_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57305_RXN3O-401>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_456215_RXNQT-4301_SGD_PWY3O-17>
@@ -2975,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2983,17 +3341,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000050_PWY3O-17/PWY3O-17_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-17/PWY3O-17>
 ] .
@@ -3003,20 +3361,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-9145_RXN3O-9804_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002403> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "hydroxymethylpyrimidine synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3032,7 +3390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3043,7 +3401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3051,19 +3409,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_456215_RXNQT-4301_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THI-P-SYN-RXN> ;
+          <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37575_THI-P-SYN-RXN>
+          <http://model.geneontology.org/CHEBI_456215_RXNQT-4301>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_18385_RXNQT-4191_SGD_PWY3O-17>
@@ -3071,49 +3429,60 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXNQT-4301_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Entity Regulation Rule 3. The relation 'thiazole synthase + glycine + NAD<sup>+</sup> &rarr; ADP-5-ethyl-4-methylthiazole-2-carboxylate + nicotinamide + thiazole synthase - dehydroalanine<sub>205</sub>' 'null' 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is the enabler of reaction 2." ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_15377_RXNQT-4191_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_null_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002629> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
+          <http://model.geneontology.org/RXN3O-401> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXNQT-4191>
+          <http://model.geneontology.org/RXNQT-4301>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_37575>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + ATP &rarr; 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + ADP' 'null' '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_null_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-82_OHMETPYRKIN-RXN_controller_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRIMSYN3-RXN> ;
+          <http://model.geneontology.org/OHMETPYRKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THI-P-SYN-RXN>
+          <http://model.geneontology.org/CPLX3O-82_OHMETPYRKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002333_CPLX3O-10511_RXN3O-401_controller_SGD_PWY3O-17>
@@ -3121,7 +3490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3132,7 +3501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3147,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3160,11 +3529,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003376>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_139151>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3178,7 +3550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3195,7 +3567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3205,17 +3577,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_58296_THI-P-SYN-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN> ;
+          <http://model.geneontology.org/THI-P-SYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN>
+          <http://model.geneontology.org/CHEBI_58296_THI-P-SYN-RXN>
 ] .

--- a/models/PWY3O-1743-PWY3O-1743.ttl
+++ b/models/PWY3O-1743-PWY3O-1743.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mannose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-1801-PWY3O-1801.ttl
+++ b/models/PWY3O-1801-PWY3O-1801.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,7 +788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,24 +877,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1801Protein17207> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_null_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PWY3O-1801>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -905,10 +894,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitoleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_null_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .

--- a/models/PWY3O-1874-PWY3O-1874.ttl
+++ b/models/PWY3O-1874-PWY3O-1874.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,13 +153,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "aminodeoxychorismate lyase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -299,6 +299,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -312,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,31 +565,28 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY3O-1874>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_PWY3O-1874>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-188-PWY3O-188.ttl
+++ b/models/PWY3O-188-PWY3O-188.ttl
@@ -1,119 +1,129 @@
-<http://model.geneontology.org/CHEBI_57540_RXN3O-165>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17549> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_null_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_4b441dbb-5cbc-4bfb-a6da-496522c323f4_RXN3O-168_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4b441dbb-5cbc-4bfb-a6da-496522c323f4_RXN3O-168>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_null_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003702_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003702_CPLX3O-109_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000002225_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000001093_CPLX3O-117_component>
+        a       <http://identifiers.org/sgd/S000001093> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://identifiers.org/sgd/S000005591>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000004869_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004869> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'reduced cytochrome c + oxygen &rarr; oxidized cytochrome c + H<sub>2</sub>O' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002413_RXN3O-168_null_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-168>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,76 +131,299 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-165> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52970_RXN3O-165>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-165>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
-] .
-
-<http://model.geneontology.org/edac0e7e-f09f-4613-998a-42065eaf3b77_RXN3O-9794>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "reduced cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0008177>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29806> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fumarate" ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003159_CPLX3O-117_component>
+] .
+
+<http://model.geneontology.org/SGD_S000003159_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003159> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000001631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000007270_CPLX3O-109_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000007270> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000141_CPLX3O-109_component>
+        a       <http://identifiers.org/sgd/S000000141> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_RXN3O-168_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_null_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004028_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004028> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_30031>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000004869>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000005591_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000001624> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001093>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_52971>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-168> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000750_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000750_CPLX3O-109_component>
+] .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003529>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SDH" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17406> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17448> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -198,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,9 +451,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/edac0e7e-f09f-4613-998a-42065eaf3b77_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> ;
+                <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> , <http://model.geneontology.org/36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8fccc473-a8e7-4d88-af4e-48fac202b3db_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
+                <http://model.geneontology.org/10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -228,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,78 +469,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+          <http://model.geneontology.org/RXN3O-165> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller>
+          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000066_reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829_null_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SDH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17448> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/CHEBI_52970_RXN3O-168>
+<http://model.geneontology.org/CHEBI_52970_RXN3O-165>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52970> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -316,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,32 +514,219 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0008150>
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000006395>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
+          <http://model.geneontology.org/CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_4b441dbb-5cbc-4bfb-a6da-496522c323f4_RXN3O-168_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_null_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-165> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-168>
+] .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004869_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004869_CPLX3O-117_component>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/CHEBI_57540_RXN3O-165>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17549> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000000750>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "oxidized cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000002937_CPLX3O-109_component>
+        a       <http://identifiers.org/sgd/S000002937> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003415_CPLX3O-109_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003415> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-9794_null_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_null_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-168> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-165>
+] .
+
+<http://identifiers.org/sgd/S000007283>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/SGD_S000004997_CPLX3O-117_component>
+        a       <http://identifiers.org/sgd/S000004997> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003415_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003415_CPLX3O-109_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -357,11 +734,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794>
+] .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_57945_RXN3O-165_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,26 +769,84 @@
           <http://model.geneontology.org/CHEBI_57945_RXN3O-165>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://identifiers.org/sgd/S000007270>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'reduced cytochrome c + oxygen &rarr; oxidized cytochrome c + H<sub>2</sub>O' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002413_RXN3O-168_null_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000002225_CPLX3O-117_component_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-168>
+          <http://model.geneontology.org/SGD_S000002225_CPLX3O-117_component>
+] .
+
+<http://identifiers.org/sgd/S000004028>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_null_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_52970_RXN3O-168>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52970> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ubiquinol-6" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17417> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000007260_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000007260> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_PWY3O-188>
@@ -399,7 +854,893 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_RXN3O-168_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-168> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_52970_RXN3O-168>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007281_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000007281_CPLX3O-117_component>
+] .
+
+<http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000007270_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_null_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15379_RXN3O-9794>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "O<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17273> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000002937_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000005591_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
+] .
+
+<http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003581> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007283_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30031> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "succinate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17376> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0008177>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_52971_RXN3O-165>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52971> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ubiquinone-<i>6</i>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17389> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-165> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YML120C-MONOMER_RXN3O-165_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004028_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004028_CPLX3O-117_component>
+] .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002413_RXN3O-168_null_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_null_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "oxidized cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000003702_CPLX3O-109_component>
+        a       <http://identifiers.org/sgd/S000003702> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000007260>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_null_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-168>
+] .
+
+<http://identifiers.org/sgd/S000003159>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003415_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-168> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168>
+] .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000007281>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004387_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/SGD_S000004387_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004387> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000001929_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001929_CPLX3O-109_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003702_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004869_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000750_CPLX3O-109_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000750> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007281_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008177> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY3O-188/PWY3O-188> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller> , <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN3O-168> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188BiochemicalReaction17360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794>
+] .
+
+<http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17293> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003529_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_null_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-165> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-165_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-165_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000007270_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000007270_CPLX3O-109_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003964>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_57945_RXN3O-165>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17534> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_52971_RXN3O-168>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52971> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ubiquinone-<i>6</i>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17389> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-168> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
+] .
+
+<http://model.geneontology.org/YML120C-MONOMER_RXN3O-165_controller>
+        a       <http://identifiers.org/sgd/S000004589> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADH dehydrogenase (ubiquinone)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Protein17557> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004997_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004997_CPLX3O-117_component>
+] .
+
+<http://model.geneontology.org/PWY3O-188/PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "The electron transport chain is the final step of the respiratory pathway, carried out by several large multisubunit enzyme complexes embedded in the mitochondrial inner membrane. The net effect of the electron transport chain is to transfer electrons from NADH to molecular oxygen, coupled to transport of protons across the mitochondrial inner membrane. The proton transport creates an electrochemical gradient across the membrane, which is then used to power ATP synthesis by the mitochondrial inner membrane F1F0 ATP synthase as well as transport of metabolites across the membrane |CITS: [11245784]|. NADH:ubiquinone oxidoreductase (NADH dehdrogenase) catalyzes the oxidation of NADH by ubiquinone, generating ubiquinol and NAD+ |CITS: [11245784][1900238]|. In Saccharomyces cerevisiae, Candida glabata and Schizosaccharomyces pombe, a single-subunit enzyme provides this activity (Ndi1p in S. cerevisiae). In many other fungi, mammals, insects, and plants, this activity resides in a multisubunit complex, Complex I, which transports a proton across the mitochondrial inner membrane concomitantly with NADH oxidation |CITS: [11245784]|. The succinate dehydrogenase complex (Complex II) catalyzes the oxidation of succinate by ubiquinone to fumarate, generating ubiquinol and fumarate. This reaction does not result in transfer of a proton across the mitochondrial inner membrane. In S. cerevisiae the complex is composed of the flavoprotein subunit Sdh1p, the iron-sulfur protein subunit Sdh2p, the cytochrome b subunit Sdh3p, and the membrane anchor subunit Sdh4p |CITS: [14672929]|. The ubiquinol generated by NADH dehydrogenase and Complex II is oxidized to ubiquinone by ubiquinol-cytochrome-c reductase (Complex III; cytochrome bc1 complex) in a stepwise electron transfer through the complex that results in the reduction of cytochrome c and the transfer of a proton across the mitochondrial membrane |CITS: [12788490]|. The cytochrome c that is reduced in this step is the product of the CYC1 gene. The final step in the electron transport chain is catalyzed by Complex IV, cytochrome c oxidase, which oxidizes cytochrome c while reducing oxygen to water with the concomitant transport of a proton across the mitochondrial inner membrane |CITS: [1665335][7851399]|." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aerobic respiration, electron transport chain" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "PWY3O-188" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,460 +1775,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_RXN3O-168_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "minor succinate dehydrogenase (ubiquinone)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17422> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
+<http://identifiers.org/sgd/S000001631>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000066_reaction_RXN3O-9794_location_lociGO_0005829_null_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller>
-] .
-
-<http://model.geneontology.org/PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "aerobic respiration, electron transport chain - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
+<http://identifiers.org/sgd/S000002937>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_null_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_null_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008177> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY3O-188/PWY3O-188> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller> , <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/RXN3O-168> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188BiochemicalReaction17360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_null_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-165> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-168>
-] .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_52971_RXN3O-168>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52971> ;
+<http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29806> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "ubiquinone-<i>6</i>" ;
+                "fumarate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17389> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17406> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_8fccc473-a8e7-4d88-af4e-48fac202b3db_RXN3O-9794_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_null_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_null_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_dec645f0-d235-4260-925b-b9ed2c6b4e5a_RXN3O-168_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dec645f0-d235-4260-925b-b9ed2c6b4e5a_RXN3O-168>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-9794_null_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-165_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-165> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52971_RXN3O-165>
-] .
-
-<http://model.geneontology.org/PWY3O-188/PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "The electron transport chain is the final step of the respiratory pathway, carried out by several large multisubunit enzyme complexes embedded in the mitochondrial inner membrane. The net effect of the electron transport chain is to transfer electrons from NADH to molecular oxygen, coupled to transport of protons across the mitochondrial inner membrane. The proton transport creates an electrochemical gradient across the membrane, which is then used to power ATP synthesis by the mitochondrial inner membrane F1F0 ATP synthase as well as transport of metabolites across the membrane |CITS: [11245784]|. NADH:ubiquinone oxidoreductase (NADH dehdrogenase) catalyzes the oxidation of NADH by ubiquinone, generating ubiquinol and NAD+ |CITS: [11245784][1900238]|. In Saccharomyces cerevisiae, Candida glabata and Schizosaccharomyces pombe, a single-subunit enzyme provides this activity (Ndi1p in S. cerevisiae). In many other fungi, mammals, insects, and plants, this activity resides in a multisubunit complex, Complex I, which transports a proton across the mitochondrial inner membrane concomitantly with NADH oxidation |CITS: [11245784]|. The succinate dehydrogenase complex (Complex II) catalyzes the oxidation of succinate by ubiquinone to fumarate, generating ubiquinol and fumarate. This reaction does not result in transfer of a proton across the mitochondrial inner membrane. In S. cerevisiae the complex is composed of the flavoprotein subunit Sdh1p, the iron-sulfur protein subunit Sdh2p, the cytochrome b subunit Sdh3p, and the membrane anchor subunit Sdh4p |CITS: [14672929]|. The ubiquinol generated by NADH dehydrogenase and Complex II is oxidized to ubiquinone by ubiquinol-cytochrome-c reductase (Complex III; cytochrome bc1 complex) in a stepwise electron transfer through the complex that results in the reduction of cytochrome c and the transfer of a proton across the mitochondrial membrane |CITS: [12788490]|. The cytochrome c that is reduced in this step is the product of the CYC1 gene. The final step in the electron transport chain is catalyzed by Complex IV, cytochrome c oxidase, which oxidizes cytochrome c while reducing oxygen to water with the concomitant transport of a proton across the mitochondrial inner membrane |CITS: [1665335][7851399]|." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aerobic respiration, electron transport chain" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "PWY3O-188" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller>
-] .
-
-<http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "cytochrome c oxidase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17298> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
-] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000066_reaction_RXN3O-9794_location_lociGO_0005829_null_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_52971>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52970> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ubiquinol-6" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17417> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -897,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,191 +1828,179 @@
           <http://model.geneontology.org/RXN3O-9794>
 ] .
 
-<http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17293> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-165> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
+          <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
 ] .
 
-<http://model.geneontology.org/YML120C-MONOMER_RXN3O-165_controller>
-        a       <http://identifiers.org/sgd/S000004589> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADH dehydrogenase (ubiquinone)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Protein17557> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/CHEBI_57945_RXN3O-165>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17534> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_RXN3O-168_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52970_RXN3O-168>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_null_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-165> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-165_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_57945>
+<http://identifiers.org/sgd/S000004589>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_8fccc473-a8e7-4d88-af4e-48fac202b3db_RXN3O-9794_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003529_CPLX3O-109_component_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8fccc473-a8e7-4d88-af4e-48fac202b3db_RXN3O-9794>
+          <http://model.geneontology.org/SGD_S000003529_CPLX3O-109_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-165_SGD_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000141_CPLX3O-109_component_SGD_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000003964> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_52970>
+<http://identifiers.org/sgd/S000000141>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "reduced cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+          <http://model.geneontology.org/RXN3O-165> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN>
+          <http://model.geneontology.org/CHEBI_52970_RXN3O-165>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003155_CPLX3O-117_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000750_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_30031>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004997_CPLX3O-117_component_SGD_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1102,76 +2010,96 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_null_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-165>
-] .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-165> ;
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML120C-MONOMER_RXN3O-165_controller>
+          <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller>
 ] .
 
-<http://identifiers.org/sgd/S000004589>
+<http://purl.obolibrary.org/obo/CHEBI_52970>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-168> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168>
+] .
 
-<http://model.geneontology.org/CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30031> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "succinate" ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007283_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000007283_CPLX3O-117_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17376> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000141_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000141_CPLX3O-109_component>
+] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_dec645f0-d235-4260-925b-b9ed2c6b4e5a_RXN3O-168_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1186,9 +2114,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_52970_RXN3O-168> , <http://model.geneontology.org/dec645f0-d235-4260-925b-b9ed2c6b4e5a_RXN3O-168> ;
+                <http://model.geneontology.org/CHEBI_52970_RXN3O-168> , <http://model.geneontology.org/2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/4b441dbb-5cbc-4bfb-a6da-496522c323f4_RXN3O-168> , <http://model.geneontology.org/CHEBI_52971_RXN3O-168> ;
+                <http://model.geneontology.org/CHEBI_52971_RXN3O-168> , <http://model.geneontology.org/e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1196,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,18 +2132,91 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_null_PWY3O-188>
+<http://identifiers.org/sgd/S000004997>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000066_reaction_RXN3O-9794_location_lociGO_0005829_null_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
+] .
+
+<http://model.geneontology.org/reaction_RXN3O-165_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000006395_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000006395_CPLX3O-109_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003415>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
+                "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/4b441dbb-5cbc-4bfb-a6da-496522c323f4_RXN3O-168>
+<http://model.geneontology.org/36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -1224,7 +2225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1232,7 +2233,10 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_52970_RXN3O-165>
+<http://identifiers.org/sgd/S000002585>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52970> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -1241,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,211 +2257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_null_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002413_RXN3O-168_null_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_null_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-165> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
-] .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/reaction_RXN3O-165_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_edac0e7e-f09f-4613-998a-42065eaf3b77_RXN3O-9794_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller>
-        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ubiquinol cytochrome c reductase complex" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17465> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_57945_RXN3O-165_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-165> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-165>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000066_reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829_null_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,120 +2272,397 @@
           <http://model.geneontology.org/reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15379>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/dec645f0-d235-4260-925b-b9ed2c6b4e5a_RXN3O-168>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "oxidized cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_52971_RXN3O-165>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52971> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ubiquinone-<i>6</i>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17389> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15379_RXN3O-9794>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "O<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17273> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/8fccc473-a8e7-4d88-af4e-48fac202b3db_RXN3O-9794>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "oxidized cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-168> ;
+          <http://model.geneontology.org/RXN3O-165> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-188/PWY3O-188>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004387_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004387_CPLX3O-117_component>
+] .
+
+<http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ubiquinol cytochrome c reductase complex" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000003529_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000001929_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000000750_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000006395_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000003415_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000007270_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000000141_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000002937_CPLX3O-109_component> , <http://model.geneontology.org/SGD_S000003702_CPLX3O-109_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17465> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000004387>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_null_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/SGD_S000007281_CPLX3O-117_component>
+        a       <http://identifiers.org/sgd/S000007281> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15379>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000006395_CPLX3O-109_component>
+        a       <http://identifiers.org/sgd/S000006395> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000002225_CPLX3O-117_component>
+        a       <http://identifiers.org/sgd/S000002225> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "aerobic respiration, electron transport chain - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/SGD_S000001929_CPLX3O-109_component>
+        a       <http://identifiers.org/sgd/S000001929> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_edac0e7e-f09f-4613-998a-42065eaf3b77_RXN3O-9794_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-168> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000001929_CPLX3O-109_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
+] .
+
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000002937_CPLX3O-109_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002937_CPLX3O-109_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_null_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003155_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003155> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002225>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000003702>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_29806>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-165_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
+          <http://model.geneontology.org/RXN3O-165> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/edac0e7e-f09f-4613-998a-42065eaf3b77_RXN3O-9794>
+          <http://model.geneontology.org/CHEBI_52971_RXN3O-165>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001093_CPLX3O-117_component>
+] .
+
+<http://identifiers.org/sgd/S000001929>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005591> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000007283_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000007283> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003529_CPLX3O-109_component>
+        a       <http://identifiers.org/sgd/S000003529> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component>
+        a       <http://identifiers.org/sgd/S000003964> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003581>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "cytochrome c oxidase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004387_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000007260_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000007283_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000001093_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000004869_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000002225_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000007281_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000003159_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000004028_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000003155_CPLX3O-117_component> , <http://model.geneontology.org/SGD_S000004997_CPLX3O-117_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17298> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://identifiers.org/sgd/S000001624>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN>
+] .
+
+<http://identifiers.org/sgd/S000003155>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007260_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1589,22 +2670,39 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_null_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_null_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+          <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-168>
+          <http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "minor succinate dehydrogenase (ubiquinone)" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17422> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
 
 <http://model.geneontology.org/CHEBI_52971_SUCC-FUM-OXRED-UBI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52971> ;
@@ -1615,7 +2713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1623,12 +2721,76 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_PWY3O-188>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007260_CPLX3O-117_component_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000007260_CPLX3O-117_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004028_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000006395_CPLX3O-109_component_SGD_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000066_reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829_null_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_57945_RXN3O-165_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-19-PWY3O-19.ttl
+++ b/models/PWY3O-19-PWY3O-19.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -571,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,29 +796,12 @@
 <http://model.geneontology.org/reaction_2.1.1.114-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41596> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_PWY3O-19/PWY3O-19_SGD_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -829,11 +812,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41596> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_RXN3O-102_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1039,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ubiquinol-6 biosynthesis from 4-hydroxybenzoate (eukaryotic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1470,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,12 +1481,23 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_null_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_PWY3O-19/PWY3O-19_SGD_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,37 +1518,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_null_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/PWY3O-19/PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ubiquinol-6 biosynthesis from 4-hydroxybenzoate (eukaryotic)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "PWY3O-19" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1545,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,13 +1541,28 @@
           <http://model.geneontology.org/PWY3O-19/PWY3O-19>
 ] .
 
+<http://model.geneontology.org/PWY3O-19/PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ubiquinol-6 biosynthesis from 4-hydroxybenzoate (eukaryotic)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "PWY3O-19" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1598,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1624,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1669,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1706,7 +1706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1726,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1739,7 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1804,7 +1804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,7 +1826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,14 +1845,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/2.1.1.114-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008689> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1887,7 +1887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1915,7 +1915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1991,13 +1991,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-164_RXN3O-75_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005651> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "monooxygenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2070,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,7 +2117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2132,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2165,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2207,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2247,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2263,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2296,7 +2296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2313,7 +2313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2396,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2424,7 +2424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2438,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2453,7 +2453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2470,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,7 +2484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2504,7 +2504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2524,7 +2524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2541,7 +2541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2564,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2577,7 +2577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2592,7 +2592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,7 +2609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2629,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2645,7 +2645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2662,7 +2662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2678,7 +2678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2696,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2713,7 +2713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2727,7 +2727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2743,7 +2743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2754,7 +2754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2766,7 +2766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,7 +2783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2809,13 +2809,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41423> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000005651>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57856_2.1.1.114-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
@@ -2826,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2845,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2860,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2876,7 +2879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2893,7 +2896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2910,7 +2913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2927,7 +2930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2946,7 +2949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2960,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2977,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2989,7 +2992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3006,7 +3009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3034,7 +3037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3050,7 +3053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3061,7 +3064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3074,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3091,7 +3094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3104,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3136,7 +3139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3153,7 +3156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3167,7 +3170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3183,7 +3186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3195,7 +3198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3204,23 +3207,6 @@
           <http://model.geneontology.org/RXN3O-58> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN3O-58>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-12_SGD_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-12> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_1109_RXN3O-12>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-12>
@@ -3232,13 +3218,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41480> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-12_SGD_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-12> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_1109_RXN3O-12>
+] .
 
 <http://model.geneontology.org/RXN3O-58>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3259,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3272,7 +3275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3285,7 +3288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3298,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3310,7 +3313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3326,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-2-PWY3O-2.ttl
+++ b/models/PWY3O-2-PWY3O-2.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15,23 +15,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-5781>
 ] .
 
-<http://model.geneontology.org/b43f9d48-d433-4338-9837-94dbb691d8dd_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YGR202C-MONOMER_2.7.7.15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003434> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -39,13 +22,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32077> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -260,13 +260,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,29 +291,12 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/950a44c6-a4dc-4f35-8353-e4fea5c2e19d_RXN4FS-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -375,24 +369,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32127> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_47beb61d-4124-48f3-9023-fb9a3988f500_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -403,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -553,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,23 +566,12 @@
           <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_d2608b71-07eb-465c-8168-9faf1644bd5f_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -613,14 +585,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN4FS-2>
-        a       <http://purl.obolibrary.org/obo/GO_0000773> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -628,7 +600,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/950a44c6-a4dc-4f35-8353-e4fea5c2e19d_RXN4FS-2> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
+                <http://model.geneontology.org/a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -636,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,35 +762,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/47beb61d-4124-48f3-9023-fb9a3988f500_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -891,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -941,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -987,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,6 +953,23 @@
           <http://model.geneontology.org/PWY3O-2/PWY3O-2>
 ] .
 
+<http://model.geneontology.org/e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://identifiers.org/sgd/S000003389>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1006,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,23 +1011,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
-
-<http://model.geneontology.org/a101b337-5f76-4ae1-b789-c10f13b9b531_RXN3O-349>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_2.1.1.17-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1069,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,24 +1032,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_0a08d0cd-89d6-4fee-8e21-4fa40b584bdd_PHOSPHASERSYN-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1195,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/0a08d0cd-89d6-4fee-8e21-4fa40b584bdd_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1261,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1274,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1313,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1341,7 +1285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,14 +1336,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0000773>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_null_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000510> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1408,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,24 +1368,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_null_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1468,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1493,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1537,11 +1478,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_13322667-993d-43f4-b45a-5676181a89fc_2.1.1.17-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,8 +1490,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/13322667-993d-43f4-b45a-5676181a89fc_2.1.1.17-RXN>
+          <http://model.geneontology.org/e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1560,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1609,11 +1561,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_34337e89-5513-4cb1-a5ca-40b2709ad0d8_PGPPHOSPHA-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1573,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/34337e89-5513-4cb1-a5ca-40b2709ad0d8_PGPPHOSPHA-RXN>
+          <http://model.geneontology.org/8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1630,7 +1582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1650,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1667,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1686,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1697,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1733,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1747,33 +1699,16 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/91b68c87-297a-4e8c-80bb-a11e7f04a2b3_2.7.8.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_a101b337-5f76-4ae1-b789-c10f13b9b531_RXN3O-349_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1716,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a101b337-5f76-4ae1-b789-c10f13b9b531_RXN3O-349>
+          <http://model.geneontology.org/3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57880>
@@ -1796,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1809,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1820,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1835,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1848,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1862,7 +1797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,7 +1814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1895,9 +1830,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1910,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1924,7 +1870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1940,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1952,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,11 +1911,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_b43f9d48-d433-4338-9837-94dbb691d8dd_2.1.1.71-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,7 +1923,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b43f9d48-d433-4338-9837-94dbb691d8dd_2.1.1.71-RXN>
+          <http://model.geneontology.org/6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY3O-2>
@@ -1985,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1998,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,23 +1952,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_b43f9d48-d433-4338-9837-94dbb691d8dd_2.1.1.71-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2033,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2045,7 +1980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2082,7 +2017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,7 +2037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2121,7 +2056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2137,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2148,11 +2083,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_0a08d0cd-89d6-4fee-8e21-4fa40b584bdd_PHOSPHASERSYN-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,7 +2095,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0a08d0cd-89d6-4fee-8e21-4fa40b584bdd_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2171,7 +2106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2191,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2211,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2244,7 +2179,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/13322667-993d-43f4-b45a-5676181a89fc_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2252,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2268,7 +2203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2284,7 +2219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2298,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2313,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2330,7 +2265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,12 +2276,29 @@
           <http://model.geneontology.org/CHEBI_60377_RXN-5781>
 ] .
 
+<http://model.geneontology.org/3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2367,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2377,11 +2329,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_d2608b71-07eb-465c-8168-9faf1644bd5f_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,45 +2341,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d2608b71-07eb-465c-8168-9faf1644bd5f_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/d2608b71-07eb-465c-8168-9faf1644bd5f_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/13322667-993d-43f4-b45a-5676181a89fc_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2435,7 +2353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2463,7 +2381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2476,11 +2394,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_950a44c6-a4dc-4f35-8353-e4fea5c2e19d_RXN4FS-2_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2488,7 +2406,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/950a44c6-a4dc-4f35-8353-e4fea5c2e19d_RXN4FS-2>
+          <http://model.geneontology.org/a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY3O-2>
@@ -2496,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2508,7 +2426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2524,7 +2442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2538,7 +2456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,7 +2473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2587,7 +2505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2604,7 +2522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,7 +2539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,7 +2556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,28 +2572,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0a08d0cd-89d6-4fee-8e21-4fa40b584bdd_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_ETHANOLAMINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -2686,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2700,7 +2601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2717,7 +2618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2731,12 +2632,23 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2751,24 +2663,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32207> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_91b68c87-297a-4e8c-80bb-a11e7f04a2b3_2.7.8.11-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_64716> ;
@@ -2779,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2807,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2830,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2847,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2861,7 +2762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,7 +2778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2888,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2902,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2914,7 +2815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2931,7 +2832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2942,8 +2843,25 @@
           <http://model.geneontology.org/CHEBI_57856_RXN3O-349>
 ] .
 
+<http://model.geneontology.org/59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/RXN3O-349>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000773> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2951,7 +2869,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a101b337-5f76-4ae1-b789-c10f13b9b531_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2959,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2972,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2986,7 +2904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3002,7 +2920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3020,7 +2938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3040,7 +2958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3059,7 +2977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3071,7 +2989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3088,7 +3006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3104,7 +3022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3117,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3134,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3151,9 +3069,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/d2608b71-07eb-465c-8168-9faf1644bd5f_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/47beb61d-4124-48f3-9023-fb9a3988f500_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3161,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3175,7 +3093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,7 +3123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3218,7 +3136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3233,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3247,7 +3165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3282,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3303,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3316,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3328,7 +3246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3344,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3355,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3369,7 +3287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3381,7 +3299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3401,11 +3319,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32029> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3415,7 +3350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3434,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3445,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3460,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3473,7 +3408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3487,7 +3422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3510,7 +3445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3523,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3538,7 +3473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3554,7 +3489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3569,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3583,7 +3518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3603,7 +3538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3617,7 +3552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3636,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3647,7 +3582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3658,7 +3593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3670,7 +3605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,7 +3624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3709,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3717,34 +3652,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_a101b337-5f76-4ae1-b789-c10f13b9b531_RXN3O-349_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_950a44c6-a4dc-4f35-8353-e4fea5c2e19d_RXN4FS-2_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_null_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3755,7 +3668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3772,7 +3685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3789,7 +3702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3809,7 +3722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3825,7 +3738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3844,18 +3757,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3867,7 +3797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3884,7 +3814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3904,7 +3834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3920,7 +3850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3935,7 +3865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3949,7 +3879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3987,7 +3917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4000,7 +3930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4013,7 +3943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4024,7 +3954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4036,7 +3966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4052,7 +3982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4064,7 +3994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4075,23 +4005,6 @@
           <http://model.geneontology.org/YPR113W-MONOMER_2.7.8.11-RXN_controller>
 ] .
 
-<http://model.geneontology.org/34337e89-5513-4cb1-a5ca-40b2709ad0d8_PGPPHOSPHA-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15354_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15354> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4101,7 +4014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4115,7 +4028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4132,7 +4045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4162,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4180,13 +4093,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32173> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -4197,7 +4121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4216,7 +4140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4228,7 +4152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4248,7 +4172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4265,7 +4189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4276,35 +4200,13 @@
           <http://model.geneontology.org/YGR007W-MONOMER_2.7.7.14-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4315,12 +4217,34 @@
           <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4331,7 +4255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4342,7 +4266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4357,7 +4281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4372,7 +4296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4386,7 +4310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4406,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4423,7 +4347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4442,7 +4366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4459,7 +4383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4479,7 +4403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4499,7 +4423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4513,7 +4437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4533,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4550,7 +4474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4567,7 +4491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4583,28 +4507,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/86eb087d-a08f-4ebe-87d8-0b3a68ad29b9_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4612,7 +4519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4629,7 +4536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4648,7 +4555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4659,7 +4566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4670,7 +4577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4685,7 +4592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4701,7 +4608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4712,7 +4619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4726,7 +4633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4742,7 +4649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4754,7 +4661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4771,7 +4678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4782,6 +4689,17 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4791,7 +4709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4808,7 +4726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4828,7 +4746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4845,7 +4763,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/91b68c87-297a-4e8c-80bb-a11e7f04a2b3_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_57880_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -4853,7 +4771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4874,7 +4792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4894,7 +4812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4908,7 +4826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4924,7 +4842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4941,7 +4859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4953,7 +4871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4969,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4980,7 +4898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4991,7 +4909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5000,13 +4918,30 @@
 <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5029,7 +4964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5040,12 +4975,29 @@
           <http://model.geneontology.org/CHEBI_15378_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5053,11 +5005,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_86eb087d-a08f-4ebe-87d8-0b3a68ad29b9_2.1.1.71-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5065,7 +5017,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/86eb087d-a08f-4ebe-87d8-0b3a68ad29b9_2.1.1.71-RXN>
+          <http://model.geneontology.org/c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5074,7 +5026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5094,7 +5046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5103,7 +5055,7 @@
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 <http://model.geneontology.org/2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000773> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -5111,9 +5063,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b43f9d48-d433-4338-9837-94dbb691d8dd_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/86eb087d-a08f-4ebe-87d8-0b3a68ad29b9_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5121,7 +5073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5138,7 +5090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5151,7 +5103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5162,7 +5114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5177,7 +5129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5197,7 +5149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5214,7 +5166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5222,23 +5174,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_13322667-993d-43f4-b45a-5676181a89fc_2.1.1.17-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_RXN-5781_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5249,7 +5201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5264,7 +5216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5277,7 +5229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5289,7 +5241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5308,7 +5260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5323,7 +5275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5342,7 +5294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5359,7 +5311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5376,7 +5328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5392,28 +5344,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_58190_2.7.7.14-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58190> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>O</i>-phosphoethanolamine" ;
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32274> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_2.7.7.14-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -5426,7 +5372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5437,16 +5383,22 @@
           <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_34337e89-5513-4cb1-a5ca-40b2709ad0d8_PGPPHOSPHA-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_58190_2.7.7.14-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58190> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>O</i>-phosphoethanolamine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32274> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN4FS-2>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5457,7 +5409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5470,7 +5422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5485,7 +5437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5507,7 +5459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5520,7 +5472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5539,7 +5491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5555,7 +5507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5570,7 +5522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5583,11 +5535,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_47beb61d-4124-48f3-9023-fb9a3988f500_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5595,16 +5547,33 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/47beb61d-4124-48f3-9023-fb9a3988f500_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_91b68c87-297a-4e8c-80bb-a11e7f04a2b3_2.7.8.11-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5612,15 +5581,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/91b68c87-297a-4e8c-80bb-a11e7f04a2b3_2.7.8.11-RXN>
+          <http://model.geneontology.org/59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN>
 ] .
+
+<http://model.geneontology.org/6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5634,7 +5620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5653,7 +5639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5673,7 +5659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5686,7 +5672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5697,7 +5683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5712,7 +5698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5725,7 +5711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5737,7 +5723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5753,7 +5739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5765,7 +5751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5795,7 +5781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5808,7 +5794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5819,7 +5805,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5844,7 +5841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5857,7 +5854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5869,7 +5866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5886,7 +5883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5903,7 +5900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5919,7 +5916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5936,7 +5933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5947,17 +5944,6 @@
           <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_86eb087d-a08f-4ebe-87d8-0b3a68ad29b9_2.1.1.71-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -5967,7 +5953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5984,7 +5970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6004,7 +5990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6021,7 +6007,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/34337e89-5513-4cb1-a5ca-40b2709ad0d8_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6029,7 +6015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6037,12 +6023,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_null_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -6057,7 +6054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6074,7 +6071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-20-PWY3O-20.ttl
+++ b/models/PWY3O-20-PWY3O-20.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,7 +112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate polyglutamylation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,13 +236,35 @@
           <http://model.geneontology.org/PWY3O-20/PWY3O-20>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57945_1.5.1.20-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,30 +309,13 @@
 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/95e27e67-e495-4087-af2b-2d01c647644f_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,15 +355,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/a1c520bc-23ee-442c-8be2-10377f960c5b_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/0b09c235-0e71-4c84-81a2-78e09041df4d_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> , <http://model.geneontology.org/13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,13 +374,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,13 +408,30 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
 ] .
 
+<http://model.geneontology.org/6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_5cb96e46-0e4f-4bff-8f43-fcc42552c423_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,8 +439,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5cb96e46-0e4f-4bff-8f43-fcc42552c423_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -410,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,12 +514,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_RXN3O-22_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -489,28 +556,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64805> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/4caf6853-d425-4346-89a4-11893d9bbbcc_FOLYLPOLYGLUTAMATESYNTH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -523,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,11 +623,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_f50c8c40-b12d-4b11-ae8b-210f28619b38_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +635,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f50c8c40-b12d-4b11-ae8b-210f28619b38_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
@@ -595,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,11 +655,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_c88c1ca4-9f40-479f-acb5-183887bb5a47_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +667,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c88c1ca4-9f40-479f-acb5-183887bb5a47_FOLYLPOLYGLUTAMATESYNTH-RXN>
+          <http://model.geneontology.org/12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY3O-20>
@@ -625,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -645,24 +695,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57451>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_4caf6853-d425-4346-89a4-11893d9bbbcc_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,17 +712,6 @@
           <http://model.geneontology.org/PWY3O-20/PWY3O-20>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_RXN0-2921>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -693,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,12 +729,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_95e27e67-e495-4087-af2b-2d01c647644f_1.5.1.20-RXN_SGD_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,23 +759,23 @@
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a1c520bc-23ee-442c-8be2-10377f960c5b_RXN3O-22_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -758,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -772,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -799,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -814,9 +842,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/49b49e15-9694-4c62-9e00-377699de2a85_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/7da5f3e8-ee27-49b8-8aff-704acfc8e0f8_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -824,13 +852,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20BiochemicalReaction65070> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -844,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -892,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -916,6 +961,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0008841>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -925,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,11 +1003,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_95e27e67-e495-4087-af2b-2d01c647644f_1.5.1.20-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +1015,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/95e27e67-e495-4087-af2b-2d01c647644f_1.5.1.20-RXN>
+          <http://model.geneontology.org/6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -970,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1036,11 +1092,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_49b49e15-9694-4c62-9e00-377699de2a85_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,7 +1104,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/49b49e15-9694-4c62-9e00-377699de2a85_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-20>
@@ -1056,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1067,28 +1123,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0b09c235-0e71-4c84-81a2-78e09041df4d_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1099,11 +1138,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64805> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1112,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1127,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,33 +1211,22 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/c88c1ca4-9f40-479f-acb5-183887bb5a47_FOLYLPOLYGLUTAMATESYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 7,8-dihydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_232f309a-19dd-428b-a854-c44929050c57_GLYOHMETRANS-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1189,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,30 +1245,13 @@
           <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/5cb96e46-0e4f-4bff-8f43-fcc42552c423_FORMYLTHFGLUSYNTH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,13 +1262,24 @@
           <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_0b09c235-0e71-4c84-81a2-78e09041df4d_RXN3O-22_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,7 +1287,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0b09c235-0e71-4c84-81a2-78e09041df4d_RXN3O-22>
+          <http://model.geneontology.org/13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1257,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,6 +1307,23 @@
           <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1277,15 +1333,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/4caf6853-d425-4346-89a4-11893d9bbbcc_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/c88c1ca4-9f40-479f-acb5-183887bb5a47_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,7 +1355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,13 +1375,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64881> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1335,7 +1402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,28 +1422,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/cfa11142-52a1-4dee-84ac-ffea702a8a07_RXN3O-681>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1386,7 +1436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1419,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,13 +1500,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/bea008af-1e51-4729-8ce8-0d6a9ec69a44_DIHYDROFOLATEREDUCT-RXN>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_null_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -1465,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1473,23 +1534,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_null_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1500,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1514,7 +1564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1559,23 +1609,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_808ef3af-21ea-4bf3-829a-a91a86fc48b7_1.5.1.20-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1597,11 +1636,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1609,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,11 +1681,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_300dafb4-fabd-4bf0-9459-d816048ff66f_RXN3O-681_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,26 +1693,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/300dafb4-fabd-4bf0-9459-d816048ff66f_RXN3O-681>
+          <http://model.geneontology.org/f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_bea008af-1e51-4729-8ce8-0d6a9ec69a44_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1671,15 +1716,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-681_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/300dafb4-fabd-4bf0-9459-d816048ff66f_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> , <http://model.geneontology.org/cfa11142-52a1-4dee-84ac-ffea702a8a07_RXN3O-681> ;
+                <http://model.geneontology.org/13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681> , <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1689,11 +1734,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_5c2c78cd-9983-4d55-92dd-e10c0c7f332e_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1701,7 +1746,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5c2c78cd-9983-4d55-92dd-e10c0c7f332e_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005767>
@@ -1716,15 +1761,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-2921_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f563745d-9ad2-4e14-9018-de426b28d6ac_RXN0-2921> , <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> , <http://model.geneontology.org/4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> , <http://model.geneontology.org/e8182ac5-64dc-4f70-88b5-5613a19d3fc8_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> , <http://model.geneontology.org/63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN0-2921_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1732,23 +1777,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_7da5f3e8-ee27-49b8-8aff-704acfc8e0f8_FORMATETHFLIG-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1797,7 +1831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,13 +1842,16 @@
           <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_17839>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,15 +1862,23 @@
           <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_17839>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1848,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1863,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1871,30 +1916,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/808ef3af-21ea-4bf3-829a-a91a86fc48b7_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_f563745d-9ad2-4e14-9018-de426b28d6ac_RXN0-2921_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,7 +1930,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f563745d-9ad2-4e14-9018-de426b28d6ac_RXN0-2921>
+          <http://model.geneontology.org/4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20>
@@ -1910,29 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_5cb96e46-0e4f-4bff-8f43-fcc42552c423_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_5c2c78cd-9983-4d55-92dd-e10c0c7f332e_GLYOHMETRANS-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1974,18 +1980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_f50c8c40-b12d-4b11-ae8b-210f28619b38_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2000,15 +1995,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/5cb96e46-0e4f-4bff-8f43-fcc42552c423_FORMYLTHFGLUSYNTH-RXN> ;
+                <http://model.geneontology.org/613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/b2eee55d-ad00-4854-ad1a-0506c9d98ba3_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
+                <http://model.geneontology.org/07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,12 +2011,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002333_YOR241W-MONOMER_RXN3O-681_controller_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2048,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2061,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2090,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,7 +2120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2125,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2138,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2146,11 +2158,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_b2eee55d-ad00-4854-ad1a-0506c9d98ba3_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2158,11 +2170,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b2eee55d-ad00-4854-ad1a-0506c9d98ba3_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -2171,7 +2194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2185,7 +2208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2205,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2229,11 +2252,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2241,7 +2281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2261,9 +2301,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5c2c78cd-9983-4d55-92dd-e10c0c7f332e_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/232f309a-19dd-428b-a854-c44929050c57_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2273,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2289,7 +2329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2320,30 +2360,13 @@
 <http://purl.obolibrary.org/obo/GO_0004489>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e8182ac5-64dc-4f70-88b5-5613a19d3fc8_RXN0-2921>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2360,12 +2383,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2377,7 +2411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,17 +2422,6 @@
           <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_b2eee55d-ad00-4854-ad1a-0506c9d98ba3_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2407,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2418,17 +2441,6 @@
           <http://model.geneontology.org/reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_300dafb4-fabd-4bf0-9459-d816048ff66f_RXN3O-681_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2438,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2455,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2469,7 +2481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2485,7 +2497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2500,7 +2512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2513,7 +2525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2528,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2545,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2559,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2575,28 +2587,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/b2eee55d-ad00-4854-ad1a-0506c9d98ba3_FORMYLTHFGLUSYNTH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2604,7 +2599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2620,7 +2615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2631,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2640,17 +2635,6 @@
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_e8182ac5-64dc-4f70-88b5-5613a19d3fc8_RXN0-2921_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003093> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2658,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2672,7 +2656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2686,29 +2670,12 @@
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/232f309a-19dd-428b-a854-c44929050c57_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2719,7 +2686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2731,7 +2698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,13 +2709,24 @@
           <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_bea008af-1e51-4729-8ce8-0d6a9ec69a44_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,7 +2734,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bea008af-1e51-4729-8ce8-0d6a9ec69a44_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2765,7 +2743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2775,23 +2753,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43474_RXN0-2921>
 ] .
-
-<http://model.geneontology.org/a1c520bc-23ee-442c-8be2-10377f960c5b_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -2805,7 +2766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2818,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2833,7 +2794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2848,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2862,7 +2823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2873,12 +2834,29 @@
           <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
+<http://model.geneontology.org/4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002333_YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2887,13 +2865,24 @@
 <http://identifiers.org/sgd/S000004719>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2911,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2928,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2941,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2956,7 +2945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2969,11 +2958,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_7da5f3e8-ee27-49b8-8aff-704acfc8e0f8_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2981,7 +2970,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7da5f3e8-ee27-49b8-8aff-704acfc8e0f8_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2990,7 +2979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3006,18 +2995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_0b09c235-0e71-4c84-81a2-78e09041df4d_RXN3O-22_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3046,7 +3024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3060,33 +3038,33 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/300dafb4-fabd-4bf0-9459-d816048ff66f_RXN3O-681>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3096,7 +3074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3107,7 +3085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3135,7 +3113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3153,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3167,7 +3145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3186,11 +3164,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_808ef3af-21ea-4bf3-829a-a91a86fc48b7_1.5.1.20-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3198,7 +3176,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/808ef3af-21ea-4bf3-829a-a91a86fc48b7_1.5.1.20-RXN>
+          <http://model.geneontology.org/c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3209,7 +3187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3221,7 +3199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,7 +3219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3254,7 +3232,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3268,7 +3257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3279,20 +3268,20 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/7da5f3e8-ee27-49b8-8aff-704acfc8e0f8_FORMATETHFLIG-RXN>
+<http://model.geneontology.org/13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3301,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3313,7 +3302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3324,12 +3313,12 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_c88c1ca4-9f40-479f-acb5-183887bb5a47_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3341,7 +3330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3359,7 +3348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3376,7 +3365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3384,24 +3373,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_49b49e15-9694-4c62-9e00-377699de2a85_FORMATETHFLIG-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3418,7 +3396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3434,7 +3412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3447,7 +3425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3460,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3472,7 +3450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3488,7 +3466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3500,7 +3478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3511,13 +3489,30 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
+<http://model.geneontology.org/d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_4caf6853-d425-4346-89a4-11893d9bbbcc_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3525,7 +3520,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4caf6853-d425-4346-89a4-11893d9bbbcc_FOLYLPOLYGLUTAMATESYNTH-RXN>
+          <http://model.geneontology.org/bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-20>
@@ -3533,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3548,7 +3543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3568,7 +3563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3581,7 +3576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3596,7 +3591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3607,23 +3602,6 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/f563745d-9ad2-4e14-9018-de426b28d6ac_RXN0-2921>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3633,7 +3611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3641,16 +3619,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_e8182ac5-64dc-4f70-88b5-5613a19d3fc8_RXN0-2921_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3658,7 +3647,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e8182ac5-64dc-4f70-88b5-5613a19d3fc8_RXN0-2921>
+          <http://model.geneontology.org/63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-681>
@@ -3670,7 +3659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3684,7 +3673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3703,11 +3692,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3718,7 +3724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3738,9 +3744,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/bea008af-1e51-4729-8ce8-0d6a9ec69a44_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/f50c8c40-b12d-4b11-ae8b-210f28619b38_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3748,7 +3754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3761,7 +3767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3776,7 +3782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3789,7 +3795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3803,7 +3809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3823,7 +3829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3840,7 +3846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3857,7 +3863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3877,7 +3883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3888,6 +3894,17 @@
           <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/1.5.1.20-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3897,9 +3914,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/808ef3af-21ea-4bf3-829a-a91a86fc48b7_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/95e27e67-e495-4087-af2b-2d01c647644f_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3907,7 +3924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3920,7 +3937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3931,7 +3948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3945,7 +3962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3956,6 +3973,17 @@
           <http://model.geneontology.org/reaction_RXN0-2921_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_RXN3O-681>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3965,11 +3993,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64820> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3979,7 +4024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4001,7 +4046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4015,7 +4060,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4036,7 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4049,11 +4105,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22_SGD_PWY3O-20> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22>
+] .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4064,7 +4137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4072,29 +4145,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a1c520bc-23ee-442c-8be2-10377f960c5b_RXN3O-22_SGD_PWY3O-20> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a1c520bc-23ee-442c-8be2-10377f960c5b_RXN3O-22>
-] .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4109,7 +4165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4139,7 +4195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4147,51 +4203,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/5c2c78cd-9983-4d55-92dd-e10c0c7f332e_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4203,7 +4242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4216,11 +4255,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_cfa11142-52a1-4dee-84ac-ffea702a8a07_RXN3O-681_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4228,23 +4267,23 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cfa11142-52a1-4dee-84ac-ffea702a8a07_RXN3O-681>
+          <http://model.geneontology.org/13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681>
 ] .
 
-<http://model.geneontology.org/49b49e15-9694-4c62-9e00-377699de2a85_FORMATETHFLIG-RXN>
+<http://model.geneontology.org/1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4257,7 +4296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4277,7 +4316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4290,7 +4329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4298,11 +4337,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_232f309a-19dd-428b-a854-c44929050c57_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4310,7 +4349,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/232f309a-19dd-428b-a854-c44929050c57_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4319,7 +4358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4336,7 +4375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4347,23 +4386,6 @@
           <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller>
 ] .
 
-<http://model.geneontology.org/f50c8c40-b12d-4b11-ae8b-210f28619b38_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4373,7 +4395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4390,7 +4412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4410,7 +4432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4427,7 +4449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4438,23 +4460,12 @@
           <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_f563745d-9ad2-4e14-9018-de426b28d6ac_RXN0-2921_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4469,21 +4480,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule65023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_cfa11142-52a1-4dee-84ac-ffea702a8a07_RXN3O-681_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .

--- a/models/PWY3O-214-PWY3O-214.ttl
+++ b/models/PWY3O-214-PWY3O-214.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,39 +20,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_58095_2.6.1.28-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.28-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_2.6.1.28-RXN>
+          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller>
+          <http://model.geneontology.org/reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214>
@@ -60,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +73,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -117,41 +130,52 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-tryptophan + 3-phenyl-2-oxopropanoate &harr; (indol-3-yl)pyruvate + L-phenylalanine' 'null' '(indol-3-yl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (indol-3-yl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_4.1.1.74-RXN_null_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.74-RXN> ;
+          <http://model.geneontology.org/2.6.1.28-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_4.1.1.74-RXN>
+          <http://model.geneontology.org/4.1.1.74-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_18086_1.1.1.190-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.190-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18086_1.1.1.190-RXN>
+          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+        a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17640_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17640> ;
@@ -162,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,43 +194,67 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-58_4.1.1.74-RXN_controller_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.28-RXN> ;
+          <http://model.geneontology.org/4.1.1.74-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
+          <http://model.geneontology.org/CPLX3O-58_4.1.1.74-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.1.190-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDL168W-MONOMER_1.1.1.190-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-118_4.1.1.74-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_4.1.1.74-RXN_null_PWY3O-214>
@@ -214,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -227,10 +275,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,22 +346,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-tryptophan + 3-phenyl-2-oxopropanoate &harr; (indol-3-yl)pyruvate + L-phenylalanine' 'null' '(indol-3-yl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (indol-3-yl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_4.1.1.74-RXN_null_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_2.6.1.28-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.28-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.1.1.74-RXN>
+          <http://model.geneontology.org/CHEBI_57912_2.6.1.28-RXN>
 ] .
 
 <http://model.geneontology.org/YOL086C-MONOMER_1.1.1.190-RXN_controller>
@@ -321,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,19 +379,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-58_4.1.1.74-RXN_controller_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_15378_4.1.1.74-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.1.1.74-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_4.1.1.74-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_4.1.1.74-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1.1.1.190-RXN>
@@ -355,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -379,19 +427,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_57540_1.1.1.190-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.190-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDL168W-MONOMER_1.1.1.190-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57540_1.1.1.190-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -402,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -438,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,158 +496,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_2.6.1.28-RXN_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.28-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57912_2.6.1.28-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_17640_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17640_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002411_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004688>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_18086_1.1.1.190-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18086> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(indol-3-yl)acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41970> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_15378_4.1.1.74-RXN_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.74-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_4.1.1.74-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_57540_1.1.1.190-RXN_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.190-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.1.1.190-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002411_1.1.1.190-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,6 +526,195 @@
           <http://model.geneontology.org/1.1.1.190-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR303C-MONOMER_1.1.1.190-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-71_4.1.1.74-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002411_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_18086_1.1.1.190-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18086> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(indol-3-yl)acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41970> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.28-RXN_controller_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.28-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.28-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.74-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18086_4.1.1.74-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_57945_1.1.1.190-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.1.190-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_1.1.1.190-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0050362>
@@ -641,20 +731,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/CPLX3O-71_4.1.1.74-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,15 +757,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YOL086C-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -692,27 +784,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.28-RXN_controller_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_null_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.28-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.28-RXN_controller>
+          <http://model.geneontology.org/reaction_2.6.1.28-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_4.1.1.74-RXN>
@@ -724,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -745,19 +839,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002411_2.6.1.28-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.6.1.28-RXN>
+          <http://model.geneontology.org/CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_18086>
@@ -770,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -800,10 +894,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,39 +909,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.1.1.74-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18086_4.1.1.74-RXN>
+          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
 ] .
 
 <http://model.geneontology.org/reaction_4.1.1.74-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_57945_1.1.1.190-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000066_reaction_1.1.1.190-RXN_location_lociGO_0005829_null_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.190-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.1.1.190-RXN>
+          <http://model.geneontology.org/reaction_1.1.1.190-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17890>
@@ -864,10 +962,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -896,169 +996,12 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_null_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.28-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.6.1.28-RXN_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_18005_2.6.1.28-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18005> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-phenyl-2-oxopropanoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41860> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.74-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000066_reaction_1.1.1.190-RXN_location_lociGO_0005829_null_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.190-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.1.1.190-RXN_location_lociGO_0005829>
-] .
-
-<http://identifiers.org/sgd/S000003225>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_15378_1.1.1.190-RXN_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_18086_4.1.1.74-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_18086> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(indol-3-yl)acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41970> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57912> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "trp" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41843> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_18005>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-67_4.1.1.74-RXN_controller_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1075,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,6 +1029,179 @@
           <http://model.geneontology.org/YGL256W-MONOMER_1.1.1.190-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_18005_2.6.1.28-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18005> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-phenyl-2-oxopropanoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41860> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-58_4.1.1.74-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_17640_2.6.1.28-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.28-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17640_2.6.1.28-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_17640_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17640_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
+] .
+
+<http://identifiers.org/sgd/S000003225>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_15378_1.1.1.190-RXN_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_18086_4.1.1.74-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_18086> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(indol-3-yl)acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41970> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57912> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "trp" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41843> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_18005>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_4.1.1.74-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.74-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17640_4.1.1.74-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_15378_1.1.1.190-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.1.190-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_1.1.1.190-RXN>
+] .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_17640_2.6.1.28-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17640> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1095,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1133,36 +1249,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_17640_2.6.1.28-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YOL086C-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.28-RXN> ;
+          <http://model.geneontology.org/1.1.1.190-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17640_2.6.1.28-RXN>
+          <http://model.geneontology.org/YOL086C-MONOMER_1.1.1.190-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YGL256W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214>
@@ -1170,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1179,14 +1295,19 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CPLX3O-58_4.1.1.74-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,27 +1317,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_4.1.1.74-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002411_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.74-RXN> ;
+          <http://model.geneontology.org/2.6.1.28-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17640_4.1.1.74-RXN>
+          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002411_1.1.1.190-RXN_SGD_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1224,19 +1354,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_15378_1.1.1.190-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002411_2.6.1.28-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.190-RXN> ;
+          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.1.1.190-RXN>
+          <http://model.geneontology.org/2.6.1.28-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002327>
@@ -1244,6 +1374,17 @@
 
 <http://identifiers.org/sgd/S000004918>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/4.1.1.74-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0047434> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1264,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1277,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1292,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tryptophan degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1308,18 +1449,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-118_4.1.1.74-RXN_controller_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.74-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-118_4.1.1.74-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-58_4.1.1.74-RXN_controller_SGD_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1327,11 +1485,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YOL086C-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YBR145W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1497,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.190-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL086C-MONOMER_1.1.1.190-RXN_controller>
+          <http://model.geneontology.org/YBR145W-MONOMER_1.1.1.190-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_4.1.1.74-RXN>
@@ -1351,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1372,19 +1530,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002411_2.6.1.28-RXN_SGD_PWY3O-214>
@@ -1392,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1415,13 +1573,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214BiochemicalReaction41899> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000000349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1433,7 +1594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1473,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1483,195 +1644,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002411_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.28-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.190-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-214/PWY3O-214>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_4.1.1.74-RXN_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001179>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/YHR137W-MONOMER_2.6.1.28-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001179> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aromatic amino acid aminotransferase II" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214Protein41896> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-118_4.1.1.74-RXN_controller_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.74-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_4.1.1.74-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YBR145W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.190-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR145W-MONOMER_1.1.1.190-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_null_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0047299>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_2.6.1.28-RXN_SGD_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_1.1.1.190-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/CHEBI_57540_1.1.1.190-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41928> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_18005_2.6.1.28-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,12 +1676,238 @@
           <http://model.geneontology.org/CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_4.1.1.74-RXN_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001179>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YHR137W-MONOMER_2.6.1.28-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001179> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aromatic amino acid aminotransferase II" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214Protein41896> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000066_reaction_4.1.1.74-RXN_location_lociGO_0005829_null_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.74-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_4.1.1.74-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_17890_1.1.1.190-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.1.190-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17890_1.1.1.190-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_null_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0047299>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_2.6.1.28-RXN_SGD_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_1.1.1.190-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.74-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-71_4.1.1.74-RXN_controller>
+] .
+
+<http://model.geneontology.org/CHEBI_57540_1.1.1.190-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214SmallMolecule41928> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR083W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.1.190-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR083W-MONOMER_1.1.1.190-RXN_controller>
+] .
+
+<http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002788> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-67_4.1.1.74-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+] .
+
 <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_17640_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1719,13 +1922,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "PWY3O-214" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005446>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1735,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1744,31 +1956,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000066_reaction_4.1.1.74-RXN_location_lociGO_0005829_null_PWY3O-214> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.74-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_4.1.1.74-RXN_location_lociGO_0005829>
-] .
-
 <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1776,19 +1969,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_17890_1.1.1.190-RXN_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_58095_2.6.1.28-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.190-RXN> ;
+          <http://model.geneontology.org/2.6.1.28-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17890_1.1.1.190-RXN>
+          <http://model.geneontology.org/CHEBI_58095_2.6.1.28-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPTOPHAN-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/YBR145W-MONOMER_1.1.1.190-RXN_controller>
@@ -1798,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1830,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1840,41 +2050,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.1.1.74-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-71_4.1.1.74-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_4.1.1.74-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58095>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_17640_2.6.1.28-RXN_SGD_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58095>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_57540_1.1.1.190-RXN_SGD_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1882,19 +2092,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR083W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_18086_1.1.1.190-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.1.190-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR083W-MONOMER_1.1.1.190-RXN_controller>
+          <http://model.geneontology.org/CHEBI_18086_1.1.1.190-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17640_4.1.1.74-RXN>
@@ -1906,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1915,4 +2125,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0047018>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002788>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/PWY3O-2220-PWY3O-2220.ttl
+++ b/models/PWY3O-2220-PWY3O-2220.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of adenine, hypoxanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -624,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,7 +947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1036,7 +1036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1084,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1343,7 +1343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,17 +1354,6 @@
           <http://model.geneontology.org/CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine + ATP &rarr; AMP + ADP + H<SUP>+</SUP>' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -1373,7 +1362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1384,6 +1373,17 @@
           <http://model.geneontology.org/AMP-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_ADENOSINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1463,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1542,7 +1542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1554,7 +1554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1591,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,7 +1639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1789,7 +1789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1884,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1921,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1965,7 +1965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,7 +2009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2099,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2125,7 +2125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,7 +2160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2222,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2236,7 +2236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2289,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2349,7 +2349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2362,7 +2362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-224-PWY3O-224.ttl
+++ b/models/PWY3O-224-PWY3O-224.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,6 +81,9 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000005073>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -93,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -113,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,14 +293,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,13 +357,13 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/MONOMER3O-4139_RXN-8443_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005073> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "nicotinic acid riboside kinase / nicotinamide ribose kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-230-PWY3O-230.ttl
+++ b/models/PWY3O-230-PWY3O-230.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,7 +19,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,8 +36,25 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/dd26c886-44a3-4d1c-bf52-424604199833_GLYOHMETRANS-RXN>
+<http://model.geneontology.org/2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -45,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,11 +81,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_dd26c886-44a3-4d1c-bf52-424604199833_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,7 +93,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dd26c886-44a3-4d1c-bf52-424604199833_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -86,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,6 +123,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN_SGD_PWY3O-230>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -115,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,17 +176,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_dd26c886-44a3-4d1c-bf52-424604199833_GLYOHMETRANS-RXN_SGD_PWY3O-230>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -175,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -188,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -255,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -269,38 +286,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/50b7e7ba-18b2-42a8-aef1-4583531faf03_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN_SGD_PWY3O-230>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY3O-230>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -311,11 +322,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_50b7e7ba-18b2-42a8-aef1-4583531faf03_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +334,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/50b7e7ba-18b2-42a8-aef1-4583531faf03_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -341,15 +352,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/dd26c886-44a3-4d1c-bf52-424604199833_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/50b7e7ba-18b2-42a8-aef1-4583531faf03_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,23 +368,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_50b7e7ba-18b2-42a8-aef1-4583531faf03_GLYOHMETRANS-RXN_SGD_PWY3O-230>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY3O-230/PWY3O-230_SGD_PWY3O-230>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "serine biosynthesis from glyoxylate - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-236-PWY3O-236.ttl
+++ b/models/PWY3O-236-PWY3O-236.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-238-PWY3O-238.ttl
+++ b/models/PWY3O-238-PWY3O-238.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,23 +143,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/9a19fa91-c9bd-4edd-a3f2-1525f564831b_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -169,7 +152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -219,6 +202,23 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,16 +294,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22_SGD_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a0f75393-deb2-4449-be09-3cef65cc20f4_RXN3O-22_SGD_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22_SGD_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +339,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a0f75393-deb2-4449-be09-3cef65cc20f4_RXN3O-22>
+          <http://model.geneontology.org/3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -320,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,6 +359,17 @@
           <http://model.geneontology.org/CHEBI_58199_HOMOCYSMET-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22_SGD_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -339,18 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_9a19fa91-c9bd-4edd-a3f2-1525f564831b_RXN3O-22_SGD_PWY3O-238>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -438,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -532,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -573,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -656,24 +684,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a0f75393-deb2-4449-be09-3cef65cc20f4_RXN3O-22_SGD_PWY3O-238>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_PWY3O-238/PWY3O-238_SGD_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -743,23 +760,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/a0f75393-deb2-4449-be09-3cef65cc20f4_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -772,9 +772,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/a0f75393-deb2-4449-be09-3cef65cc20f4_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> , <http://model.geneontology.org/9a19fa91-c9bd-4edd-a3f2-1525f564831b_RXN3O-22> ;
+                <http://model.geneontology.org/ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -809,11 +809,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_9a19fa91-c9bd-4edd-a3f2-1525f564831b_RXN3O-22_SGD_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22_SGD_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +821,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9a19fa91-c9bd-4edd-a3f2-1525f564831b_RXN3O-22>
+          <http://model.geneontology.org/ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-242-PWY3O-242.ttl
+++ b/models/PWY3O-242-PWY3O-242.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,29 +80,12 @@
           <http://model.geneontology.org/MONOMER3O-107_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/dea68c2b-caf8-479b-bb51-1da591ef5ccc_RXN-10938>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +100,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-10938_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/dea68c2b-caf8-479b-bb51-1da591ef5ccc_RXN-10938> , <http://model.geneontology.org/CHEBI_15377_RXN-10938> ;
+                <http://model.geneontology.org/3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938> , <http://model.geneontology.org/CHEBI_15377_RXN-10938> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17283_RXN-10938> , <http://model.geneontology.org/CHEBI_43474_RXN-10938> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -127,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -157,20 +140,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002333_YFR019W-MONOMER_2.7.1.150-RXN_controller_SGD_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -183,13 +155,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42976> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002333_YFR019W-MONOMER_2.7.1.150-RXN_controller_SGD_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -200,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,13 +279,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-365_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004296> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4-kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -362,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -446,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +491,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_17283_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/6a3667d7-d5a6-4c55-9e63-02d9c411197f_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
+                <http://model.geneontology.org/fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFR019W-MONOMER_2.7.1.150-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -516,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,24 +530,13 @@
           <http://model.geneontology.org/CHEBI_30616_2.7.1.150-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_184fdcfc-e1ce-4a88-af00-a124651edb21_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,13 +624,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000003871>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_17526_2.7.1.68-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,13 +645,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-76_RXN3O-364_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003871> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 3-phosphate phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -821,20 +796,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-352_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003636> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4-kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -851,13 +826,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42960> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000004296>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -867,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -897,7 +875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -934,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -976,7 +954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,12 +965,29 @@
           <http://model.geneontology.org/CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
 ] .
 
+<http://model.geneontology.org/fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000050_PWY3O-242/PWY3O-242_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1030,11 +1025,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_6a3667d7-d5a6-4c55-9e63-02d9c411197f_2.7.1.150-RXN_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1037,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.150-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6a3667d7-d5a6-4c55-9e63-02d9c411197f_2.7.1.150-RXN>
+          <http://model.geneontology.org/fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1051,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,31 +1077,12 @@
           <http://model.geneontology.org/MONOMER3O-72_RXN-10961_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_null_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.7.1.68-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1121,13 +1097,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42987> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_null_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.7.1.68-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-364>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1138,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1153,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1169,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1180,11 +1175,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005050>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1192,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1223,7 +1221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1283,7 +1281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1334,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,7 +1410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1454,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,6 +1490,17 @@
           <http://model.geneontology.org/MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000050_PWY3O-242/PWY3O-242_SGD_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1501,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1509,23 +1518,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000050_PWY3O-242/PWY3O-242_SGD_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829_null_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1557,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1577,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1585,24 +1583,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_6a3667d7-d5a6-4c55-9e63-02d9c411197f_2.7.1.150-RXN_SGD_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000050_PWY3O-242/PWY3O-242_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1619,7 +1606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,47 +1620,44 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_456216_2.7.1.68-RXN_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_RXN3O-364_null_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1684,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1711,7 +1695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1760,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1771,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1794,29 +1778,15 @@
           <http://model.geneontology.org/MONOMER3O-365_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/6a3667d7-d5a6-4c55-9e63-02d9c411197f_2.7.1.150-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-69_RXN3O-364_controller_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1828,7 +1798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1858,7 +1828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1875,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1894,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1907,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1920,7 +1890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1933,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,11 +1920,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43043> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1963,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1974,11 +1961,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1986,7 +1990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2006,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2042,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2057,7 +2061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2073,7 +2077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2084,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2110,13 +2114,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000002616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://identifiers.org/sgd/S000001915>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004438>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0016308>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN>
@@ -2128,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2136,28 +2143,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/MONOMER3O-86_RXN-10938_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylinositol 3,5-bisphosphate 5-phosphatase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43069> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_57880_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,13 +2160,45 @@
           <http://model.geneontology.org/CHEBI_57880_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/MONOMER3O-86_RXN-10938_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005269> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylinositol 3,5-bisphosphate 5-phosphatase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43069> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2205,7 +2229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2216,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2227,14 +2251,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0016308>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000066_reaction_2.7.1.68-RXN_location_lociGO_0005829_null_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2242,7 +2285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,44 +2296,16 @@
           <http://model.geneontology.org/CHEBI_17283_RXN3O-364>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000066_reaction_2.7.1.68-RXN_location_lociGO_0005829_null_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-72_RXN-10961_controller_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10938> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN-10938>
-] .
 
 <http://model.geneontology.org/1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0016303> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2311,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2319,12 +2334,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10938> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_RXN-10938>
+] .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2339,7 +2371,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/184fdcfc-e1ce-4a88-af00-a124651edb21_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2349,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2366,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2379,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2390,7 +2422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2401,28 +2433,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/184fdcfc-e1ce-4a88-af00-a124651edb21_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000005269>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43474_RXN-10938>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -2433,7 +2451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2465,7 +2483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2477,7 +2495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2496,7 +2514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2512,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2523,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2535,7 +2553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2574,7 +2592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2585,7 +2603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2594,15 +2612,27 @@
 <http://purl.obolibrary.org/obo/CHEBI_17283>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/MONOMER3O-69_RXN-10938_controller>
+        a       <http://identifiers.org/sgd/S000005050> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43025> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_RXN-10961_null_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2613,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2624,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2635,35 +2665,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/MONOMER3O-69_RXN-10938_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43025> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-69_RXN3O-364_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005050> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2678,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2692,7 +2710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2712,7 +2730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2725,7 +2743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2739,7 +2757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2758,7 +2776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2769,17 +2787,6 @@
           <http://model.geneontology.org/1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_dea68c2b-caf8-479b-bb51-1da591ef5ccc_RXN-10938_SGD_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0016303>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2789,7 +2796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2809,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2828,7 +2835,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_17526_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bf4135e0-39df-4046-817a-420c8ed4e21f_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR208W-MONOMER_2.7.1.68-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2836,7 +2843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2848,13 +2855,13 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/MONOMER3O-69_RXN-10961_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005050> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2864,11 +2871,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_bf4135e0-39df-4046-817a-420c8ed4e21f_2.7.1.68-RXN_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2876,7 +2883,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.68-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bf4135e0-39df-4046-817a-420c8ed4e21f_2.7.1.68-RXN>
+          <http://model.geneontology.org/e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
@@ -2888,7 +2895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2902,7 +2909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2913,13 +2920,24 @@
           <http://model.geneontology.org/CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN_SGD_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-55_RXN3O-364_controller_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2936,7 +2954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2956,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2970,7 +2988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2987,7 +3005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3004,7 +3022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3023,7 +3041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3035,7 +3053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3051,7 +3069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3066,7 +3084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3086,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3099,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3124,7 +3142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3137,7 +3155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3152,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3168,7 +3186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3190,7 +3208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3202,13 +3220,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005050> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3221,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3235,7 +3253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3254,11 +3272,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_dea68c2b-caf8-479b-bb51-1da591ef5ccc_RXN-10938_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3284,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10938> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dea68c2b-caf8-479b-bb51-1da591ef5ccc_RXN-10938>
+          <http://model.geneontology.org/3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938>
 ] .
 
 <http://model.geneontology.org/YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller>
@@ -3276,7 +3294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3284,39 +3302,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://identifiers.org/sgd/S000003636>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/bf4135e0-39df-4046-817a-420c8ed4e21f_2.7.1.68-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_bf4135e0-39df-4046-817a-420c8ed4e21f_2.7.1.68-RXN_SGD_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3324,7 +3317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3340,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3352,7 +3345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,7 +3364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3387,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3398,7 +3391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3406,11 +3399,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_184fdcfc-e1ce-4a88-af00-a124651edb21_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3418,7 +3411,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/184fdcfc-e1ce-4a88-af00-a124651edb21_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
+          <http://model.geneontology.org/b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-55_RXN-10938_controller_SGD_PWY3O-242>
@@ -3426,7 +3419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3437,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3458,7 +3451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3472,7 +3465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3489,7 +3482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3505,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3517,7 +3510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3537,7 +3530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3553,7 +3546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3564,12 +3557,34 @@
           <http://model.geneontology.org/RXN-10961>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3584,7 +3599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3597,7 +3612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3612,30 +3627,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43121> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.1.68-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-10961>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -3646,13 +3644,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42976> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.1.68-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/GO_0004439>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3663,7 +3678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3680,7 +3695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3696,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3708,7 +3723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3724,7 +3739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3739,7 +3754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3752,7 +3767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3764,7 +3779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-246-PWY3O-246.ttl
+++ b/models/PWY3O-246-PWY3O-246.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -39,19 +39,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -69,13 +69,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-246SmallMolecule26166> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -88,22 +91,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000056>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +117,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -125,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -140,24 +146,52 @@
 <http://purl.obolibrary.org/obo/CHEBI_16982>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-246> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -172,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "(R,R)-butanediol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -233,19 +267,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
@@ -257,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -266,22 +300,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-246/PWY3O-246_SGD_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-246/PWY3O-246>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
@@ -295,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,11 +358,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +370,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -349,19 +381,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-246/PWY3O-246_SGD_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-246/PWY3O-246>
+          <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -377,10 +409,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,3-butanediol dehydrogenase / diacetyl reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,11 +458,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,15 +470,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-246>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-246>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-246" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-259-PWY3O-259.ttl
+++ b/models/PWY3O-259-PWY3O-259.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,26 +83,26 @@
 <http://model.geneontology.org/reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY3O-259>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY3O-259>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -273,7 +273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis II (Kennedy pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -786,23 +786,6 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-259SmallMolecule21017> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57876_2.7.7.14-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -813,11 +796,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-259SmallMolecule20884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-259SmallMolecule21017> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,7 +1005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-261-PWY3O-261.ttl
+++ b/models/PWY3O-261-PWY3O-261.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,23 +79,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller>
 ] .
-
-<http://model.geneontology.org/802d1825-0426-4d95-bd39-acd3493f403a_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004647>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -108,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -317,6 +300,17 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN_SGD_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -330,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,18 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_802d1825-0426-4d95-bd39-acd3493f403a_GLYOHMETRANS-RXN_SGD_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -398,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,12 +471,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://identifiers.org/sgd/S000001864>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -511,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -553,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,17 +584,6 @@
           <http://model.geneontology.org/CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_ec307b5b-ee78-40ca-8ad8-3d51a68fc7ff_GLYOHMETRANS-RXN_SGD_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001336> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -616,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -756,11 +731,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_802d1825-0426-4d95-bd39-acd3493f403a_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +743,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/802d1825-0426-4d95-bd39-acd3493f403a_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57524_RXN0-5114>
@@ -780,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,11 +1104,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_ec307b5b-ee78-40ca-8ad8-3d51a68fc7ff_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1116,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ec307b5b-ee78-40ca-8ad8-3d51a68fc7ff_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001336>
@@ -1159,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1278,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,14 +1308,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1350,7 +1322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1377,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1388,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1410,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1439,15 +1411,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/802d1825-0426-4d95-bd39-acd3493f403a_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/ec307b5b-ee78-40ca-8ad8-3d51a68fc7ff_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,7 +1450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,7 +1473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of serine and glycine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1526,28 +1498,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/GO_0004617>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_RXN0-5114_SGD_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004617>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000001864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "alanine:glyoxylate aminotransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1561,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,13 +1581,24 @@
           <http://model.geneontology.org/YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN_SGD_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,11 +1620,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1632,7 +1649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1668,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1682,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1698,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1712,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1740,7 +1757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,7 +1774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1801,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1814,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1828,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1872,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1890,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1906,7 +1923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,7 +1943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1945,7 +1962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1970,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2017,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2029,7 +2046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2045,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2057,7 +2074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2074,7 +2091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2090,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2101,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,28 +2146,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ec307b5b-ee78-40ca-8ad8-3d51a68fc7ff_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2158,7 +2158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,7 +2177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2190,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,7 +2237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2264,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-285-PWY3O-285.ttl
+++ b/models/PWY3O-285-PWY3O-285.ttl
@@ -3,11 +3,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002411_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN>
+] .
 
 <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -17,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,19 +181,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
@@ -184,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,19 +237,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_null_PWY3O-285>
@@ -240,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -250,20 +267,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000066_reaction_RXN-7607_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-7607> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
+          <http://model.geneontology.org/reaction_RXN-7607_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/AIRS-RXN>
@@ -285,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,36 +317,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
+          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58564>
@@ -340,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -375,19 +394,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_AMP-DEAMINASE-RXN>
@@ -399,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,22 +449,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -454,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,25 +480,6 @@
           <http://model.geneontology.org/AIRS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
@@ -493,13 +491,89 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33444> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004731>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hypoxanthine guanine phosphoribosyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34124> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -510,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,83 +592,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hypoxanthine guanine phosphoribosyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34124> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0004731>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -632,28 +636,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/b8e39aa3-11f4-4ee1-aaf8-3dc077d972ec_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -664,13 +651,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33577> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -679,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,7 +698,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -703,47 +737,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -754,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,19 +762,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -785,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,24 +896,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004643>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
 <http://model.geneontology.org/RXN0-745>
@@ -935,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,57 +950,58 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GUANPRIBOSYLTRAN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
@@ -1001,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1031,38 +1039,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002411_RXN-7607_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-7607>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_910518fb-e836-4a70-80cc-05587d893ac7_GART-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1077,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1127,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,19 +1137,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY3O-285>
@@ -1160,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1183,7 +1180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1222,21 +1219,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1247,7 +1255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,27 +1269,27 @@
 <http://purl.obolibrary.org/obo/GO_0008892>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_58457>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FGAMSYN-RXN>
+          <http://model.geneontology.org/AIRS-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_58457>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_17596_INOPHOSPHOR-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17596> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1292,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1301,12 +1309,31 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,32 +1344,21 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_9d56acbf-93b8-4c05-88b9-713bc4142c20_AICARTRANSFORM-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_AICARSYN-RXN_SGD_PWY3O-285>
@@ -1350,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1389,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1402,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1418,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1426,19 +1442,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1447,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1487,19 +1503,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17596_RXN-7607>
+          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY3O-285>
@@ -1507,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1521,46 +1537,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/450b6141-f4e7-4ceb-906b-a01231e41ec8_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_PWY3O-285>
@@ -1568,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1578,36 +1575,36 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/AICARSYN-RXN>
@@ -1629,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1646,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1656,19 +1653,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1677,7 +1674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,6 +1685,17 @@
           <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1697,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1710,19 +1718,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-746>
@@ -1734,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1748,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,7 +1775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,19 +1805,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
@@ -1817,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1829,7 +1837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1840,51 +1848,51 @@
           <http://model.geneontology.org/CHEBI_15378_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
-] .
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1897,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1911,7 +1919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1946,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,19 +1964,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_XANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004637>
@@ -1983,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2003,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2030,17 +2038,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
@@ -2050,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2058,19 +2066,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_INOPHOSPHOR-RXN>
+          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17368>
@@ -2081,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2089,20 +2097,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000005681_CPLX3O-11_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005681> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2113,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,29 +2140,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://model.geneontology.org/CPLX3O-11_RXN-7607_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "inosine 5' monophosphate (IMP)-specific 5' nucleotidase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005681_CPLX3O-11_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2158,7 +2177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2169,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2194,7 +2213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2211,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2224,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2242,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2252,19 +2271,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17596_RXN-7607>
@@ -2276,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2290,7 +2309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2320,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2328,19 +2347,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
+          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2349,7 +2368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2362,19 +2381,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY3O-285>
@@ -2382,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2414,7 +2433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2428,7 +2447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2460,22 +2479,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-746>
+          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY3O-285>
@@ -2483,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,7 +2528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2533,7 +2550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2548,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,7 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2578,7 +2595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2589,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2600,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2615,7 +2632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2625,38 +2642,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2664,38 +2681,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_RXN-7607_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-7607> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
+          <http://model.geneontology.org/CHEBI_58053_RXN-7607>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15377_GUANINE-DEAMINASE-RXN>
 ] .
 
 <http://model.geneontology.org/YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller>
@@ -2705,7 +2720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2718,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2728,20 +2743,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
@@ -2752,7 +2769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2763,7 +2780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2778,7 +2795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,19 +2805,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPREDUCT-RXN>
+          <http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
 ] .
 
 <http://www.w3.org/2004/02/skos/core#note>
@@ -2811,29 +2828,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
@@ -2845,7 +2860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2859,7 +2874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2871,37 +2886,39 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
+          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2910,7 +2927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2947,7 +2964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2956,43 +2973,26 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
+          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000003293>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AICARSYN-RXN>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3000,7 +3000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3012,12 +3012,31 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3037,9 +3056,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/b8e39aa3-11f4-4ee1-aaf8-3dc077d972ec_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/910518fb-e836-4a70-80cc-05587d893ac7_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3047,7 +3066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3055,13 +3074,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3077,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3088,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3101,7 +3123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3114,18 +3136,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_17712_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17712_XANPRIBOSYLTRAN-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3136,7 +3175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3149,7 +3188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3162,7 +3201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3180,7 +3219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3190,19 +3229,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY3O-285>
@@ -3210,18 +3249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3229,20 +3257,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3256,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3266,19 +3305,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_17596_INOPHOSPHOR-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005085>
@@ -3293,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3310,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3323,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3338,7 +3377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3347,22 +3386,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
@@ -3374,7 +3411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3391,7 +3428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3418,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3428,19 +3465,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GUANINE-DEAMINASE-RXN>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002807>
@@ -3455,7 +3492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3470,7 +3507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3486,7 +3523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3505,20 +3542,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+<http://model.geneontology.org/0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "ribonucleotide reductase" ;
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3531,19 +3587,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_43474_RXN-7607_SGD_PWY3O-285>
@@ -3551,7 +3607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3559,11 +3615,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_450b6141-f4e7-4ceb-906b-a01231e41ec8_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3571,11 +3627,20 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/450b6141-f4e7-4ceb-906b-a01231e41ec8_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3584,19 +3649,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
@@ -3608,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3621,7 +3686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3633,7 +3698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3649,19 +3714,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_AMP-DEAMINASE-RXN_SGD_PWY3O-285>
@@ -3669,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3680,7 +3745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3692,7 +3757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3705,19 +3770,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 <http://identifiers.org/sgd/S000004424>
@@ -3732,13 +3797,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33858> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002411_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YER170W-MONOMER_ADENYL-KIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000972> ;
@@ -3747,7 +3823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3755,12 +3831,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002411_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3771,7 +3847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3786,7 +3862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3796,19 +3872,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_PWY3O-285>
@@ -3816,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3831,7 +3907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3851,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3864,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3877,7 +3953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3897,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3907,19 +3983,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002333_CPLX3O-11_RXN-7607_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-11_RXN-7607_controller>
+          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_ADENOSINE-KINASE-RXN>
@@ -3931,7 +4007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3940,22 +4016,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY3O-285>
@@ -3963,7 +4037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3974,7 +4048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3982,19 +4056,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
 <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
@@ -4016,7 +4090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4029,29 +4103,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_null_PWY3O-285>
@@ -4059,7 +4131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4067,19 +4139,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR209C-MONOMER_INOPHOSPHOR-RXN_controller>
+          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY3O-285>
@@ -4087,7 +4159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4102,7 +4174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4121,7 +4193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4136,7 +4208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4163,7 +4235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4173,19 +4245,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY3O-285>
@@ -4193,7 +4265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4205,7 +4277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4217,13 +4289,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanylate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4237,7 +4309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4257,7 +4329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4267,19 +4339,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_null_PWY3O-285>
@@ -4287,7 +4359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4299,7 +4371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4315,7 +4387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4326,19 +4398,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456215_ADENPRIBOSYLTRAN-RXN>
@@ -4350,7 +4422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4364,7 +4436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4384,7 +4456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4397,7 +4469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4405,19 +4477,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4428,7 +4500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4441,19 +4513,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002411_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/SAICARSYN-RXN>
@@ -4475,7 +4547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4495,7 +4567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4515,7 +4587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4528,7 +4600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4539,7 +4611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4550,11 +4622,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58053_RXN-7607>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58053> ;
@@ -4565,7 +4640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4575,19 +4650,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
+          <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
@@ -4595,29 +4670,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002397> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanine deaminase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4629,22 +4704,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000066_reaction_RXN-7607_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-7607_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN>
@@ -4666,7 +4739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4683,7 +4756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4700,7 +4773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4710,19 +4783,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
@@ -4734,7 +4807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4754,13 +4827,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33858> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4770,19 +4854,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GART-RXN>
+          <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4791,7 +4875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4804,37 +4888,35 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/AIRCARBOXY-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_AIRCARBOXY-RXN>
+          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
 ] .
+
+<http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004915> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GPAT" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34074> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_15378_GART-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4845,7 +4927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4853,20 +4935,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004915> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GPAT" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34074> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/AIRCARBOXY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_AIRCARBOXY-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4876,7 +4960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4895,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4906,7 +4990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4917,29 +5001,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58467>
@@ -4951,7 +5033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4967,7 +5049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4978,7 +5060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5003,7 +5085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5016,19 +5098,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5039,7 +5121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5050,23 +5132,23 @@
           <http://model.geneontology.org/reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_450b6141-f4e7-4ceb-906b-a01231e41ec8_AICARTRANSFORM-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5077,7 +5159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5088,7 +5170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5099,7 +5181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5107,27 +5189,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_XANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5138,7 +5231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5146,19 +5239,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_43474_RXN-7607_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-7607> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-745>
+          <http://model.geneontology.org/CHEBI_43474_RXN-7607>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_null_PWY3O-285>
@@ -5166,7 +5259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5174,19 +5267,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GUANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_16235_GUANINE-DEAMINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY3O-285>
@@ -5194,7 +5287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5205,7 +5298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5219,7 +5312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5227,17 +5320,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
@@ -5251,7 +5344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5264,7 +5357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5275,17 +5368,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
@@ -5295,7 +5388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5306,29 +5399,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GUANINE-DEAMINASE-RXN>
+          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5342,7 +5437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5362,7 +5457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5375,7 +5470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5386,7 +5481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5397,7 +5492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5412,7 +5507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5422,19 +5517,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -5449,7 +5544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5461,31 +5556,12 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_null_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/AIRS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5497,23 +5573,49 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456215> ;
@@ -5524,7 +5626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5541,7 +5643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5553,20 +5655,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/GART-RXN>
 ] .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
@@ -5586,7 +5690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5599,7 +5703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5611,7 +5715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5622,13 +5726,24 @@
           <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_AMPSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5639,17 +5754,6 @@
           <http://model.geneontology.org/CHEBI_57567_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_37565> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5659,7 +5763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5667,27 +5771,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_AMP-DEAMINASE-RXN_null_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_AMP-DEAMINASE-RXN_null_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller>
+] .
 
 <http://model.geneontology.org/YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002849> ;
@@ -5696,7 +5817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5709,7 +5830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5724,7 +5845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5741,7 +5862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5754,44 +5875,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
+          <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003894>
@@ -5804,7 +5927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5814,19 +5937,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_17368_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_17368_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002634>
@@ -5841,7 +5964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5850,22 +5973,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-7607> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58595>
@@ -5876,7 +5997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5891,7 +6012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5904,27 +6025,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
@@ -5936,7 +6059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5949,7 +6072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5957,17 +6080,6 @@
 
 <http://model.geneontology.org/reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_RXN-7607_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5978,13 +6090,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33624> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_RXN-7607_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5995,7 +6118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6008,7 +6131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6016,19 +6139,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004748>
@@ -6036,11 +6159,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_9d56acbf-93b8-4c05-88b9-713bc4142c20_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6048,7 +6171,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9d56acbf-93b8-4c05-88b9-713bc4142c20_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -6059,19 +6182,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPKIN-RXN>
+          <http://model.geneontology.org/ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6080,7 +6203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6096,7 +6219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6107,27 +6230,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6136,7 +6261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6152,7 +6277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6160,27 +6285,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6191,17 +6327,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
@@ -6215,7 +6351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6231,7 +6367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6242,7 +6378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6260,7 +6396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6270,19 +6406,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_ADENPRIBOSYLTRAN-RXN>
@@ -6294,7 +6430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6308,7 +6444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6324,7 +6460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6335,7 +6471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6346,7 +6482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6357,7 +6493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6368,7 +6504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6383,7 +6519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6396,7 +6532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6411,7 +6547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6424,19 +6560,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7607_location_lociGO_0005829>
@@ -6447,7 +6583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6458,19 +6594,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY3O-285>
@@ -6478,7 +6614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6493,7 +6629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine biosynthesis and salvage pathways - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6503,19 +6639,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
@@ -6527,11 +6663,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33732> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glu" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33678> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6544,47 +6714,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33678> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
-] .
 
 <http://model.geneontology.org/ADPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6605,7 +6741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6614,20 +6750,22 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -6642,7 +6780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6669,7 +6807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6684,7 +6822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6697,7 +6835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6709,7 +6847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6725,7 +6863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6740,7 +6878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6750,19 +6888,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
@@ -6774,7 +6912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6790,7 +6928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6810,7 +6948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6820,19 +6958,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6841,7 +6979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6861,7 +6999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6874,7 +7012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6885,7 +7023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6893,19 +7031,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
+          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
@@ -6913,11 +7051,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6928,21 +7083,24 @@
           <http://model.geneontology.org/CHEBI_456215_ADENYL-KIN-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000005681>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_AMPSYN-RXN_SGD_PWY3O-285>
@@ -6950,7 +7108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6961,7 +7119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6976,7 +7134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6993,7 +7151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7010,7 +7168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7025,7 +7183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7050,7 +7208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7061,7 +7219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7069,19 +7227,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002411_GDPREDUCT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
+          <http://model.geneontology.org/GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
@@ -7089,7 +7247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7114,7 +7272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7131,7 +7289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7141,38 +7299,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_RXN-7607_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_RXN-7607>
+          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002849>
@@ -7183,7 +7339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7191,19 +7347,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
+          <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285>
@@ -7211,11 +7367,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002397>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7234,7 +7393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7242,12 +7401,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7255,31 +7414,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://identifiers.org/sgd/S000004498>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -7287,7 +7438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7307,7 +7458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7324,7 +7475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7333,33 +7484,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
-
-<http://identifiers.org/sgd/S000004498>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7370,7 +7527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7381,7 +7538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7392,19 +7549,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
@@ -7416,7 +7573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7430,7 +7587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7441,13 +7598,24 @@
           <http://model.geneontology.org/CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7467,7 +7635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7476,22 +7644,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7500,7 +7666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7511,6 +7677,9 @@
           <http://model.geneontology.org/CHEBI_30616_ADENOSINE-KINASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0003938>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000005164>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -7519,21 +7688,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0003938>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7558,7 +7735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7575,7 +7752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7588,7 +7765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7596,19 +7773,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_17712_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17712_XANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
@@ -7620,28 +7797,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33709> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/9d56acbf-93b8-4c05-88b9-713bc4142c20_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -7651,6 +7811,25 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &rarr; inosine + phosphate' 'null' 'inosine + phosphate &rarr; &alpha;-D-ribose-1-phosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002413_INOPHOSPHOR-RXN_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7607> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/INOPHOSPHOR-RXN>
+] .
+
 <http://model.geneontology.org/YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000005085> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -7658,7 +7837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7666,40 +7845,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DADPKIN-RXN>
-] .
 
 <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7713,7 +7892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7724,30 +7903,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17596_INOPHOSPHOR-RXN>
+          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7755,19 +7945,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285>
@@ -7775,7 +7965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7786,7 +7976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7797,19 +7987,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002411_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PWY3O-285>
@@ -7817,7 +8007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7828,7 +8018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7843,7 +8033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7859,7 +8049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7870,7 +8060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7881,19 +8071,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY3O-285>
@@ -7901,7 +8091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7915,7 +8105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7926,34 +8116,49 @@
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_null_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7962,7 +8167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7973,40 +8178,42 @@
           <http://model.geneontology.org/YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8017,7 +8224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8029,7 +8236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8046,7 +8253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8062,7 +8269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8070,19 +8277,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
+          <http://model.geneontology.org/0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
@@ -8094,7 +8301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8112,7 +8319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8139,7 +8346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8155,7 +8362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8166,7 +8373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8174,19 +8381,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/YLR209C-MONOMER_INOPHOSPHOR-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
@@ -8198,7 +8405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8211,7 +8418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8219,92 +8426,94 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_15377_RXN-7607_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-7607> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-745>
+          <http://model.geneontology.org/CHEBI_15377_RXN-7607>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_null_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
-] .
 
 <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8315,7 +8524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8326,7 +8535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8339,7 +8548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8359,7 +8568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8372,20 +8581,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_b8e39aa3-11f4-4ee1-aaf8-3dc077d972ec_GART-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -8397,7 +8595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8405,19 +8603,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8426,7 +8624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8442,7 +8640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8453,7 +8651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8464,27 +8662,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8493,7 +8693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8513,7 +8713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8523,19 +8723,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY3O-285>
@@ -8543,7 +8743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8558,7 +8758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8571,7 +8771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8579,31 +8779,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -8611,7 +8803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8622,8 +8814,16 @@
           <http://model.geneontology.org/CHEBI_456216_ADPREDUCT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PWY3O-285/PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
@@ -8634,7 +8834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -8647,7 +8847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8655,36 +8855,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8693,7 +8893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8704,17 +8904,6 @@
           <http://model.geneontology.org/CHEBI_29888_ADENPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002411_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_RXN-7607>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8724,7 +8913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8732,13 +8921,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002411_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8758,7 +8958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8769,6 +8969,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_16235>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
+] .
+
 <http://purl.obolibrary.org/obo/GO_0004644>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -8777,7 +8994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8798,7 +9015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8808,51 +9025,51 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_RXN0-746>
+          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8863,7 +9080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8872,20 +9089,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/reaction_INOPHOSPHOR-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
@@ -8893,7 +9112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8904,7 +9123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8919,7 +9138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8932,7 +9151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8947,7 +9166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8956,20 +9175,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17596>
@@ -8983,7 +9204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8998,7 +9219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9011,7 +9232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9025,7 +9246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9033,19 +9254,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
+          <http://model.geneontology.org/CHEBI_29888_GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456215_AMP-DEAMINASE-RXN>
@@ -9057,7 +9278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9071,7 +9292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9082,6 +9303,15 @@
           <http://model.geneontology.org/YML035C-MONOMER_AMP-DEAMINASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_GUANINE-DEAMINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9091,7 +9321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9101,19 +9331,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000066_reaction_RXN-7607_location_lociGO_0005829_null_PWY3O-285>
@@ -9121,7 +9351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9132,7 +9362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9144,7 +9374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9153,6 +9383,23 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_XANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
@@ -9164,7 +9411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9174,17 +9421,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
@@ -9194,7 +9441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9206,7 +9453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9226,7 +9473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9239,7 +9486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9247,19 +9494,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_137981>
@@ -9271,7 +9518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9282,25 +9529,25 @@
           <http://model.geneontology.org/SAICARSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58426>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58475> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9311,7 +9558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9331,7 +9578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9344,7 +9591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9355,7 +9602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9366,7 +9613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9377,7 +9624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9388,7 +9635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9396,19 +9643,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_SAICARSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY3O-285>
@@ -9416,7 +9663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9430,7 +9677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9452,7 +9699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9463,7 +9710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9474,7 +9721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9482,19 +9729,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_43474_RXN-7607_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN-7607>
+          <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16335_ADENOSINE-KINASE-RXN>
@@ -9506,7 +9753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9523,7 +9770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9536,7 +9783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9544,19 +9791,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -9571,7 +9818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9579,23 +9826,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9603,27 +9850,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-746>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9638,7 +9885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9648,19 +9895,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
@@ -9672,7 +9919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9692,7 +9939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9709,7 +9956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9719,19 +9966,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_ADENINE-DEAMINASE-RXN_null_PWY3O-285>
@@ -9739,7 +9986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9751,7 +9998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9767,27 +10014,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000003563>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
@@ -9801,7 +10051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9817,11 +10067,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16235> ;
@@ -9832,7 +10085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9840,16 +10093,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -9857,7 +10102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9868,25 +10113,35 @@
           <http://model.geneontology.org/CHEBI_15377_AMP-DEAMINASE-RXN>
 ] .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
+          <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_137981_AIRCARBOXY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_137981> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9897,7 +10152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9911,7 +10166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9929,7 +10184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9942,7 +10197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9957,7 +10212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9967,21 +10222,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GART-RXN>
+          <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9990,7 +10245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10006,7 +10261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10021,7 +10276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10038,7 +10293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10048,19 +10303,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
@@ -10072,7 +10327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10085,7 +10340,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-11_RXN-7607_controller_BFO_0000051_SGD_S000005681_CPLX3O-11_component_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10096,7 +10362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10107,7 +10373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10120,7 +10386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10133,7 +10399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10153,7 +10419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10161,39 +10427,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58467_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
+          <http://model.geneontology.org/CHEBI_58467_IMPCYCLOHYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_17368_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17368_HYPOXANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
@@ -10201,7 +10476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10212,7 +10487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10227,7 +10502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10236,20 +10511,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
@@ -10259,7 +10536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10272,7 +10549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10300,7 +10577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10310,19 +10587,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002411_RXN-7607_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/RXN-7607>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
@@ -10330,7 +10607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10341,7 +10618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10349,19 +10626,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_b8e39aa3-11f4-4ee1-aaf8-3dc077d972ec_GART-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b8e39aa3-11f4-4ee1-aaf8-3dc077d972ec_GART-RXN>
+          <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285>
@@ -10369,7 +10646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10383,7 +10660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10399,7 +10676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10414,7 +10691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10423,22 +10700,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GUANYL-KIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -10460,7 +10735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10476,7 +10751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10498,7 +10773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10519,20 +10794,22 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
@@ -10540,7 +10817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10555,7 +10832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10571,7 +10848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10585,19 +10862,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -10606,7 +10883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10626,7 +10903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10647,7 +10924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10660,18 +10937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10682,7 +10948,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10693,7 +10970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10706,7 +10983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10723,7 +11000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10733,36 +11010,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-7607> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN0-745>
+          <http://model.geneontology.org/CHEBI_17596_RXN-7607>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
@@ -10774,7 +11051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10787,19 +11064,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GUANINE-DEAMINASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57464_GMP-SYN-NH3-RXN>
@@ -10811,7 +11088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10824,7 +11101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10839,7 +11116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10848,20 +11125,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
@@ -10872,7 +11151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10883,29 +11162,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GDPKIN-RXN>
+          <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0000034>
@@ -10916,7 +11193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10927,7 +11204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10938,7 +11215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10951,7 +11228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10964,7 +11241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10972,19 +11249,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GUANINE-DEAMINASE-RXN>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
@@ -10996,7 +11273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11012,7 +11289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11020,19 +11297,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
@@ -11044,7 +11321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11061,7 +11338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11078,7 +11355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11088,19 +11365,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11109,7 +11386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11125,7 +11402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11140,7 +11417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11153,7 +11430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11161,19 +11438,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_DADPKIN-RXN_SGD_PWY3O-285>
@@ -11181,7 +11458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11193,7 +11470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11206,19 +11483,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11227,7 +11504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11243,7 +11520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11258,7 +11535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11277,7 +11554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11293,7 +11570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11304,7 +11581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11315,18 +11592,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58017_XANPRIBOSYLTRAN-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11341,7 +11635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11361,7 +11655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11390,7 +11684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11399,22 +11693,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
@@ -11429,7 +11721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11442,7 +11734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11457,7 +11749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11477,9 +11769,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> , <http://model.geneontology.org/450b6141-f4e7-4ceb-906b-a01231e41ec8_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9d56acbf-93b8-4c05-88b9-713bc4142c20_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -11487,7 +11779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11497,19 +11789,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
+          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_43474_INOPHOSPHOR-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456215_ADENYL-KIN-RXN>
@@ -11521,7 +11813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11546,7 +11838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11559,7 +11851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11567,36 +11859,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
@@ -11618,7 +11910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11631,7 +11923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11639,19 +11931,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285>
@@ -11659,7 +11951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11670,7 +11962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11684,19 +11976,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11705,7 +11997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11721,7 +12013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11732,7 +12024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11746,7 +12038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11754,19 +12046,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
+          <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GART-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11775,7 +12067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11788,19 +12080,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
+          <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
@@ -11814,7 +12106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11827,36 +12119,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002411_DGDPKIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DGDPKIN-RXN>
+          <http://model.geneontology.org/RXN0-746>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -11865,7 +12159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11885,7 +12179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11898,7 +12192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11913,7 +12207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11926,7 +12220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11939,7 +12233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11949,19 +12243,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
+          <http://model.geneontology.org/RXN0-746> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
 <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
@@ -11973,7 +12267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11987,7 +12281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12003,7 +12297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12018,7 +12312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12031,7 +12325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12056,7 +12350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12065,62 +12359,60 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &rarr; inosine + phosphate' 'null' 'inosine + phosphate &rarr; &alpha;-D-ribose-1-phosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002413_INOPHOSPHOR-RXN_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN>
+          <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004641>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
-] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
+          <http://model.geneontology.org/RXN0-745> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_RXN0-746>
+          <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
@@ -12128,7 +12420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12139,27 +12431,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
+          <http://model.geneontology.org/reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000004351>
@@ -12167,27 +12461,44 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002411_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
+
+<http://model.geneontology.org/a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002411_ADPREDUCT-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12205,7 +12516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12215,19 +12526,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/GDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
+          <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -12238,7 +12549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12258,7 +12569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12274,7 +12585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12285,7 +12596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12296,7 +12607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12304,19 +12615,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_FGAMSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58595_DGDPKIN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -12325,7 +12636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12337,22 +12648,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -12363,7 +12672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12389,7 +12698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12402,7 +12711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12410,19 +12719,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_910518fb-e836-4a70-80cc-05587d893ac7_GART-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/910518fb-e836-4a70-80cc-05587d893ac7_GART-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/AICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY3O-285>
@@ -12430,7 +12758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12442,7 +12770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12458,7 +12786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12469,7 +12797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12480,7 +12808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12498,28 +12826,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33378> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/910518fb-e836-4a70-80cc-05587d893ac7_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -12532,7 +12843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12542,19 +12853,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller>
+          <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
@@ -12566,7 +12877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12595,7 +12906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12622,7 +12933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12635,7 +12946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12646,7 +12957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12654,19 +12965,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_15377_RXN-7607_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7607> ;
+          <http://model.geneontology.org/PRPPAMIDOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-7607>
+          <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004830>
@@ -12677,7 +12988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12695,7 +13006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12708,27 +13019,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
+          <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_PWY3O-285>
@@ -12736,7 +13049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12747,7 +13060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12772,7 +13085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12782,19 +13095,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_28938_GUANINE-DEAMINASE-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002816>
@@ -12809,7 +13122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12817,23 +13130,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000002862>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -12842,7 +13156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12855,36 +13169,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-11_RXN-7607_controller_BFO_0000051_SGD_S000005681_CPLX3O-11_component_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DADPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-11_RXN-7607_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/SGD_S000005681_CPLX3O-11_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
@@ -12896,7 +13229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12904,29 +13237,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANYL-KIN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12940,7 +13267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12956,7 +13283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12964,19 +13291,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
+          <http://model.geneontology.org/DADPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
@@ -12984,7 +13311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12996,7 +13323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13012,7 +13339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13025,7 +13352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13038,7 +13365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13055,7 +13382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13068,7 +13395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13081,7 +13408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13089,19 +13416,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/INOPHOSPHOR-RXN>
@@ -13123,7 +13450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13138,7 +13465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13151,7 +13478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13162,7 +13489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13170,19 +13497,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002333_CPLX3O-11_RXN-7607_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
+          <http://model.geneontology.org/RXN-7607> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61404_RXN0-745>
+          <http://model.geneontology.org/CPLX3O-11_RXN-7607_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_PWY3O-285>
@@ -13190,7 +13517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13201,7 +13528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13209,19 +13536,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY3O-285>
@@ -13229,7 +13556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13244,7 +13571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13257,7 +13584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13267,19 +13594,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/INOPHOSPHOR-RXN> ;
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_INOPHOSPHOR-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY3O-285>
@@ -13287,7 +13614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13300,7 +13627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13330,7 +13657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13342,19 +13669,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN> ;
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
@@ -13366,7 +13693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13382,7 +13709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13397,7 +13724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13410,7 +13737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13421,7 +13748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13432,7 +13759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13440,19 +13767,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16235_GUANINE-DEAMINASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-NH3-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
@@ -13460,7 +13787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13472,7 +13799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13492,7 +13819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13505,7 +13832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13522,19 +13849,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYRIBONUCSYN-RXN> ;
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY3O-285>
@@ -13542,7 +13869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13554,7 +13881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13584,7 +13911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13604,7 +13931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13617,7 +13944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13625,19 +13952,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GART-RXN> ;
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
+          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -13646,7 +13973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13662,7 +13989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13670,19 +13997,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
+          <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17712>
@@ -13694,7 +14021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13710,7 +14037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13722,7 +14049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13742,7 +14069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13755,7 +14082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-3-PWY3O-3.ttl
+++ b/models/PWY3O-3-PWY3O-3.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -81,17 +81,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_bf86a6a6-c01e-4b65-8370-ab7f4d8e7458_2.7.8.11-RXN_SGD_PWY3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17268> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -101,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,11 +103,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_bf86a6a6-c01e-4b65-8370-ab7f4d8e7458_2.7.8.11-RXN_SGD_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN_SGD_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +115,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bf86a6a6-c01e-4b65-8370-ab7f4d8e7458_2.7.8.11-RXN>
+          <http://model.geneontology.org/510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN>
@@ -138,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,6 +141,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -160,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -218,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +264,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/bf86a6a6-c01e-4b65-8370-ab7f4d8e7458_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -266,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -447,19 +453,13 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/bf86a6a6-c01e-4b65-8370-ab7f4d8e7458_2.7.8.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN_SGD_PWY3O-3>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .

--- a/models/PWY3O-31704-PWY3O-31704.ttl
+++ b/models/PWY3O-31704-PWY3O-31704.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -88,9 +88,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-316_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> , <http://model.geneontology.org/45fea2c4-d2e3-43dc-be62-2ef2a1e7dcc9_RXN66-316> ;
+                <http://model.geneontology.org/0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316> , <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/24eb622e-8e99-4221-88cf-51d32016580d_RXN66-316> , <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> ;
+                <http://model.geneontology.org/9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316> , <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-316_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,19 +167,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_1.3.1.71-RXN>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,24 +205,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' 'null' '4&alpha;-methyl-zymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN66-315_null_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-314> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-315>
-] .
+<http://model.geneontology.org/CHEBI_15377_RXN66-311>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44148> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-203>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -243,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -251,22 +249,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_15377_RXN66-311>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44148> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-315> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -274,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,28 +288,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_58349_RXN66-319_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_15378_RXN66-319_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN66-319>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-319>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,7 +317,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN66-281>
+          <http://model.geneontology.org/CHEBI_15440_RXN66-281>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-130>
@@ -331,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,11 +339,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_FERRICYTOCHROME-B5_RXN66-311_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +351,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_87287_RXN66-311>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-311>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704>
@@ -361,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -369,11 +367,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +379,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-316>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-316>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -392,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,22 +405,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002413_RXN66-313_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-312> ;
+          <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-313>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -431,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,18 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_c0a9f0ba-4f13-4b37-9694-c6ac7fdaba77_RXN66-317_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -582,30 +567,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704BiochemicalReaction44304> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.3.1.71-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller>
-] .
 
 <http://model.geneontology.org/CHEBI_128769_FPPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_128769> ;
@@ -616,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -644,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,59 +649,42 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN66-310_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-306> ;
+          <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-310>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 <http://identifiers.org/sgd/S000004090>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002333_YGR060W-MONOMER_RXN66-312_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002413_RXN66-313_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-312_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/LANOSTEROL-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15441_LANOSTEROL-SYNTHASE-RXN>
+          <http://model.geneontology.org/RXN66-313>
 ] .
 
 <http://model.geneontology.org/reaction_RXN66-306_location_lociGO_0005829>
@@ -748,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,11 +709,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/LANOSTEROL-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15441_LANOSTEROL-SYNTHASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +738,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317>
+          <http://model.geneontology.org/74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_FERRICYTOCHROME-B5_RXN3O-218_SGD_PWY3O-31704>
@@ -778,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,19 +771,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_58349_RXN66-314_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_136486_RXN66-314_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN66-314>
+          <http://model.geneontology.org/CHEBI_136486_RXN66-314>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000066_reaction_RXN66-316_location_lociGO_0005829_null_PWY3O-31704>
@@ -823,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -862,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,11 +855,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15378_RXN66-311_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15379_RXN66-311_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +867,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-311>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-311>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_RXN66-317>
@@ -911,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,13 +888,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-188_RXN3O-178_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004467> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "SAM:C-24 sterol methyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -984,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1002,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1036,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1080,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,11 +1099,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_16933_1.3.1.71-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_58349_1.3.1.71-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,7 +1111,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002333_YGR060W-MONOMER_RXN66-317_controller_SGD_PWY3O-31704>
@@ -1151,7 +1119,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1173,45 +1152,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52386_RXN66-318>
+          <http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002411_1.3.1.71-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-227> ;
+          <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.3.1.71-RXN>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,8 +1198,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315>
+          <http://model.geneontology.org/adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315>
 ] .
+
+<http://model.geneontology.org/0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1228,7 +1224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,27 +1240,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000004467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_58349_RXN66-306_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_15378_RXN66-306_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-306> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN66-306>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-306>
 ] .
 
 <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317>
@@ -1276,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,11 +1285,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-312_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_FERROCYTOCHROME-B5_RXN66-312_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1298,7 +1297,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_87287_RXN66-312>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-312>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY3O-31704>
@@ -1306,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,29 +1350,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002413_RXN66-317_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-316> ;
+          <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-317>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_58349_RXN66-319_SGD_PWY3O-31704>
@@ -1381,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1409,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1424,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1437,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1455,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1485,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1511,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1524,27 +1521,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002333_YGR060W-MONOMER_RXN66-316_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002413_RXN66-317_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-316_controller>
+          <http://model.geneontology.org/RXN66-317>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004310>
@@ -1556,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,44 +1571,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/e5fad526-03ca-4df2-b6e8-3bb327bf63e8_RXN66-317>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN66-313>
+          <http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
 ] .
 
 <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829>
@@ -1621,7 +1603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,22 +1615,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_13390_RXN66-318>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002333_YGR060W-MONOMER_RXN66-310_controller_SGD_PWY3O-31704>
@@ -1656,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1675,28 +1655,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_RXN3O-227>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-227>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_FERRICYTOCHROME-B5_RXN66-310_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1684,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_87289_RXN66-310>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-310>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000066_reaction_RXN66-312_location_lociGO_0005829_null_PWY3O-31704>
@@ -1712,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1723,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1731,11 +1711,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15379_RXN66-315_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,7 +1723,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-315>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-315>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1752,7 +1732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1768,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1814,7 +1794,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/305e7de0-ae59-4f59-b93d-b85fa2544f9c_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN66-318> , <http://model.geneontology.org/4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1824,7 +1804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1840,18 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_24eb622e-8e99-4221-88cf-51d32016580d_RXN66-316_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1866,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1890,11 +1859,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,7 +1871,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_FERROCYTOCHROME-B5_RXN66-310_SGD_PWY3O-31704>
@@ -1910,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1925,7 +1894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1938,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1953,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1970,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1986,11 +1955,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_52386_RXN66-319_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_57783_RXN66-319_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,7 +1967,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52386_RXN66-319>
+          <http://model.geneontology.org/CHEBI_57783_RXN66-319>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_RXN-12263>
@@ -2010,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,48 +1989,50 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-281> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_RXN66-281>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002333_YGR060W-MONOMER_RXN66-311_controller_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-311> ;
+          <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-311_controller>
+          <http://model.geneontology.org/YHR190W-MONOMER_RXN66-281_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0050613>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002413_RXN66-312_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-311> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN66-312>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,7 +2040,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
+          <http://model.geneontology.org/0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316>
 ] .
 
 <http://identifiers.org/sgd/S000001114>
@@ -2081,7 +2052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2097,29 +2068,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN66-313_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-313_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_13390_RXN66-313>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2130,7 +2099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,7 +2118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,30 +2129,13 @@
           <http://model.geneontology.org/RXN-12263>
 ] .
 
-<http://model.geneontology.org/24eb622e-8e99-4221-88cf-51d32016580d_RXN66-316>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15378_RXN66-310_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15379_RXN66-310_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2191,7 +2143,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-310>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-310>
 ] .
 
 <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
@@ -2202,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2227,7 +2179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2240,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2257,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2287,7 +2239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2300,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2339,12 +2291,10 @@
                 <http://model.geneontology.org/YLR056W-MONOMER_RXN3O-218_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-227> ;
-        <http://purl.obolibrary.org/obo/RO_0002629>
-                <http://model.geneontology.org/RXN3O-227> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2361,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2370,22 +2320,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000066_reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_18249>
@@ -2395,22 +2343,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000066_reaction_RXN66-310_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15378_RXN66-310_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-310_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-310>
 ] .
 
 <http://model.geneontology.org/CHEBI_15440_RXN66-281>
@@ -2422,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2435,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2446,7 +2392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2454,11 +2400,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2412,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-317>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-203_SGD_PWY3O-31704>
@@ -2474,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2488,7 +2434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2504,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2532,11 +2478,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_15378_RXN66-314_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_57783_RXN66-314_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2544,7 +2490,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-314>
+          <http://model.geneontology.org/CHEBI_57783_RXN66-314>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
@@ -2556,7 +2502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,29 +2514,31 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-319_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2598,16 +2546,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_RXN66-281>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-281>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-311_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_FERROCYTOCHROME-B5_RXN66-311_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,7 +2563,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_87289_RXN66-311>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-311>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY3O-31704>
@@ -2623,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2634,7 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2645,20 +2593,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-232_RXN3O-227_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004617> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "C-22 sterol desaturase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2673,7 +2621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2691,7 +2639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2705,7 +2653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2728,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2744,7 +2692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2758,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2769,7 +2717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2784,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,11 +2742,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_15378_1.3.1.71-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_18249_1.3.1.71-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2806,7 +2754,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_18249_1.3.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_1.3.1.71-RXN_location_lociGO_0005829>
@@ -2817,7 +2765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2828,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2839,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2849,20 +2797,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002333_YGR060W-MONOMER_RXN66-315_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002413_RXN66-316_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller>
+          <http://model.geneontology.org/RXN66-316>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2871,7 +2821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2895,11 +2845,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_17813_RXN66-306_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_57783_RXN66-306_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,7 +2857,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-306> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17813_RXN66-306>
+          <http://model.geneontology.org/CHEBI_57783_RXN66-306>
 ] .
 
 <http://model.geneontology.org/reaction_RXN66-319_location_lociGO_0005829>
@@ -2915,11 +2865,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_15377_RXN66-312_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_64925_RXN66-312_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2927,7 +2877,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-312>
+          <http://model.geneontology.org/CHEBI_64925_RXN66-312>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY3O-31704>
@@ -2935,7 +2885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2949,7 +2899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2964,22 +2914,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000066_reaction_RXN66-317_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2988,7 +2936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3004,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3015,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3026,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3036,20 +2984,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-314_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_RXN66-313_location_lociGO_0005829>
@@ -3061,7 +3011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3072,12 +3022,29 @@
           <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
+<http://model.geneontology.org/4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3092,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3109,7 +3076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3126,7 +3093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3142,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3151,12 +3118,23 @@
 <http://identifiers.org/sgd/S000004815>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_null_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3171,7 +3149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3184,28 +3162,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/305e7de0-ae59-4f59-b93d-b85fa2544f9c_RXN66-318>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_87287>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3219,7 +3180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3235,7 +3196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3249,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3260,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3273,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3290,7 +3251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3303,7 +3264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3311,19 +3272,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002411_RXN66-314_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-313> ;
+          <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-314>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3334,7 +3295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3347,19 +3308,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_305e7de0-ae59-4f59-b93d-b85fa2544f9c_RXN66-318_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/305e7de0-ae59-4f59-b93d-b85fa2544f9c_RXN66-318>
+          <http://model.geneontology.org/CHEBI_13392_RXN66-318>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704>
@@ -3367,7 +3328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3375,11 +3336,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3387,33 +3348,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18249_RXN3O-227>
+          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_RXN3O-227>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4,4-dimethylzymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002333_YGR060W-MONOMER_RXN66-310_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002413_RXN66-311_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-310_controller>
+          <http://model.geneontology.org/RXN66-311>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_1949_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_FERROCYTOCHROME-B5_RXN66-315_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3421,7 +3384,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_1949_RXN66-315>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
@@ -3433,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3452,7 +3415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3470,7 +3433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3487,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3500,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3513,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3522,22 +3485,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000066_reaction_RXN66-312_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15378_RXN66-312_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-312_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-312>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3546,7 +3507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3562,7 +3523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3576,7 +3537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3591,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3600,20 +3561,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'squalene + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized [NADPH-hemoprotein reductase] + H<sub>2</sub>O' 'null' '(3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene &rarr; lanosterol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002333_YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002413_LANOSTEROL-SYNTHASE-RXN_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller>
+          <http://model.geneontology.org/LANOSTEROL-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-312>
@@ -3625,7 +3588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3641,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3662,7 +3625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3675,7 +3638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3690,7 +3653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3700,38 +3663,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002411_RXN3O-178_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR100W-MONOMER_RXN66-319_controller>
+          <http://model.geneontology.org/RXN3O-178>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' 'null' 'squalene + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized [NADPH-hemoprotein reductase] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_SQUALENE-MONOOXYGENASE-RXN_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-281> ;
+          <http://model.geneontology.org/RXN66-306> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_57783_RXN66-314_SGD_PWY3O-31704>
@@ -3739,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3747,11 +3708,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3759,7 +3720,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-316>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000066_reaction_RXN3O-218_location_lociGO_0005829_null_PWY3O-31704>
@@ -3767,7 +3728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3784,7 +3745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3800,19 +3761,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN66-313_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64925_RXN66-313>
+          <http://model.geneontology.org/CHEBI_13392_RXN66-313>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3823,7 +3784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3834,17 +3795,6 @@
           <http://model.geneontology.org/reaction_RXN-12263_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN3O-218>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3854,7 +3804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3862,21 +3812,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002333_YGR060W-MONOMER_RXN66-317_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002413_RXN66-318_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-317_controller>
+          <http://model.geneontology.org/RXN66-318>
 ] .
 
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
@@ -3888,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3897,31 +3860,29 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000066_reaction_RXN3O-227_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_15379_RXN3O-227_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-227_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-227>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_18364_RXN66-310_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_FERROCYTOCHROME-B5_RXN66-310_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3929,7 +3890,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18364_RXN66-310>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-310>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_15377_RXN66-310_SGD_PWY3O-31704>
@@ -3937,7 +3898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3960,7 +3921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3973,7 +3934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3984,7 +3945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3995,7 +3956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4006,7 +3967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4023,7 +3984,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN66-315> , <http://model.geneontology.org/CHEBI_1949_RXN66-315> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15378_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1db98e15-5b95-43f0-908e-caf74a4e7b0e_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
+                <http://model.geneontology.org/adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -4031,7 +3992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4044,7 +4005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4055,7 +4016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4066,7 +4027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4079,7 +4040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4092,7 +4053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4107,7 +4068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4127,7 +4088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4137,11 +4098,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15440_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4149,7 +4110,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15440_SQUALENE-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_52972_RXN3O-218_SGD_PWY3O-31704>
@@ -4157,7 +4118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4165,36 +4126,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_c0a9f0ba-4f13-4b37-9694-c6ac7fdaba77_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002333_YGR060W-MONOMER_RXN66-317_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c0a9f0ba-4f13-4b37-9694-c6ac7fdaba77_RXN66-317>
+          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-317_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000066_reaction_RXN3O-227_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN3O-227_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_57783_1.3.1.71-RXN_SGD_PWY3O-31704>
@@ -4202,7 +4165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4220,7 +4183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4229,20 +4192,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' 'null' '4&alpha;-methyl-zymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN66-315_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
+          <http://model.geneontology.org/RXN66-315>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4251,7 +4216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4264,11 +4229,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_58349_RXN66-319_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4276,33 +4241,33 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18252_RXN66-319>
+          <http://model.geneontology.org/CHEBI_58349_RXN66-319>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN66-281_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57310_RXN66-281>
+          <http://model.geneontology.org/CHEBI_13390_RXN66-281>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_15377_RXN66-311_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4310,7 +4275,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-311>
+          <http://model.geneontology.org/CHEBI_87287_RXN66-311>
 ] .
 
 <http://model.geneontology.org/RXN3O-178>
@@ -4332,7 +4297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4349,7 +4314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4358,34 +4323,21 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000066_reaction_RXN66-316_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-316_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-316>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002629_RXN3O-227_null_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4393,7 +4345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4409,7 +4361,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4421,7 +4384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4441,7 +4404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4449,23 +4412,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_45fea2c4-d2e3-43dc-be62-2ef2a1e7dcc9_RXN66-316_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002411_1.3.1.71-RXN_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4474,12 +4426,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4494,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4507,7 +4470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4535,7 +4498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4545,19 +4508,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_57783_1.3.1.71-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_1.3.1.71-RXN>
+          <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002413_RXN66-316_null_PWY3O-31704>
@@ -4565,7 +4528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4582,44 +4545,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN66-310_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-306> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN66-310>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002333_YGR060W-MONOMER_RXN66-312_controller_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-306> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_FERRICYTOCHROME-B5_RXN66-312_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-312>
+          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-312_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_87289_RXN66-310>
@@ -4631,7 +4596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4647,7 +4612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4660,11 +4625,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4672,8 +4637,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-317>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4681,7 +4657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4692,24 +4668,30 @@
           <http://model.geneontology.org/CHEBI_52972_RXN3O-218>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_58349_RXN66-314_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4717,7 +4699,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_1949_RXN66-314>
+          <http://model.geneontology.org/CHEBI_58349_RXN66-314>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4726,7 +4708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4742,7 +4724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4753,7 +4735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4767,29 +4749,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000066_reaction_RXN66-311_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15378_RXN66-311_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-311_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-311>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_RXN66-313>
@@ -4801,7 +4781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4818,7 +4798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4834,7 +4814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4852,7 +4832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4865,7 +4845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4879,7 +4859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4893,7 +4873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4904,7 +4884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4915,29 +4895,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_16933_1.3.1.71-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.3.1.71-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/RXN66-281>
@@ -4959,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4969,11 +4964,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4981,41 +4976,43 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN66-318>
+          <http://model.geneontology.org/CHEBI_52386_RXN66-318>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002333_MONOMER3O-232_RXN3O-227_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002411_1.3.1.71-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-232_RXN3O-227_controller>
+          <http://model.geneontology.org/1.3.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000066_reaction_RXN66-311_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-311_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_PWY3O-31704>
@@ -5023,7 +5020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5031,11 +5028,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5043,7 +5040,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-315>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -5055,7 +5052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5071,7 +5068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5086,7 +5083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5096,11 +5093,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_58349_RXN66-306_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5108,7 +5105,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-306> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18364_RXN66-306>
+          <http://model.geneontology.org/CHEBI_58349_RXN66-306>
 ] .
 
 <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316>
@@ -5120,7 +5117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5130,11 +5127,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15379_RXN66-312_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-312_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5142,7 +5139,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-312>
+          <http://model.geneontology.org/CHEBI_87287_RXN66-312>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5151,7 +5148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5167,7 +5164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5183,7 +5180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5199,7 +5196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5217,7 +5214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5236,21 +5233,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002629>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_15378_1.3.1.71-RXN_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5261,7 +5255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5276,7 +5270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5293,7 +5287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5308,7 +5302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5325,7 +5319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5338,7 +5332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5349,7 +5343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5357,19 +5351,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_24eb622e-8e99-4221-88cf-51d32016580d_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002333_YGR060W-MONOMER_RXN66-316_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/24eb622e-8e99-4221-88cf-51d32016580d_RXN66-316>
+          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-316_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5380,7 +5374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5400,7 +5394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5410,11 +5404,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5422,7 +5416,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_136486_RXN66-313>
+          <http://model.geneontology.org/CHEBI_16526_RXN66-313>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY3O-31704>
@@ -5430,7 +5424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5442,7 +5436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5458,7 +5452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5469,7 +5463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5484,7 +5478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -5493,37 +5487,22 @@
                 "org.biopax.paxtools.model.level3.Pathway" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_52972_RXN3O-227_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-227> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52972_RXN3O-227>
+          <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_PWY3O-31704>
@@ -5531,7 +5510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5539,19 +5518,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_15377_RXN66-310_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-310> ;
+          <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-310>
+          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_RXN3O-227>
 ] .
 
 <http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
@@ -5561,7 +5540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5570,22 +5549,54 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000066_reaction_RXN66-315_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-310> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_87289_RXN66-310>
+] .
+
+<http://model.geneontology.org/adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-315_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-315>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY3O-31704>
@@ -5593,7 +5604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5605,7 +5616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5621,7 +5632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5636,7 +5647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5653,7 +5664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5661,12 +5672,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_15378_RXN66-306_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5677,28 +5699,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/1db98e15-5b95-43f0-908e-caf74a4e7b0e_RXN66-315>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN66-317>
         a       <http://purl.obolibrary.org/obo/GO_0000254> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5709,9 +5714,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/e5fad526-03ca-4df2-b6e8-3bb327bf63e8_RXN66-317> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/c0a9f0ba-4f13-4b37-9694-c6ac7fdaba77_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-317_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5719,7 +5724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5732,7 +5737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5747,7 +5752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5762,7 +5767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5775,11 +5780,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5787,7 +5792,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_1949_RXN66-314>
@@ -5799,7 +5804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5812,7 +5817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5823,7 +5828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5834,7 +5839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5845,7 +5850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5860,7 +5865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5869,20 +5874,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000066_reaction_RXN66-315_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-315_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002413_RXN66-317_null_PWY3O-31704>
@@ -5890,7 +5897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5905,7 +5912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5918,11 +5925,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_15378_RXN66-319_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_52386_RXN66-319_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5930,16 +5937,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-319>
+          <http://model.geneontology.org/CHEBI_52386_RXN66-319>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5947,24 +5954,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15440_RXN66-281>
+          <http://model.geneontology.org/CHEBI_29888_RXN66-281>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_FERRICYTOCHROME-B5_RXN66-311_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002333_YGR060W-MONOMER_RXN66-311_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-311>
+          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-311_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY3O-31704>
@@ -5972,7 +5979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5983,7 +5990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5991,11 +5998,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6003,7 +6010,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-316>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704>
@@ -6011,7 +6018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6023,7 +6030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6035,20 +6042,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-313_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN3O-178_SGD_PWY3O-31704>
@@ -6056,7 +6065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6071,7 +6080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6088,7 +6097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6099,6 +6108,9 @@
           <http://model.geneontology.org/YJL167W-MONOMER_FPPSYN-RXN_controller>
 ] .
 
+<http://identifiers.org/sgd/S000004617>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-218>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6108,7 +6120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6135,7 +6147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6148,7 +6160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6159,7 +6171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6174,24 +6186,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44437> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44440> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_e5fad526-03ca-4df2-b6e8-3bb327bf63e8_RXN66-317_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-312>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000254> ;
@@ -6212,7 +6213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6228,7 +6229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6243,7 +6244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6256,27 +6257,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000066_reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704>
@@ -6284,27 +6287,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000066_reaction_RXN66-310_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-310_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002333_YGR060W-MONOMER_RXN66-315_controller_SGD_PWY3O-31704>
@@ -6312,7 +6317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6320,19 +6325,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_e5fad526-03ca-4df2-b6e8-3bb327bf63e8_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e5fad526-03ca-4df2-b6e8-3bb327bf63e8_RXN66-317>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-317>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN66-281_SGD_PWY3O-31704>
@@ -6340,7 +6345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6352,7 +6357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6368,7 +6373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6376,11 +6381,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_136486_RXN66-314_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_15378_RXN66-314_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6388,7 +6393,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_136486_RXN66-314>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-314>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6397,7 +6402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6410,47 +6415,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002411_RXN66-319_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-318> ;
+          <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-319>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-281_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_13392_RXN66-281>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15379_RXN66-311_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-311_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6458,7 +6461,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-311>
+          <http://model.geneontology.org/CHEBI_87289_RXN66-311>
 ] .
 
 <http://model.geneontology.org/CHEBI_15440_SQUALENE-MONOOXYGENASE-RXN>
@@ -6470,7 +6473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6483,7 +6486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6498,7 +6501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6511,7 +6514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6525,7 +6528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6541,7 +6544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6552,7 +6555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6563,7 +6566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6588,7 +6591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6603,7 +6606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6622,7 +6625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6633,19 +6636,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_58349_1.3.1.71-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_15378_1.3.1.71-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_PWY3O-31704>
@@ -6653,7 +6656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6661,36 +6664,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002411_RXN66-319_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
+          <http://model.geneontology.org/RXN66-319>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-281_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_13390_RXN66-318>
@@ -6702,7 +6707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6715,7 +6720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6726,7 +6731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6734,31 +6739,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_1db98e15-5b95-43f0-908e-caf74a4e7b0e_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002333_YGR060W-MONOMER_RXN66-315_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1db98e15-5b95-43f0-908e-caf74a4e7b0e_RXN66-315>
+          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6766,7 +6760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6777,12 +6771,23 @@
           <http://model.geneontology.org/CHEBI_17038_RXN3O-178>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-312_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6795,7 +6800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6812,7 +6817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6822,28 +6827,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_FERROCYTOCHROME-B5_RXN66-312_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_17813_RXN66-306_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-312> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-312>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_15378_RXN66-306_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6851,28 +6839,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-306> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-306>
+          <http://model.geneontology.org/CHEBI_17813_RXN66-306>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/45fea2c4-d2e3-43dc-be62-2ef2a1e7dcc9_RXN66-316>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_15377_RXN66-312_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-312> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-312>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6880,7 +6868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6892,20 +6880,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000066_reaction_RXN66-317_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6914,7 +6904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6930,7 +6920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6941,7 +6931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6952,7 +6942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6963,7 +6953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6974,7 +6964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6999,7 +6989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7012,7 +7002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7030,7 +7020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7047,7 +7037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7060,7 +7050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7068,6 +7058,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-218>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7078,7 +7085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7091,7 +7098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7102,7 +7109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7113,7 +7120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7128,7 +7135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7138,19 +7145,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002411_RXN66-314_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
+          <http://model.geneontology.org/RXN66-314>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7159,7 +7166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7172,11 +7179,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7184,7 +7191,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN66-318>
+          <http://model.geneontology.org/4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002333_YHR007C-MONOMER_RXN3O-130_controller_SGD_PWY3O-31704>
@@ -7192,7 +7199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7200,11 +7207,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7212,7 +7219,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-227>
+          <http://model.geneontology.org/CHEBI_18249_RXN3O-227>
 ] .
 
 <http://model.geneontology.org/CHEBI_13390_RXN66-313>
@@ -7224,7 +7231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7234,28 +7241,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_FERRICYTOCHROME-B5_RXN66-310_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002333_YGR060W-MONOMER_RXN66-310_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-310>
+          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-310_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15379_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_1949_RXN66-315_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7263,7 +7270,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-315>
+          <http://model.geneontology.org/CHEBI_1949_RXN66-315>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7272,7 +7279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7292,7 +7299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7304,20 +7311,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000066_reaction_RXN66-312_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-312_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7328,7 +7337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7344,7 +7353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7369,7 +7378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7377,29 +7386,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/c0a9f0ba-4f13-4b37-9694-c6ac7fdaba77_RXN66-317>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7414,24 +7406,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44459> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_305e7de0-ae59-4f59-b93d-b85fa2544f9c_RXN66-318_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_18249_RXN3O-227>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18249> ;
@@ -7442,7 +7423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7452,19 +7433,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002333_YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704>
@@ -7472,7 +7453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7497,7 +7478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7514,7 +7495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7531,7 +7512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7548,7 +7529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7558,19 +7539,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_57783_RXN66-319_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN66-319>
+          <http://model.geneontology.org/YLR100W-MONOMER_RXN66-319_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_57783_RXN66-319_SGD_PWY3O-31704>
@@ -7578,46 +7559,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-281> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR190W-MONOMER_RXN66-281_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' 'null' 'squalene + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized [NADPH-hemoprotein reductase] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002413_RXN66-312_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_SQUALENE-MONOOXYGENASE-RXN_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-311> ;
+          <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-312>
+          <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-312> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_PWY3O-31704>
@@ -7625,7 +7606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7633,19 +7614,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_45fea2c4-d2e3-43dc-be62-2ef2a1e7dcc9_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/45fea2c4-d2e3-43dc-be62-2ef2a1e7dcc9_RXN66-316>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-316>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7654,7 +7635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7670,7 +7651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7685,7 +7666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7702,7 +7683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7715,7 +7696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7723,11 +7704,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN66-313_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN66-313_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7735,7 +7716,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN66-313>
+          <http://model.geneontology.org/CHEBI_64925_RXN66-313>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7744,7 +7725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7760,7 +7741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7771,7 +7752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7786,7 +7767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7800,7 +7781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7820,7 +7801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7836,7 +7817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7844,11 +7825,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15379_RXN66-310_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_18364_RXN66-310_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7856,7 +7837,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-310>
+          <http://model.geneontology.org/CHEBI_18364_RXN66-310>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_128769>
@@ -7867,7 +7848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7885,7 +7866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7912,7 +7893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7933,7 +7914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7946,7 +7927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7954,11 +7935,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15440_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7966,7 +7947,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15440_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000066_reaction_RXN66-311_location_lociGO_0005829_null_PWY3O-31704>
@@ -7974,7 +7955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7985,7 +7966,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7993,11 +7985,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8005,37 +7997,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317>
+          <http://model.geneontology.org/01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_1db98e15-5b95-43f0-908e-caf74a4e7b0e_RXN66-315_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Entity Regulation Rule 3. The relation 'episterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; ergosta-5,7,24(28)-trien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' 'ergosta-5,7,24(28)-trien-3&beta;-ol + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + an oxidized [NADPH-hemoprotein reductase] + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is the enabler of reaction 2." ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002629_RXN3O-227_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002629> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-218> ;
+          <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-227>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
@@ -8043,19 +8022,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_57783_RXN66-314_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN66-314>
+          <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0000250>
@@ -8067,7 +8046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8079,31 +8058,29 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-319> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-319_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_18252_RXN66-319>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN66-281_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8111,41 +8088,43 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-281> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-281>
+          <http://model.geneontology.org/CHEBI_57310_RXN66-281>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_FERROCYTOCHROME-B5_RXN66-311_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_15377_RXN66-311_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-311>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-311>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000066_reaction_RXN66-316_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_RXN66-316_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_RXN66-281_location_lociGO_0005829>
@@ -8159,7 +8138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8189,7 +8168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8206,7 +8185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8219,7 +8198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8230,7 +8209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8241,7 +8220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8252,7 +8231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8267,7 +8246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8281,7 +8260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8297,7 +8276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8312,7 +8291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8325,7 +8304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8336,7 +8315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8350,7 +8329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8365,7 +8344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8382,7 +8361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8412,7 +8391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8422,11 +8401,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_18249_1.3.1.71-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_57783_1.3.1.71-RXN_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8434,7 +8413,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18249_1.3.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_57783_1.3.1.71-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -8445,7 +8424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8458,7 +8437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8470,22 +8449,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002413_RXN66-316_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-315> ;
+          <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-316>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8494,7 +8471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8510,28 +8487,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_57783_RXN66-306_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-306> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN66-306>
+          <http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_64925_RXN66-312_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_FERRICYTOCHROME-B5_RXN66-312_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8539,7 +8516,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64925_RXN66-312>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-312>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8548,7 +8525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8561,11 +8538,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8573,7 +8550,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-317>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8582,7 +8559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8598,29 +8575,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-314> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-314_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_1949_RXN66-314>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8631,7 +8606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8647,7 +8622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8658,7 +8633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8676,7 +8651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8691,7 +8666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8708,7 +8683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8721,7 +8696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8732,7 +8707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8750,7 +8725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8780,7 +8755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8797,7 +8772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8824,7 +8799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8836,20 +8811,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_null_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+          <http://model.geneontology.org/reaction_1.3.1.71-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_16521_RXN3O-130>
@@ -8861,7 +8838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8874,7 +8851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8885,7 +8862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8893,11 +8870,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8905,43 +8882,41 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_RXN66-318>
+          <http://model.geneontology.org/CHEBI_16526_RXN66-318>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002333_MONOMER3O-232_RXN3O-227_controller_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_RXN3O-227>
+          <http://model.geneontology.org/MONOMER3O-232_RXN3O-227_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4,4-dimethylzymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002413_RXN66-311_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-310> ;
+          <http://model.geneontology.org/RXN66-311> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-311>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57310>
@@ -8949,19 +8924,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_FERROCYTOCHROME-B5_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-315>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8970,7 +8945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8982,22 +8957,20 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-306> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN66-306_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_18364_RXN66-306>
 ] .
 
 <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315>
@@ -9009,7 +8982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9019,11 +8992,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15378_RXN66-312_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15379_RXN66-312_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9031,7 +9004,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-312>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-312>
 ] .
 
 <http://identifiers.org/sgd/S000003703>
@@ -9043,7 +9016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9059,7 +9032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9074,7 +9047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9090,7 +9063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9101,7 +9074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9112,7 +9085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9127,7 +9100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9136,30 +9109,28 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'squalene + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized [NADPH-hemoprotein reductase] + H<sub>2</sub>O' 'null' '(3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene &rarr; lanosterol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002413_LANOSTEROL-SYNTHASE-RXN_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
+          <http://model.geneontology.org/1.3.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/LANOSTEROL-SYNTHASE-RXN>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-311_SGD_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9170,7 +9141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9185,7 +9156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9193,19 +9164,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY3O-31704>
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-311_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_87287_RXN66-311>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_87287> ;
@@ -9216,7 +9187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9236,7 +9207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9249,7 +9220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9257,36 +9228,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002411_RXN3O-178_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-319> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-178>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-306> ;
+          <http://model.geneontology.org/SQUALENE-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_null_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-306> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN66-306_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
@@ -9298,7 +9271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9311,7 +9284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9322,7 +9295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9330,11 +9303,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9342,7 +9315,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316>
+          <http://model.geneontology.org/9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316>
 ] .
 
 <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
@@ -9354,7 +9327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9368,7 +9341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9386,7 +9359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9402,7 +9375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9410,11 +9383,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9422,7 +9395,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-313> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_RXN66-313>
+          <http://model.geneontology.org/CHEBI_136486_RXN66-313>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9431,7 +9404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9451,7 +9424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9460,22 +9433,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002413_RXN66-318_null_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-317> ;
+          <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN66-318>
+          <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317>
@@ -9487,7 +9458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9497,11 +9468,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_15379_RXN3O-227_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_52972_RXN3O-227_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9509,24 +9480,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-227> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-227>
+          <http://model.geneontology.org/CHEBI_52972_RXN3O-227>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_FERROCYTOCHROME-B5_RXN66-310_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_15377_RXN66-310_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-310> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-310>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-310>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY3O-31704>
@@ -9534,7 +9505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9545,7 +9516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-31723-PWY3O-31723.ttl
+++ b/models/PWY3O-31723-PWY3O-31723.ttl
@@ -1,6 +1,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000006152_CPLX-7627_component>
+        a       <http://identifiers.org/sgd/S000006152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57384> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10,7 +19,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -25,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -35,11 +44,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +56,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN>
@@ -59,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,6 +81,9 @@
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -88,32 +100,46 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000006152>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/SGD_S000001665_CPLX-7627_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,11 +234,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +246,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
@@ -228,19 +254,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000050_PWY3O-31723/PWY3O-31723_SGD_PWY3O-31723> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-31723/PWY3O-31723>
 ] .
 
 <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN>
@@ -260,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -286,10 +329,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "fatty acid synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000006152_CPLX-7627_component> , <http://model.geneontology.org/SGD_S000001665_CPLX-7627_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -325,11 +370,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN>
+] .
+
+<http://model.geneontology.org/reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,29 +402,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000006152_CPLX-7627_component_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000006152_CPLX-7627_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN>
@@ -371,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,13 +448,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31723SmallMolecule75673> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000001665>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -407,19 +470,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -427,6 +490,17 @@
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000001665_CPLX-7627_component_SGD_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -437,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,36 +521,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000050_PWY3O-31723/PWY3O-31723_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000001665_CPLX-7627_component_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-31723/PWY3O-31723>
+          <http://model.geneontology.org/SGD_S000001665_CPLX-7627_component>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -490,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +595,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000006152_CPLX-7627_component_SGD_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -530,13 +615,24 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,26 +640,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_PWY3O-31723>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -571,11 +656,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +668,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FATTY-ACYL-COA-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -598,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acids biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-335-PWY3O-335.ttl
+++ b/models/PWY3O-335-PWY3O-335.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -14,11 +14,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -29,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetoin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -37,13 +40,24 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,11 +90,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002411_ACETOINDEHYDROG-RXN_SGD_PWY3O-335> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6081> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ACETOINDEHYDROG-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -88,14 +119,27 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN_SGD_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,3-butanediol dehydrogenase / diacetyl reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,21 +147,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN-6081>
+          <http://model.geneontology.org/CHEBI_15339_RXN-6081>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY3O-335>
@@ -125,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -134,29 +181,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_58476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/de297c06-c981-4216-80ac-be62d5ec4e15_ACETOINDEHYDROG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22271> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY3O-335>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,6 +218,9 @@
 <http://purl.obolibrary.org/obo/GO_0003984>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000000056>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -197,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -221,11 +254,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_de297c06-c981-4216-80ac-be62d5ec4e15_ACETOINDEHYDROG-RXN_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +266,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/de297c06-c981-4216-80ac-be62d5ec4e15_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
@@ -245,13 +278,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22288> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY3O-335> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6081> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17499_RXN-6081>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -261,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -277,20 +327,22 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_RXN-6081_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_null_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58476_RXN-6081>
+          <http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_24331>
@@ -301,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,19 +384,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15339_RXN-6081>
+          <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -356,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -387,11 +439,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22404> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22271> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -404,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,11 +515,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY3O-335> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6081> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16583_RXN-6081>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -465,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,19 +612,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_PWY3O-335/PWY3O-335_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-6081>
+          <http://model.geneontology.org/PWY3O-335/PWY3O-335>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-335>
@@ -537,9 +632,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
+        a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -549,37 +653,24 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_de297c06-c981-4216-80ac-be62d5ec4e15_ACETOINDEHYDROG-RXN_SGD_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_null_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -588,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -644,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,27 +770,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002411_ACETOINDEHYDROG-RXN_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN-6081>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_PWY3O-335/PWY3O-335_SGD_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -717,13 +819,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22329> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000515> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -737,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -759,24 +870,27 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000004714>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_PWY3O-335/PWY3O-335_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-335/PWY3O-335>
+          <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -788,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -819,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -858,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -885,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -900,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -934,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +1068,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/de297c06-c981-4216-80ac-be62d5ec4e15_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -962,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,7 +1093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,19 +1106,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_RXN-6081_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17499_RXN-6081>
+          <http://model.geneontology.org/CHEBI_58476_RXN-6081>
 ] .
 
 <http://model.geneontology.org/CHEBI_15339_RXN-6081>
@@ -1016,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1042,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1095,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1176,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1186,32 +1300,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16583_RXN-6081>
+          <http://model.geneontology.org/CHEBI_15378_RXN-6081>
 ] .
 
 <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetolactate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component> , <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335Complex22409> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .

--- a/models/PWY3O-351-PWY3O-351.ttl
+++ b/models/PWY3O-351-PWY3O-351.ttl
@@ -1,35 +1,37 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_3.1.3.77-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_3.1.3.77-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY3O-351> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58828_3.1.3.77-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_SAMDECARB-RXN>
+          <http://model.geneontology.org/reaction_SAMDECARB-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY3O-351>
@@ -37,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -48,19 +50,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_R147-RXN>
+          <http://model.geneontology.org/CHEBI_15379_R147-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58795_R147-RXN>
@@ -72,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,28 +104,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5.3.1.23-RXN> ;
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +133,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57834_SPERMIDINESYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SPERMIDINESYN-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -146,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,19 +158,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_83813_R15-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
+          <http://model.geneontology.org/CHEBI_83813_R15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002411_R15-RXN_SGD_PWY3O-351>
@@ -176,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,19 +228,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R145-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_R15-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -249,46 +251,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_45725_SPERMINE-SYNTHASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_35910_R15-RXN>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,19 +360,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58795>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -394,27 +394,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
+          <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/SPERMIDINESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_null_PWY3O-351>
@@ -422,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -432,32 +434,30 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002411_R15-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R15-RXN> ;
+          <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_R15-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/R15-RXN>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000764> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,3-dioxomethiopentane-1-phosphate enolase/phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -523,6 +523,25 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' 'null' '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_null_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5.3.1.23-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/R145-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_45725>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -532,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -543,64 +562,81 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57834_SPERMINE-SYNTHASE-RXN>
+          <http://model.geneontology.org/reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/R145-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58828_R145-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' 'null' '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R145-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3.1.3.77-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004136> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "spermine synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351Protein34759> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -609,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -622,33 +658,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004136> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "spermine synthase" ;
+<http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351Protein34759> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -659,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -699,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,11 +741,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +753,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58795_3.1.3.77-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3.1.3.77-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16723_R147-RXN>
@@ -733,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,36 +792,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_SAMDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SAMDECARB-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_R147-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_R147-RXN>
+          <http://model.geneontology.org/CHEBI_58795_R147-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_null_PWY3O-351>
@@ -797,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -811,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -822,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -830,21 +862,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' 'null' '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5.3.1.23-RXN> ;
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_5.3.1.23-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/5.3.1.23-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -869,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,19 +911,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPR069C-MONOMER_SPERMIDINESYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_17509_SPERMIDINESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0010309>
@@ -902,11 +934,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +946,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR208W-MONOMER_R15-RXN_controller>
+          <http://model.geneontology.org/CPLX-9432_R15-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_83813>
@@ -925,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -987,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1017,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1028,46 +1060,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R145-RXN> ;
+          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_R145-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
+          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58548_R145-RXN>
@@ -1079,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,13 +1145,13 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004611> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acireductone dioxygenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,19 +1161,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_null_PWY3O-351>
@@ -1151,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1162,20 +1192,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002910> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "S-adenosylmethionine synthetase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1188,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1212,20 +1242,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000006273>
@@ -1236,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,31 +1296,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
+          <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SPERMIDINESYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004007> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "5'-methylthioadenosine phosphorylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,19 +1330,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_35910_R15-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35910_R15-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY3O-351>
@@ -1318,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1326,19 +1358,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003909>
@@ -1351,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,36 +1393,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_326268_SPERMIDINESYN-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57844_R15-RXN>
+          <http://model.geneontology.org/reaction_R15-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
@@ -1402,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1415,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1448,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1456,45 +1490,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SPERMINE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_57443_SPERMINE-SYNTHASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R147-RXN> ;
+          <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1536,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57844_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY3O-351>
@@ -1510,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1524,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1532,19 +1566,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_3.1.3.77-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004766>
@@ -1552,19 +1586,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
+          <http://model.geneontology.org/CHEBI_59789_SAMDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/SAMDECARB-RXN>
@@ -1586,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1603,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1613,11 +1647,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,7 +1659,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16723_R147-RXN>
+          <http://model.geneontology.org/CHEBI_15378_R147-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_PWY3O-351>
@@ -1633,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1664,46 +1698,47 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_326268>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5.3.1.23-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5.3.1.23-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58533_5.3.1.23-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_326268>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_R15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_57834_SPERMIDINESYN-RXN>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
@@ -1713,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,11 +1758,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,7 +1770,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
+          <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
@@ -1747,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,19 +1795,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_R145-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58548_R145-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 <http://model.geneontology.org/CHEBI_17509_SPERMIDINESYN-RXN>
@@ -1784,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1794,40 +1829,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' 'null' '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_SAMDECARB-RXN_null_PWY3O-351> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SAMDECARB-RXN>
+          <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -1838,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1852,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1867,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1905,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1913,19 +1946,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15740_R147-RXN>
@@ -1937,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1954,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,40 +1996,45 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_SPERMIDINESYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_35910_R15-RXN_SGD_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57443_SPERMIDINESYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_16723_R15-RXN_SGD_PWY3O-351> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16723_R15-RXN>
+          <http://model.geneontology.org/CHEBI_35910_R15-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001251>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002910>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_83813_R15-RXN>
@@ -2008,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2035,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2045,19 +2083,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_57834_SPERMINE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_null_PWY3O-351>
@@ -2065,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2076,21 +2114,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' 'null' '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R147-RXN> ;
+          <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_R147-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3.1.3.77-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004170>
@@ -2105,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2115,19 +2153,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY3O-351>
@@ -2135,7 +2173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2159,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2172,29 +2210,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' 'null' '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R147-RXN>
+          <http://model.geneontology.org/CHEBI_58795_3.1.3.77-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_null_PWY3O-351>
@@ -2202,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2213,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2221,19 +2257,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_SAMDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY3O-351>
@@ -2241,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2249,19 +2285,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15740_R147-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_null_PWY3O-351>
@@ -2269,7 +2305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2280,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2290,42 +2326,45 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5.3.1.23-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58548_5.3.1.23-RXN>
+          <http://model.geneontology.org/reaction_5.3.1.23-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58828>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000004007>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/YPR069C-MONOMER_SPERMIDINESYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
@@ -2337,7 +2376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2347,19 +2386,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002411_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/YHR208W-MONOMER_R15-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57443_SPERMINE-SYNTHASE-RXN>
@@ -2371,7 +2410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2379,12 +2418,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000004611>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_null_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2395,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2406,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2425,54 +2467,56 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_R145-RXN>
+          <http://model.geneontology.org/reaction_R145-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3.1.3.77-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAMDECARB-RXN> ;
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY3O-351>
@@ -2480,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2491,46 +2535,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_3.1.3.77-RXN_SGD_PWY3O-351> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58828_3.1.3.77-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAMDECARB-RXN> ;
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SAMDECARB-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' 'null' '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_SAMDECARB-RXN_null_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SAMDECARB-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -2545,7 +2591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,10 +2603,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2577,7 +2625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2594,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2604,19 +2652,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_R147-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 <http://model.geneontology.org/SPERMIDINESYN-RXN>
@@ -2638,7 +2686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2655,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2668,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2678,10 +2726,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "methylthioribose-1 P isomerase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2691,19 +2741,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
@@ -2715,7 +2765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2738,7 +2788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2754,19 +2804,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SPERMIDINESYN-RXN>
+          <http://model.geneontology.org/CHEBI_326268_SPERMIDINESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351>
@@ -2774,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2789,7 +2839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2808,27 +2858,30 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_83813_R15-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_83813_R15-RXN>
+          <http://model.geneontology.org/CHEBI_57844_R15-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2843,16 +2896,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351SmallMolecule34574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58548_5.3.1.23-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58548> ;
@@ -2863,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2879,11 +2929,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2891,7 +2941,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_45725_SPERMINE-SYNTHASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SPERMINE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
@@ -2903,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2911,21 +2961,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57844_S-ADENMETSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001179>
@@ -2939,7 +2992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2950,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2967,7 +3020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2975,49 +3028,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
 ] .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPERMIDINESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
@@ -3029,7 +3089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3042,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3053,19 +3113,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002411_R15-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R15-RXN>
+          <http://model.geneontology.org/CHEBI_16723_R147-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
@@ -3077,7 +3137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3094,7 +3154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3107,7 +3167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3118,7 +3178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3146,7 +3206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3161,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3171,47 +3231,52 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5.3.1.23-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5.3.1.23-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58533_5.3.1.23-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000000764>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_83813_R15-RXN_SGD_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_PWY3O-351>
@@ -3219,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3230,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3238,36 +3303,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+          <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
 ] .
+
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
+        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_R145-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58828_R145-RXN>
+          <http://model.geneontology.org/CHEBI_58548_R145-RXN>
 ] .
 
 <http://model.geneontology.org/R145-RXN>
@@ -3289,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3319,7 +3393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3336,7 +3410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3349,19 +3423,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3.1.3.77-RXN>
+          <http://model.geneontology.org/CHEBI_15377_3.1.3.77-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_null_PWY3O-351>
@@ -3369,7 +3443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3377,19 +3451,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SAMDECARB-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY3O-351>
@@ -3397,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3408,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3422,7 +3496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3432,20 +3506,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_R147-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58795_R147-RXN>
+          <http://model.geneontology.org/reaction_R147-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
@@ -3455,7 +3531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3464,22 +3540,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' 'null' '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5.3.1.23-RXN>
+          <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/YHR208W-MONOMER_R15-RXN_controller>
@@ -3489,7 +3563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3502,19 +3576,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SPERMIDINESYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17509_SPERMIDINESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57443_SPERMIDINESYN-RXN>
 ] .
 
 <http://model.geneontology.org/5.3.1.23-RXN>
@@ -3536,7 +3610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3549,19 +3623,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_16723_R15-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_R15-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16723_R15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY3O-351>
@@ -3569,7 +3643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3578,21 +3652,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_57443>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_null_PWY3O-351>
@@ -3600,7 +3685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3611,7 +3696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3619,11 +3704,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3631,7 +3716,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
@@ -3643,7 +3728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3660,7 +3745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3673,7 +3758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3684,21 +3769,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' 'null' '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/R147-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY3O-351>
@@ -3706,7 +3791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3716,22 +3801,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SAMDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
+          <http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5.3.1.23-RXN_SGD_PWY3O-351>
@@ -3739,7 +3822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3747,38 +3830,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R15-RXN> ;
+          <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
+          <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' 'null' '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5.3.1.23-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R145-RXN>
+          <http://model.geneontology.org/CHEBI_58548_5.3.1.23-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_null_PWY3O-351>
@@ -3786,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3794,21 +3875,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_null_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
+          <http://model.geneontology.org/SPERMIDINESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_null_PWY3O-351>
@@ -3816,7 +3897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3831,7 +3912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3840,22 +3921,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_null_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002411_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+          <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY3O-351> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5.3.1.23-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY3O-351>
@@ -3863,7 +3959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3877,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3885,19 +3981,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SPERMINE-SYNTHASE-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57443_SPERMINE-SYNTHASE-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
@@ -3908,19 +4004,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_R145-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY3O-351>
@@ -3928,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3936,19 +4032,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_PWY3O-351/PWY3O-351_SGD_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/PWY3O-351/PWY3O-351>
 ] .
 
 <http://model.geneontology.org/PWY3O-351>
@@ -3960,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3976,7 +4072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3989,7 +4085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-355-PWY3O-355.ttl
+++ b/models/PWY3O-355-PWY3O-355.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -537,7 +537,7 @@
                 "org.biopax.paxtools.model.level3.Pathway" .
 
 <http://model.geneontology.org/RXN-9634>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "stearate biosynthesis III (fungi) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1074,7 +1074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1168,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1284,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1301,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,7 +1315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,7 +1332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,14 +1348,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-5293>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1373,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1488,13 +1488,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0008659>
+<http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1503,7 +1503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1582,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1613,7 +1613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,7 +1659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,7 +1753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1769,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1794,6 +1794,9 @@
           <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004315>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -1803,7 +1806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1860,7 +1863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1885,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1900,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1915,7 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/RXN3O-1803>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a palmitoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctadecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1930,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1944,7 +1947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2007,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2018,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2033,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2050,7 +2053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2084,7 +2087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2139,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2150,7 +2153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2162,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2190,7 +2193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2206,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2217,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2232,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2245,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2256,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-3827-PWY3O-3827.ttl
+++ b/models/PWY3O-3827-PWY3O-3827.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glucose-6-phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-4-PWY3O-4.ttl
+++ b/models/PWY3O-4-PWY3O-4.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "carnitine shuttle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-402-PWY3O-402.ttl
+++ b/models/PWY3O-402-PWY3O-402.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -310,28 +310,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47022> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/544bd9ec-faf8-4716-a151-7e97f3354795_RXN3O-786>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -343,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,13 +357,30 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +443,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_ee827223-86fb-4205-9c7d-460367491653_RXN3O-785_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -501,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -637,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -657,13 +668,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16322_RXN-4941> , <http://model.geneontology.org/CHEBI_30616_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/4fc12762-ca34-434a-a9ff-c92aa59d38ba_RXN-4941> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-64_RXN-4941_controller> , <http://model.geneontology.org/MONOMER3O-205_RXN-4941_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,18 +832,7 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-7184>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/591ca5e6-f3cb-4894-a46f-5d2c6a2010f1_RXN3O-143>
+<http://model.geneontology.org/12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -841,13 +841,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_2.7.1.151-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -861,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,13 +1028,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction47132> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4- or 6-diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_RXN-7163>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1017,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1033,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1047,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1095,12 +1140,23 @@
           <http://model.geneontology.org/PWY3O-402/PWY3O-402>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_58130_RXN-7163_SGD_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1111,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,7 +1207,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58628_RXN3O-143> , <http://model.geneontology.org/CHEBI_30616_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN3O-143> , <http://model.geneontology.org/591ca5e6-f3cb-4894-a46f-5d2c6a2010f1_RXN3O-143> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN3O-143> , <http://model.geneontology.org/1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-143_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1159,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1200,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1238,11 +1294,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_544bd9ec-faf8-4716-a151-7e97f3354795_RXN3O-786_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1306,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/544bd9ec-faf8-4716-a151-7e97f3354795_RXN3O-786>
+          <http://model.geneontology.org/12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1261,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1291,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1308,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1316,16 +1372,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_cc7b8aa6-b964-4924-a8d3-c8b18e0e3ec4_RXN3O-9819_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ee827223-86fb-4205-9c7d-460367491653_RXN3O-785>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphoinositol pentakisphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1333,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1357,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,13 +1445,13 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MONOMER3O-224_RXN3O-143_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004402> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "inositol hexakisphosphate kinase / diphosphoinositol-pentakisphosphate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1385,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,24 +1510,13 @@
           <http://model.geneontology.org/PWY3O-402/PWY3O-402>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_ad47484f-c704-4e02-b16d-4b3b598e097c_RXN3O-258_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_456216_2.7.1.152-RXN_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1467,7 +1535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,7 +1552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1504,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,7 +1588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1539,7 +1607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1624,7 +1692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1641,7 +1709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,29 +1740,12 @@
           <http://model.geneontology.org/CHEBI_57895_RXN-7184>
 ] .
 
-<http://model.geneontology.org/94252ecb-e007-49b2-97dc-426911c14b24_RXN3O-785>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_30616_RXN-7163_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1705,7 +1756,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1727,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1739,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1772,11 +1834,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_591ca5e6-f3cb-4894-a46f-5d2c6a2010f1_RXN3O-143_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1846,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-143> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/591ca5e6-f3cb-4894-a46f-5d2c6a2010f1_RXN3O-143>
+          <http://model.geneontology.org/1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
@@ -1792,28 +1854,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/4fc12762-ca34-434a-a9ff-c92aa59d38ba_RXN-4941>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1821,7 +1866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1837,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1848,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1862,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1879,7 +1924,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_RXN3O-258> , <http://model.geneontology.org/CHEBI_58130_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ad47484f-c704-4e02-b16d-4b3b598e097c_RXN3O-258> , <http://model.geneontology.org/CHEBI_456216_RXN3O-258> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN3O-258> , <http://model.geneontology.org/564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-258_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1887,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,24 +1957,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_591ca5e6-f3cb-4894-a46f-5d2c6a2010f1_RXN3O-143_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1982,7 +2016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1993,24 +2027,13 @@
           <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_544bd9ec-faf8-4716-a151-7e97f3354795_RXN3O-786_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002333_YDR315C-MONOMER_RXN-7163_controller_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2023,11 +2046,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_29eb26e9-384e-4da6-b495-71e248b78c5a_3.1.4.11-RXN_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,25 +2058,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/29eb26e9-384e-4da6-b495-71e248b78c5a_3.1.4.11-RXN>
+          <http://model.geneontology.org/88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN>
 ] .
-
-<http://model.geneontology.org/ad47484f-c704-4e02-b16d-4b3b598e097c_RXN3O-258>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4- or 6-diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-258>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -2064,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2131,7 +2137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2153,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2165,7 +2171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2185,7 +2191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2201,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2223,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2231,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2245,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2262,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2271,24 +2288,13 @@
 <http://purl.obolibrary.org/obo/GO_0004435>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_19f07e21-ad1a-42e7-9651-1b6bc7d65347_RXN3O-786_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_58628_2.7.1.152-RXN_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,7 +2311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2321,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2332,7 +2338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2344,7 +2350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2378,7 +2384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,29 +2395,12 @@
           <http://model.geneontology.org/CHEBI_16322_RXN-7163>
 ] .
 
-<http://model.geneontology.org/cc7b8aa6-b964-4924-a8d3-c8b18e0e3ec4_RXN3O-9819>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4- or 6-diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2436,7 +2425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2452,7 +2441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2469,7 +2458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2489,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2497,25 +2486,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000066_reaction_RXN3O-786_location_lociGO_0005829_null_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2527,7 +2516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2544,7 +2533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2560,7 +2549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2575,7 +2564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2595,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2612,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2628,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2639,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2653,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2661,11 +2650,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_cc7b8aa6-b964-4924-a8d3-c8b18e0e3ec4_RXN3O-9819_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,7 +2662,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cc7b8aa6-b964-4924-a8d3-c8b18e0e3ec4_RXN3O-9819>
+          <http://model.geneontology.org/5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7184_location_lociGO_0005829>
@@ -2684,7 +2673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2695,7 +2684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2707,7 +2696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2730,7 +2719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2744,7 +2733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2760,7 +2749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2775,15 +2764,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9819_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> , <http://model.geneontology.org/cc7b8aa6-b964-4924-a8d3-c8b18e0e3ec4_RXN3O-9819> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> , <http://model.geneontology.org/5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/4abf65e2-1a06-401b-9087-acf9715b16dc_RXN3O-9819> , <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> , <http://model.geneontology.org/49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-786> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2799,7 +2788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2819,7 +2808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2832,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2844,7 +2833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2860,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2871,7 +2860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2885,7 +2874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2902,7 +2891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2913,24 +2902,13 @@
           <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_4abf65e2-1a06-401b-9087-acf9715b16dc_RXN3O-9819_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_15378_2.7.1.152-RXN_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2946,7 +2924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2957,7 +2935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2969,7 +2947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2982,11 +2960,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_19f07e21-ad1a-42e7-9651-1b6bc7d65347_RXN3O-786_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2994,7 +2972,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/19f07e21-ad1a-42e7-9651-1b6bc7d65347_RXN3O-786>
+          <http://model.geneontology.org/2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786>
 ] .
 
 <http://model.geneontology.org/YDR315C-MONOMER_RXN-7163_controller>
@@ -3004,7 +2982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3018,7 +2996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3037,7 +3015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3049,7 +3027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3069,7 +3047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3088,7 +3066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3104,18 +3082,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4- or 6-diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_57627_2.7.1.151-RXN_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3129,7 +3135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3140,17 +3146,6 @@
           <http://model.geneontology.org/reaction_RXN-7162_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_RXN3O-143>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3160,13 +3155,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46966> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PWY3O-402/PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
@@ -3177,7 +3183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3185,12 +3191,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3205,7 +3228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3222,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3239,7 +3262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3256,7 +3279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3286,11 +3309,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_ad47484f-c704-4e02-b16d-4b3b598e097c_RXN3O-258_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3298,7 +3321,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-258> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ad47484f-c704-4e02-b16d-4b3b598e097c_RXN3O-258>
+          <http://model.geneontology.org/564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_58130_2.7.1.152-RXN_SGD_PWY3O-402>
@@ -3306,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3317,7 +3340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3332,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3349,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3362,7 +3385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3374,7 +3397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3393,7 +3416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3404,7 +3427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3419,7 +3442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3446,7 +3469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3460,7 +3483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3480,7 +3503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3493,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3505,7 +3528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3516,17 +3539,6 @@
           <http://model.geneontology.org/PWY3O-402/PWY3O-402>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_29eb26e9-384e-4da6-b495-71e248b78c5a_3.1.4.11-RXN_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/RXN3O-785>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3536,7 +3548,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/94252ecb-e007-49b2-97dc-426911c14b24_RXN3O-785> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
+                <http://model.geneontology.org/ee827223-86fb-4205-9c7d-460367491653_RXN3O-785> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58130_RXN3O-785> , <http://model.geneontology.org/CHEBI_43474_RXN3O-785> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3546,7 +3558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3563,7 +3575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3577,7 +3589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3597,7 +3609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3610,7 +3622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3621,7 +3633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3635,7 +3647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3650,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3664,7 +3676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3680,7 +3692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3695,7 +3707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3711,7 +3723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3722,6 +3734,23 @@
           <http://model.geneontology.org/RXN3O-786>
 ] .
 
+<http://model.geneontology.org/464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0008440>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3730,7 +3759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3742,7 +3771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3753,30 +3782,13 @@
           <http://model.geneontology.org/MONOMER3O-64_RXN-7162_controller>
 ] .
 
-<http://model.geneontology.org/19f07e21-ad1a-42e7-9651-1b6bc7d65347_RXN3O-786>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_30616_2.7.1.152-RXN_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,13 +3800,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-224_RXN3O-258_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004402> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "inositol hexakisphosphate kinase / diphosphoinositol-pentakisphosphate kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3807,7 +3819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3822,7 +3834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3835,11 +3847,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_94252ecb-e007-49b2-97dc-426911c14b24_RXN3O-785_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_ee827223-86fb-4205-9c7d-460367491653_RXN3O-785_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3847,7 +3859,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-785> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/94252ecb-e007-49b2-97dc-426911c14b24_RXN3O-785>
+          <http://model.geneontology.org/ee827223-86fb-4205-9c7d-460367491653_RXN3O-785>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_203600_2.7.1.127-RXN_SGD_PWY3O-402>
@@ -3855,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3869,7 +3881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3886,7 +3898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3902,7 +3914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3915,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3928,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3940,7 +3952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3959,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3973,7 +3985,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3988,7 +4011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3999,17 +4022,6 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_4fc12762-ca34-434a-a9ff-c92aa59d38ba_RXN-4941_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '[PP]<sub>2</sub>-IP<sub>4</sub> + H<sub>2</sub>O &rarr; diphosphoinositol pentakisphosphate + phosphate' 'null' 'diphosphoinositol pentakisphosphate + H<sub>2</sub>O &rarr; phytate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -4018,7 +4030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4041,7 +4053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4058,28 +4070,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46986> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/4abf65e2-1a06-401b-9087-acf9715b16dc_RXN3O-9819>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4088,7 +4083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4100,7 +4095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4116,7 +4111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4127,7 +4122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4142,7 +4137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4153,6 +4148,17 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-7162>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phytate + ATP + H<SUP>+</SUP> &rarr; 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'ATP + 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate &rarr; ADP + [PP]<sub>2</sub>-IP<sub>4</sub>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -4161,7 +4167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4178,7 +4184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4194,18 +4200,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002580>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002333_MONOMER3O-224_RXN3O-258_controller_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4216,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4231,7 +4240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4251,7 +4260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4263,13 +4272,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-64_2.7.1.127-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002580> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "IPMK" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4283,7 +4292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4293,6 +4302,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN-7163>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-7162_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -4306,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4315,13 +4335,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-64_RXN-4941_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002580> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "IPMK" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4335,7 +4355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4355,7 +4375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4371,7 +4391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4391,7 +4411,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/29eb26e9-384e-4da6-b495-71e248b78c5a_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -4401,7 +4421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4414,28 +4434,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/29eb26e9-384e-4da6-b495-71e248b78c5a_3.1.4.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-786>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4446,9 +4449,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-786_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/544bd9ec-faf8-4716-a151-7e97f3354795_RXN3O-786> , <http://model.geneontology.org/CHEBI_15377_RXN3O-786> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-786> , <http://model.geneontology.org/12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-786> , <http://model.geneontology.org/19f07e21-ad1a-42e7-9651-1b6bc7d65347_RXN3O-786> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-786> , <http://model.geneontology.org/2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-786_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -4456,7 +4459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4470,7 +4473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4486,20 +4489,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-64_2.7.1.151-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002580> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "IPMK" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4512,7 +4515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4528,7 +4531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4545,7 +4548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4558,7 +4561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4569,7 +4572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4584,7 +4587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4594,11 +4597,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_4abf65e2-1a06-401b-9087-acf9715b16dc_RXN3O-9819_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4606,7 +4609,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4abf65e2-1a06-401b-9087-acf9715b16dc_RXN3O-9819>
+          <http://model.geneontology.org/49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819>
 ] .
 
 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829>
@@ -4617,7 +4620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4628,7 +4631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4639,7 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4657,7 +4660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4670,7 +4673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4682,7 +4685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4712,7 +4715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4725,7 +4728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4739,7 +4742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4756,7 +4759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4775,7 +4778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4791,20 +4794,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-64_RXN-7162_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000002580> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "IPMK" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4818,7 +4821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4834,7 +4837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4845,7 +4848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4857,7 +4860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4874,7 +4877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4885,12 +4888,23 @@
           <http://model.geneontology.org/PWY3O-402/PWY3O-402>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_15378_RXN-7163_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4902,7 +4916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4918,7 +4932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4929,18 +4943,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004402>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4952,7 +4969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4968,11 +4985,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_4fc12762-ca34-434a-a9ff-c92aa59d38ba_RXN-4941_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4980,7 +4997,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-4941> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4fc12762-ca34-434a-a9ff-c92aa59d38ba_RXN-4941>
+          <http://model.geneontology.org/464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4991,7 +5008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5003,13 +5020,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-64_RXN-7184_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002580> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "IPMK" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5025,7 +5042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -5036,7 +5053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -5044,14 +5061,3 @@
 
 <http://model.geneontology.org/reaction_RXN3O-786_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_94252ecb-e007-49b2-97dc-426911c14b24_RXN3O-785_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .

--- a/models/PWY3O-4031-PWY3O-4031.ttl
+++ b/models/PWY3O-4031-PWY3O-4031.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,11 +267,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_9788de15-5019-478e-a4e1-4f92379cc348_RXN-7668_SGD_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +279,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9788de15-5019-478e-a4e1-4f92379cc348_RXN-7668>
+          <http://model.geneontology.org/5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY3O-4031>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -421,18 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_9788de15-5019-478e-a4e1-4f92379cc348_RXN-7668_SGD_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,23 +520,6 @@
 <http://identifiers.org/sgd/S000001004>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/fd161783-9c6f-4984-aa5c-e84d0e02e475_RXN-7669>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_4170> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -557,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +635,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7669_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/fd161783-9c6f-4984-aa5c-e84d0e02e475_RXN-7669> ;
+                <http://model.geneontology.org/194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_24384_RXN-7669> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -671,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -687,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,13 +671,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-4054_RXN-7667_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001766> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycogenin glucosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,24 +702,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_fd161783-9c6f-4984-aa5c-e84d0e02e475_RXN-7669_SGD_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -866,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -907,11 +868,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_d07d50aa-eec1-475f-843a-34e9fa5b7760_RXN-7668_SGD_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +880,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d07d50aa-eec1-475f-843a-34e9fa5b7760_RXN-7668>
+          <http://model.geneontology.org/2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -930,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -961,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -982,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -995,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1003,11 +964,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_fd161783-9c6f-4984-aa5c-e84d0e02e475_RXN-7669_SGD_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +976,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7669> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fd161783-9c6f-4984-aa5c-e84d0e02e475_RXN-7669>
+          <http://model.geneontology.org/194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669>
 ] .
 
 <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_RXN-7667>
@@ -1025,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1039,7 +1000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,13 +1011,30 @@
           <http://model.geneontology.org/PWY3O-4031/PWY3O-4031>
 ] .
 
+<http://model.geneontology.org/5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1140,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,30 +1200,13 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/d07d50aa-eec1-475f-843a-34e9fa5b7760_RXN-7668>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1282,28 +1243,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_RXN-7667_SGD_PWY3O-4031> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7667> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_RXN-7667>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1313,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,6 +1268,34 @@
           <http://model.geneontology.org/GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_RXN-7667_SGD_PWY3O-4031> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7667> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_RXN-7667>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668_SGD_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPD-7010_RXN-7667>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1333,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1346,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1361,13 +1333,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51306> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668_SGD_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1377,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,7 +1377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1409,13 +1392,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-4031_RXN-7667_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003673> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycogenin glucosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1449,7 +1432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1465,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1505,7 +1488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1542,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1557,13 +1540,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001766> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycogenin glucosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1576,7 +1559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1619,7 +1602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1646,7 +1629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1678,6 +1661,17 @@
           <http://model.geneontology.org/CHEBI_58223_RXN-7668>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_58223_RXN-7667_SGD_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1685,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1693,24 +1687,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_58223_RXN-7667_SGD_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_PWY3O-4031/PWY3O-4031_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,7 +1710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1771,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1802,7 +1785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1818,7 +1801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1833,7 +1816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1866,14 +1849,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/9788de15-5019-478e-a4e1-4f92379cc348_RXN-7668>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669_SGD_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1881,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1895,7 +1889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,7 +1906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1948,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1961,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1982,17 +1976,6 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_d07d50aa-eec1-475f-843a-34e9fa5b7760_RXN-7668_SGD_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2006,7 +1989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,9 +2009,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7668_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d07d50aa-eec1-475f-843a-34e9fa5b7760_RXN-7668> , <http://model.geneontology.org/CHEBI_58885_RXN-7668> ;
+                <http://model.geneontology.org/2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668> , <http://model.geneontology.org/CHEBI_58885_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9788de15-5019-478e-a4e1-4f92379cc348_RXN-7668> , <http://model.geneontology.org/CHEBI_58223_RXN-7668> ;
+                <http://model.geneontology.org/CHEBI_58223_RXN-7668> , <http://model.geneontology.org/5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR258W-MONOMER_RXN-7668_controller> , <http://model.geneontology.org/YFR015C-MONOMER_RXN-7668_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2036,7 +2019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2051,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2068,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2082,7 +2065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,7 +2085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,13 +2096,16 @@
           <http://model.geneontology.org/CHEBI_46398_GLUC1PURIDYLTRANS-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000003673>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_15378_RXN-7667_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2137,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2151,7 +2137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2184,7 +2170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2197,7 +2183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2208,7 +2194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2219,7 +2205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2230,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2242,7 +2228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2258,11 +2244,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001766>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000004248>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2273,7 +2262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2284,6 +2273,23 @@
           <http://model.geneontology.org/MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2293,7 +2299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2302,13 +2308,13 @@
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 <http://model.geneontology.org/MONOMER3O-4031_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000003673> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycogenin glucosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2321,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2335,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4105-PWY3O-4105.ttl
+++ b/models/PWY3O-4105-PWY3O-4105.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -11,11 +11,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YOL086C-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YGL256W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,15 +23,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4141_controller>
+          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4141_controller>
 ] .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-58_RXN3O-4133_controller_SGD_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -42,20 +45,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-118_RXN3O-4133_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002233_CHEBI_11851_RXN3O-4133_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN3O-4133_controller>
+          <http://model.geneontology.org/CHEBI_11851_RXN3O-4133>
 ] .
+
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -63,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -87,11 +93,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR083W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YBR145W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +105,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4141_controller>
+          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4141_controller>
 ] .
 
 <http://identifiers.org/sgd/S000002327>
@@ -113,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,21 +157,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_57945_RXN3O-4141_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_PWY3O-4105/PWY3O-4105_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN3O-4141>
+          <http://model.geneontology.org/PWY3O-4105/PWY3O-4105>
 ] .
 
 <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
@@ -187,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,9 +212,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -219,13 +237,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4105Protein47730> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+        a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4141_controller>
         a       <http://identifiers.org/sgd/S000003225> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -234,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -251,13 +278,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4105SmallMolecule47653> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-4133_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -267,27 +305,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_48943_RXN3O-4133_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000066_reaction_RXN3O-4133_location_lociGO_0005829_null_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_48943_RXN3O-4133>
+          <http://model.geneontology.org/reaction_RXN3O-4133_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY3O-4105>
@@ -295,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,19 +363,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YGL256W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_57540_RXN3O-4141_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4141_controller>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-4141>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-4141_location_lociGO_0005829>
@@ -349,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -357,6 +397,15 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57762>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -369,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -379,20 +428,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-methyl-2-oxobutanoate &rarr; isobutanal + CO<SUB>2</SUB>' 'null' 'isobutanal + NADH &rarr; isobutanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_48943_RXN3O-4141_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_null_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4141> ;
+          <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_48943_RXN3O-4141>
+          <http://model.geneontology.org/RXN3O-4141>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_PWY3O-4105/PWY3O-4105_SGD_PWY3O-4105>
@@ -400,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -419,10 +470,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,19 +485,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_PWY3O-4105/PWY3O-4105_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-58_RXN3O-4133_controller_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4141> ;
+          <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4105/PWY3O-4105>
+          <http://model.geneontology.org/CPLX3O-58_RXN3O-4133_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -458,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,19 +527,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_16526_RXN3O-4133_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000050_PWY3O-4105/PWY3O-4105_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN3O-4133>
+          <http://model.geneontology.org/PWY3O-4105/PWY3O-4105>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -495,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,23 +557,6 @@
           <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4141> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4141_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_RXN3O-4141>
@@ -532,13 +568,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4105SmallMolecule47685> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_46645_RXN3O-4141_SGD_PWY3O-4105> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4141> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_46645_RXN3O-4141>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -552,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "valine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -608,13 +661,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4105BiochemicalReaction47641> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -624,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -634,22 +690,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000066_reaction_RXN3O-4141_location_lociGO_0005829_null_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-67_RXN3O-4133_controller_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4133> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-67_RXN3O-4133_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YOL086C-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4141_location_lociGO_0005829>
+          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4141_controller>
 ] .
 
 <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4141_controller>
@@ -659,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,22 +745,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-methyl-2-oxobutanoate &rarr; isobutanal + CO<SUB>2</SUB>' 'null' 'isobutanal + NADH &rarr; isobutanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_null_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-118_RXN3O-4133_controller_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4141>
+          <http://model.geneontology.org/CPLX3O-118_RXN3O-4133_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -698,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -781,19 +850,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002233_CHEBI_11851_RXN3O-4133_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-4133_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4133> ;
+          <http://model.geneontology.org/CPLX3O-67_RXN3O-4133_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_11851_RXN3O-4133>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_11851_RXN3O-4133>
@@ -805,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,19 +906,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YBR145W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_57945_RXN3O-4141_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4141_controller>
+          <http://model.geneontology.org/CHEBI_57945_RXN3O-4141>
 ] .
 
 <http://model.geneontology.org/CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
@@ -861,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +972,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-4133_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -925,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -939,30 +1019,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR303C-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4141> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4141_controller>
+] .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-67_RXN3O-4133_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_48943_RXN3O-4133_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN3O-4133_controller>
+          <http://model.geneontology.org/CHEBI_48943_RXN3O-4133>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -971,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1008,27 +1105,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_46645>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_48943>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000066_reaction_RXN3O-4133_location_lociGO_0005829_null_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-4133_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4133> ;
+          <http://model.geneontology.org/CPLX3O-58_RXN3O-4133_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4133_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_48943>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-4133_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1036,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,19 +1181,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_57540_RXN3O-4141_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_48943_RXN3O-4141_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-4141>
+          <http://model.geneontology.org/CHEBI_48943_RXN3O-4141>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YBR145W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105>
@@ -1095,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,10 +1240,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1153,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1167,11 +1275,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR083W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4141> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4141_controller>
+] .
 
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1185,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1197,10 +1322,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1216,19 +1343,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-58_RXN3O-4133_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_16526_RXN3O-4133_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN3O-4133_controller>
+          <http://model.geneontology.org/CHEBI_16526_RXN3O-4133>
 ] .
 
 <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
@@ -1240,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1254,7 +1381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1278,11 +1405,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR303C-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,7 +1417,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4141> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4141_controller>
+          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4141_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -1310,18 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_null_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,21 +1471,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_null_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000050_PWY3O-4105/PWY3O-4105_SGD_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-4133_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4133> ;
+          <http://model.geneontology.org/CPLX3O-118_RXN3O-4133_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4105/PWY3O-4105>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_PWY3O-4105>
@@ -1377,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1392,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1400,33 +1527,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000066_reaction_RXN3O-4141_location_lociGO_0005829_null_PWY3O-4105> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4141> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-4141_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_16526_RXN3O-4133_SGD_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_46645_RXN3O-4141_SGD_PWY3O-4105> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4141> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46645_RXN3O-4141>
-] .
 
 <http://model.geneontology.org/CHEBI_16526_RXN3O-4133>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -1437,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-4106-PWY3O-4106.ttl
+++ b/models/PWY3O-4106-PWY3O-4106.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway IV (from nicotinamide riboside) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -203,12 +203,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000005073>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY3O-4106>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -360,13 +363,13 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000005073> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "nicotinic acid riboside kinase / nicotinamide ribose kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,19 +398,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_PWY3O-4106>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -417,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,16 +612,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69449> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4107-PWY3O-4107.ttl
+++ b/models/PWY3O-4107-PWY3O-4107.ttl
@@ -1,10 +1,10 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_61a59c1a-72be-4bfa-b104-6db6014933e0_RXN-15025_SGD_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12,7 +12,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/61a59c1a-72be-4bfa-b104-6db6014933e0_RXN-15025>
+          <http://model.geneontology.org/fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,23 +286,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/61a59c1a-72be-4bfa-b104-6db6014933e0_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'nicotinate + 5-phospho-&alpha;-D-ribose 1-diphosphate + ATP + H<sub>2</sub>O &rarr; &beta;-nicotinate D-ribonucleotide + ADP + diphosphate + phosphate' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -311,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,29 +361,12 @@
           <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/948364a4-898c-4ff5-a120-276114719dc4_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_null_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -417,11 +383,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_948364a4-898c-4ff5-a120-276114719dc4_RXN-15025_SGD_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +395,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/948364a4-898c-4ff5-a120-276114719dc4_RXN-15025>
+          <http://model.geneontology.org/60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -438,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,9 +424,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> , <http://model.geneontology.org/61a59c1a-72be-4bfa-b104-6db6014933e0_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/948364a4-898c-4ff5-a120-276114719dc4_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -468,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -481,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -888,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,7 +868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -969,22 +935,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002200>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller>
+        a       <http://identifiers.org/sgd/S000002200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD-dependent histone deacetylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107Protein69996> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -992,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,20 +987,22 @@
           <http://model.geneontology.org/CHEBI_17154_RXN-15025>
 ] .
 
-<http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD-dependent histone deacetylase" ;
+                "a [histone]-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107Protein69996> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1024,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,13 +1170,24 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025_SGD_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_PWY3O-4107/PWY3O-4107_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1237,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1271,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1283,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1319,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,16 +1327,13 @@
           <http://model.geneontology.org/NICOTINATEPRIBOSYLTRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,7 +1353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,30 +1381,19 @@
           <http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_17154>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_null_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_61a59c1a-72be-4bfa-b104-6db6014933e0_RXN-15025_SGD_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17154>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1421,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1438,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1451,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1491,7 +1474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,13 +1486,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glutamine-dependent NAD synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1523,7 +1506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1586,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1636,7 +1619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1728,7 +1711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1740,7 +1723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,28 +1796,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107Protein70110> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,6 +1813,21 @@
           <http://model.geneontology.org/CHEBI_83767_RXN-15025>
 ] .
 
+<http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107Protein70110> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://identifiers.org/sgd/S000005735>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1854,7 +1837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1884,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1898,7 +1881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1914,11 +1897,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001116>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004515> ;
@@ -1939,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1952,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1984,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1998,7 +1984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2023,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2069,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2089,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway V (PNC V cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2105,7 +2091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2122,7 +2108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2142,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2159,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2173,7 +2159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,7 +2179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2223,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2239,7 +2225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2253,7 +2239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2269,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2281,7 +2267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2313,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2353,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2366,18 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_948364a4-898c-4ff5-a120-276114719dc4_RXN-15025_SGD_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2389,7 +2364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2406,7 +2381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2417,12 +2392,23 @@
           <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025_SGD_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2439,18 +2425,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_null_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2461,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4108-PWY3O-4108.ttl
+++ b/models/PWY3O-4108-PWY3O-4108.ttl
@@ -1,94 +1,9 @@
-<http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4113_controller>
-        a       <http://identifiers.org/sgd/S000005446> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase I" ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48511> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_null_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.80-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_4.1.1.80-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/CHEBI_1879_RXN3O-4113>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_1879> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4-tyrosol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48446> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "tyr" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48377> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://identifiers.org/sgd/S000000349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_null_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -96,31 +11,46 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58315>
+<http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
+        a       <http://identifiers.org/sgd/S000001179> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aromatic amino acid aminotransferase II" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48432> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15378_RXN3O-4113_SGD_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15621_RXN3O-4113_SGD_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,48 +58,23 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4113> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-4113>
+          <http://model.geneontology.org/CHEBI_15621_RXN3O-4113>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' 'null' '3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.1.1.80-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
-        a       <http://purl.obolibrary.org/obo/CHEBI_36242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_57540_RXN3O-4113>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-(4-hydroxyphenyl)pyruvate" ;
+                "NAD<sup>+</sup>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48410> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48461> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -178,28 +83,217 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_1879>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/4.1.1.80-RXN>
+        a       <http://purl.obolibrary.org/obo/GO_0050546> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY3O-4108/PWY3O-4108> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_4.1.1.80-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_36242_4.1.1.80-RXN> , <http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_16526_4.1.1.80-RXN> , <http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002411>
+                <http://model.geneontology.org/RXN3O-4113> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48538> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.80-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_4.1.1.80-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
+] .
+
+<http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_null_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
+] .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.80-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
+] .
+
+<http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58315> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "tyr" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48377> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
@@ -210,13 +304,346 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "PWY3O-4108" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_36242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-(4-hydroxyphenyl)pyruvate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48410> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4113_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003225> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase IV" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48529> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller>
+        a       <http://identifiers.org/sgd/S000000349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase V" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48535> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/RXN3O-4157>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY3O-4108/PWY3O-4108> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15361_RXN3O-4157> , <http://model.geneontology.org/CHEBI_58315_RXN3O-4157> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_36242_RXN3O-4157> , <http://model.geneontology.org/CHEBI_57972_RXN3O-4157> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/4.1.1.80-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48361> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_36242_4.1.1.80-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36242> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-(4-hydroxyphenyl)pyruvate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48410> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57945_RXN3O-4113_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57540_RXN3O-4113_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "L-tyrosine degradation III - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/CHEBI_1879_RXN3O-4113>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_1879> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4-tyrosol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48446> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57540_RXN3O-4113_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-4113>
+] .
+
+<http://identifiers.org/sgd/S000004688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002411_RXN3O-4113_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15378_RXN3O-4113_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_16526_4.1.1.80-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48552> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_4.1.1.80-RXN_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.80-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36242_4.1.1.80-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_null_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0050546>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -227,13 +654,618 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48396> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
+        a       <http://purl.obolibrary.org/obo/CHEBI_36242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-(4-hydroxyphenyl)pyruvate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48410> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-oxoglutarate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48571> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Complex48592> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004022>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57945_RXN3O-4113_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_RXN3O-4113>
+] .
+
+<http://model.geneontology.org/reaction_RXN3O-4113_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15621_RXN3O-4113_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002411_RXN3O-4113_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.80-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-4113>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/CHEBI_15378_RXN3O-4113>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/RXN3O-4113>
+        a       <http://purl.obolibrary.org/obo/GO_0004022> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4-tyrosol + NAD<sup>+</sup> &larr; (4-hydroxyphenyl)acetaldehyde + NADH + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY3O-4108/PWY3O-4108> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN3O-4113_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_57540_RXN3O-4113> , <http://model.geneontology.org/CHEBI_1879_RXN3O-4113> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15621_RXN3O-4113> , <http://model.geneontology.org/CHEBI_15378_RXN3O-4113> , <http://model.geneontology.org/CHEBI_57945_RXN3O-4113> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48435> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_null_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-4113_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_null_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.80-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_4.1.1.80-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4113_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000003225>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58315>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
+] .
+
+<http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15621> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(4-hydroxyphenyl)acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48489> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15378_RXN3O-4113_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-4113>
+] .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glu" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48587> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.80-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_1879>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4113_controller>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_36242>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000004918>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -254,1275 +1286,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48556> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/CHEBI_36242_4.1.1.80-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36242> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-(4-hydroxyphenyl)pyruvate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48410> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002411_RXN3O-4113_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.80-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4113>
-] .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_16526_4.1.1.80-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48552> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_4.1.1.80-RXN_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Complex48592> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57540_RXN3O-4113_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-4113>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0050546>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57945_RXN3O-4113_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.80-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_4.1.1.80-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000003225>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
-] .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4113_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller>
-        a       <http://identifiers.org/sgd/S000004918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase II" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48517> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/reaction_RXN3O-4113_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4113_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003225> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase IV" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48529> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_1879_RXN3O-4113_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_1879_RXN3O-4113>
-] .
-
-<http://model.geneontology.org/CHEBI_15378_RXN3O-4113>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48474> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_57540_RXN3O-4113>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48461> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57540_RXN3O-4113_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004022>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/RXN3O-4113>
-        a       <http://purl.obolibrary.org/obo/GO_0004022> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4-tyrosol + NAD<sup>+</sup> &larr; (4-hydroxyphenyl)acetaldehyde + NADH + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY3O-4108/PWY3O-4108> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN3O-4113_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_RXN3O-4113> , <http://model.geneontology.org/CHEBI_1879_RXN3O-4113> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15621_RXN3O-4113> , <http://model.geneontology.org/CHEBI_15378_RXN3O-4113> , <http://model.geneontology.org/CHEBI_57945_RXN3O-4113> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller> , <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48435> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
-        a       <http://identifiers.org/sgd/S000001179> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aromatic amino acid aminotransferase II" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48432> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15621>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' 'null' '3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.1.1.80-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58315> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "tyr" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48377> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.80-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN>
-] .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_36242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-(4-hydroxyphenyl)pyruvate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48410> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
-] .
-
-<http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48474> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_36242>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4113_controller>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_null_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4113_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://identifiers.org/sgd/S000001179>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_null_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_4.1.1.80-RXN_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.80-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_4.1.1.80-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0016212>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/4.1.1.80-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0050546> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY3O-4108/PWY3O-4108> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_4.1.1.80-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_36242_4.1.1.80-RXN> , <http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_4.1.1.80-RXN> , <http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/RXN3O-4113> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48538> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller>
-        a       <http://identifiers.org/sgd/S000000349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase V" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48535> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15621_RXN3O-4113_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57945_RXN3O-4113_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN3O-4113>
-] .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15621_RXN3O-4113>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15621> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(4-hydroxyphenyl)acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48489> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_57972>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48587> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_4.1.1.80-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-oxoglutarate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48571> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004688> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase III" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48523> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15378_RXN3O-4113_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.80-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN>
-] .
-
-<http://identifiers.org/sgd/S000004688>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
-] .
-
-<http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15621> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(4-hydroxyphenyl)acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48489> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_15621_RXN3O-4113_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15621_RXN3O-4113>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_PWY3O-4108/PWY3O-4108_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.80-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4108/PWY3O-4108>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "L-tyrosine degradation III - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://identifiers.org/sgd/S000004918>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1533,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,47 +1311,87 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' 'null' '3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/4.1.1.80-RXN>
+] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_1879_RXN3O-4113_SGD_PWY3O-4108>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57972>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000000349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004688> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase III" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48523> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_57945_RXN3O-4113>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -1592,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,32 +1410,160 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/RXN3O-4157>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016212> ;
+<http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller>
+        a       <http://identifiers.org/sgd/S000004918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY3O-4108/PWY3O-4108> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15361_RXN3O-4157> , <http://model.geneontology.org/CHEBI_58315_RXN3O-4157> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_36242_RXN3O-4157> , <http://model.geneontology.org/CHEBI_57972_RXN3O-4157> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/4.1.1.80-RXN> ;
+                "alcohol dehydrogenase / alcohol dehydrogenase II" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48361> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48517> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' 'null' '3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_null_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/4.1.1.80-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller>
+] .
+
+<http://identifiers.org/sgd/S000001179>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "tyr" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48377> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15621>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_4.1.1.80-RXN_SGD_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1633,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,26 +1582,130 @@
           <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000005446>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_1879_RXN3O-4113_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_1879_RXN3O-4113>
+] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002411_RXN3O-4113_SGD_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_PWY3O-4108>
+<http://identifiers.org/sgd/S000005446>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.80-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller>
+] .
+
+<http://model.geneontology.org/CHEBI_15621_RXN3O-4113>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15621> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(4-hydroxyphenyl)acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48489> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4113_controller>
+        a       <http://identifiers.org/sgd/S000005446> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase I" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48511> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
+] .
+
+<http://model.geneontology.org/reaction_4.1.1.80-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_PWY3O-4108>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4109-PWY3O-4109.ttl
+++ b/models/PWY3O-4109-PWY3O-4109.ttl
@@ -1,96 +1,85 @@
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CPLX3O-58_4.1.1.72-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate decarboxylase / decarboxylase" ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48714> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
+                "https://yeastgenome.org" .
 
-<http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4117_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005446> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase I" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48800> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "While Saccharomyces cerevisiae can use most amino acids as their sole nitrogen source, they can only use a few amino acids as a carbon source to support growth |CITS:[Large86][Cooper82]|. This is in contrast to most eukaryotes and some fungi, which can metabolize amino acids completely, utilizing them as sole sources of carbon and nitrogen |CITS:[Stryer88][Large 86]|. S. cerevisiae degrade the branched-chain amino acids (iso-leucine, leucine, and valine) and the aromatic amino acids (tryptophan, phenylalanine, and tyrosine) via the Ehrlich pathway |CITS:[Sentheshanmuganathan60][10989420]|. This pathway is comprised of the following steps: 1) deamination of the amino acid to the corresponding alpha-keto acid; 2) decarboxylation of the resulting alpha-keto acid to the respective aldehyde; and, 3) reduction of the aldehyde to form the corresponding long chain or complex alcohol, known as a fusel alcohol or fusel oil |CITS:[10989420][Large 86]|. Fusel alcohols are important flavor and aroma compounds in yeast-fermented food products and beverages (as reported in |CITS:[9546164]| Each of the three steps in branched-chain amino acid degradation can be catalyzed by more than one isozyme; which enzyme is used appears to depend on the amino acid, the carbon source and the stage of growth of the culture |CITS:[12499363]|. The initial transamination step in iso-leucine degradation can be catalyzed by either of the branched-chain amino acid transaminases BAT1 (mitochondrial) or BAT2 (cytosolic) |CITS:[10989445][8798704][8702755]|. The subsequent decarboxylation step can be catalyzed by any one of the five decarboxylases (Pdc1p, Pdc5p, Pdc6p, Thi3p, and Aro10p) |CITS:[9546164][10753893]| and the final step can be catalyzed by any one of six alcohol dehydrogenases (Adh1p, Adh2p, Adh3p, Adh4p, Adh5p, and Sfa1p) |CITS:[12499363]|." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "isoleucine degradation" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "PWY3O-4109" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_35146>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "branched-chain amino acid transaminase" ;
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_RXN3O-4117_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48855> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-58_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,198 +102,86 @@
           <http://model.geneontology.org/CPLX3O-58_4.1.1.72-RXN_controller>
 ] .
 
-<http://identifiers.org/sgd/S000000349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CPLX3O-118_4.1.1.72-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate decarboxylase / decarboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48695> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/CHEBI_48945_RXN3O-4117>
-        a       <http://purl.obolibrary.org/obo/CHEBI_48945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-methylbutanol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48746> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
+          <http://model.geneontology.org/CPLX3O-71_4.1.1.72-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-4117>
+          <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
-] .
-
-<http://identifiers.org/sgd/S000002327>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-110_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-110_4.1.1.72-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_RXN3O-4117_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CPLX3O-110_4.1.1.72-RXN_controller>
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CPLX3O-67_4.1.1.72-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "THI3" ;
+                "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48675> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48705> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+        a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4117_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005446> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase I" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48800> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_null_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4109" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
-] .
 
 <http://model.geneontology.org/CHEBI_16526_4.1.1.72-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -315,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,190 +200,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4117_controller>
-        a       <http://identifiers.org/sgd/S000004918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase II" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48794> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_35146_4.1.1.72-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48643> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YGL256W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48643> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_RXN3O-4117_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_48945_RXN3O-4117>
-] .
-
-<http://model.geneontology.org/CHEBI_57945_RXN3O-4117>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48736> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_4.1.1.72-RXN>
-] .
-
-<http://model.geneontology.org/reaction_4.1.1.72-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://identifiers.org/sgd/S000003909>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,263 +214,139 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4117> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4117_controller>
+          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4117_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_null_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_4.1.1.72-RXN_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000003225>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4117_controller>
-] .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-isoleucine + 2-oxoglutarate &harr; L-glutamate + (<i>S</i>)-3-methyl-2-oxopentanoate' 'null' '(<i>S</i>)-3-methyl-2-oxopentanoate + H<SUP>+</SUP> &rarr; 2-methylbutanal + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_null_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.1.1.72-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_16182_RXN3O-4117>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16182> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-methylbutanal" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48655> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_16182_4.1.1.72-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16182> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-methylbutanal" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48655> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN3O-4117>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_48945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0047433>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4117_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003225> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase IV" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48782> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16182_4.1.1.72-RXN>
-] .
-
-<http://model.geneontology.org/CPLX3O-67_4.1.1.72-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate decarboxylase / decarboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48705> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004022>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_null_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4117_controller>
+          <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/CHEBI_15378_4.1.1.72-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48626> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-110_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_4.1.1.72-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://identifiers.org/sgd/S000001251>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_4.1.1.72-RXN_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_35146_4.1.1.72-RXN>
+] .
+
+<http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002238> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_null_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_48945_RXN3O-4117>
+        a       <http://purl.obolibrary.org/obo/CHEBI_48945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-methylbutanol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48746> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,6 +371,394 @@
           <http://model.geneontology.org/RXN3O-4117>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_RXN3O-4117_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16182_RXN3O-4117>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN3O-4117_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-58_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "While Saccharomyces cerevisiae can use most amino acids as their sole nitrogen source, they can only use a few amino acids as a carbon source to support growth |CITS:[Large86][Cooper82]|. This is in contrast to most eukaryotes and some fungi, which can metabolize amino acids completely, utilizing them as sole sources of carbon and nitrogen |CITS:[Stryer88][Large 86]|. S. cerevisiae degrade the branched-chain amino acids (iso-leucine, leucine, and valine) and the aromatic amino acids (tryptophan, phenylalanine, and tyrosine) via the Ehrlich pathway |CITS:[Sentheshanmuganathan60][10989420]|. This pathway is comprised of the following steps: 1) deamination of the amino acid to the corresponding alpha-keto acid; 2) decarboxylation of the resulting alpha-keto acid to the respective aldehyde; and, 3) reduction of the aldehyde to form the corresponding long chain or complex alcohol, known as a fusel alcohol or fusel oil |CITS:[10989420][Large 86]|. Fusel alcohols are important flavor and aroma compounds in yeast-fermented food products and beverages (as reported in |CITS:[9546164]| Each of the three steps in branched-chain amino acid degradation can be catalyzed by more than one isozyme; which enzyme is used appears to depend on the amino acid, the carbon source and the stage of growth of the culture |CITS:[12499363]|. The initial transamination step in iso-leucine degradation can be catalyzed by either of the branched-chain amino acid transaminases BAT1 (mitochondrial) or BAT2 (cytosolic) |CITS:[10989445][8798704][8702755]|. The subsequent decarboxylation step can be catalyzed by any one of the five decarboxylases (Pdc1p, Pdc5p, Pdc6p, Thi3p, and Aro10p) |CITS:[9546164][10753893]| and the final step can be catalyzed by any one of six alcohol dehydrogenases (Adh1p, Adh2p, Adh3p, Adh4p, Adh5p, and Sfa1p) |CITS:[12499363]|." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "isoleucine degradation" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "PWY3O-4109" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4117_controller>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+] .
+
+<http://identifiers.org/sgd/S000004688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CPLX3O-58_4.1.1.72-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48714> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_57945_RXN3O-4117>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48736> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-110_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-110_4.1.1.72-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-58_4.1.1.72-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4117_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003225> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase IV" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48782> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-4117>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_35146_4.1.1.72-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48643> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4117_controller>
+        a       <http://identifiers.org/sgd/S000000349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase V" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48776> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_4.1.1.72-RXN_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_null_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_16182_4.1.1.72-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16182> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-methylbutanal" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48655> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_null_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_4.1.1.72-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004022>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_null_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58045> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -804,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,41 +776,89 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+<http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/CPLX3O-71_4.1.1.72-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "decarboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48685> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-67_4.1.1.72-RXN_controller>
+] .
 
-<http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4117_controller>
-        a       <http://identifiers.org/sgd/S000002327> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0052656>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
+] .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4117_controller>
+        a       <http://identifiers.org/sgd/S000004918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "formaldehyde dehydrogenase / alcohol dehydrogenase" ;
+                "alcohol dehydrogenase / alcohol dehydrogenase II" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48770> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48794> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-110_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -854,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,44 +879,109 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0052656>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
+<http://purl.obolibrary.org/obo/CHEBI_35146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16182_4.1.1.72-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-110_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-110_4.1.1.72-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
+] .
+
+<http://identifiers.org/sgd/S000003225>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_57540_RXN3O-4117>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -912,11 +989,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_RXN3O-4117_SGD_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,54 +1001,173 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4117> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16182_RXN3O-4117>
+          <http://model.geneontology.org/CHEBI_57945_RXN3O-4117>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_null_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_4.1.1.72-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35146_4.1.1.72-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_PWY3O-4109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_16182>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_16182_RXN3O-4117>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16182> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-methylbutanal" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48655> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_null_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003909>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48643> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "isoleucine degradation - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4117_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+] .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CPLX3O-110_4.1.1.72-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "THI3" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48675> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -994,37 +1190,68 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-118_4.1.1.72-RXN_controller>
+] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-67_4.1.1.72-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+] .
+
+<http://identifiers.org/sgd/S000002327>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000004918>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YGL256W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
-        a       <http://identifiers.org/sgd/S000001251> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "branched-chain amino acid aminotransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48861> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16182>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0052656> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1045,13 +1272,249 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109BiochemicalReaction48803> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4117_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
+] .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4117_controller>
+        a       <http://identifiers.org/sgd/S000002327> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "formaldehyde dehydrogenase / alcohol dehydrogenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48770> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000000349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CPLX3O-118_4.1.1.72-RXN_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48695> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://purl.obolibrary.org/obo/GO_0047433>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_4.1.1.72-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-isoleucine + 2-oxoglutarate &harr; L-glutamate + (<i>S</i>)-3-methyl-2-oxopentanoate' 'null' '(<i>S</i>)-3-methyl-2-oxopentanoate + H<SUP>+</SUP> &rarr; 2-methylbutanal + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_null_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/4.1.1.72-RXN>
+] .
+
+<http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "branched-chain amino acid transaminase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48855> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
+        a       <http://identifiers.org/sgd/S000001251> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "branched-chain amino acid aminotransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48861> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-71_4.1.1.72-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_null_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-4117_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000002238>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/4.1.1.72-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0047433> ;
@@ -1072,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1080,58 +1543,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_null_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-71_4.1.1.72-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,91 +1568,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4117> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4117_controller>
+          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4117_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4117_controller>
-        a       <http://identifiers.org/sgd/S000000349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase V" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48776> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
-] .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_57540_RXN3O-4117>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "isoleucine degradation - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -1234,13 +1580,164 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48848> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002788> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_15378_4.1.1.72-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109SmallMolecule48626> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002413_RXN3O-4117_null_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005446>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4117_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004688> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase III" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48788> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.1.1.72-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_4.1.1.72-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-118_4.1.1.72-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58045>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_PWY3O-4109> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4117> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_48945_RXN3O-4117>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_48945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-4117>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004022> ;
@@ -1259,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1267,316 +1764,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_null_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4117_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
-] .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_4.1.1.72-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002413_RXN3O-4117_null_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58045>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4117_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004688> ;
+<http://model.geneontology.org/CPLX3O-71_4.1.1.72-RXN_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase III" ;
+                "decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48788> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48685> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://identifiers.org/sgd/S000004688>
+<http://identifiers.org/sgd/S000002788>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_4.1.1.72-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4117_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_4.1.1.72-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000004918>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000001251>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_PWY3O-4109/PWY3O-4109_SGD_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4117> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4109/PWY3O-4109>
-] .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_null_PWY3O-4109> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.1.1.72-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_4.1.1.72-RXN_location_lociGO_0005829>
-] .
-
-<http://identifiers.org/sgd/S000005446>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_null_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4112-PWY3O-4112.ttl
+++ b/models/PWY3O-4112-PWY3O-4112.ttl
@@ -1,3 +1,20 @@
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR303C-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4109> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4109_controller>
+] .
+
 <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4109_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000349> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,24 +57,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000002788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000000349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16526_RXN3O-4108_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-110_RXN3O-4108_controller>
+          <http://model.geneontology.org/CHEBI_16526_RXN3O-4108>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YOL086C-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112>
@@ -65,7 +85,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,24 +119,13 @@
           <http://model.geneontology.org/CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR303C-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YGL256W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +133,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4109_controller>
+          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4109_controller>
 ] .
 
 <http://identifiers.org/sgd/S000002327>
@@ -129,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -152,10 +172,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,21 +185,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_15837_RXN3O-4109_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4109_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15837_RXN3O-4109>
+          <http://model.geneontology.org/CHEBI_16638_RXN3O-4109>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000050_PWY3O-4112/PWY3O-4112_SGD_PWY3O-4112>
@@ -185,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -245,19 +270,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16638_RXN3O-4108_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002233_CHEBI_17865_RXN3O-4108_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16638_RXN3O-4108>
+          <http://model.geneontology.org/CHEBI_17865_RXN3O-4108>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -266,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,11 +304,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR083W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YDL168W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +316,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4109_controller>
+          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4109_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -306,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -333,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -357,20 +382,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_57945_RXN3O-4109_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000066_reaction_RXN3O-4109_location_lociGO_0005829_null_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN3O-4109>
+          <http://model.geneontology.org/reaction_RXN3O-4109_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-4109_location_lociGO_0005829>
@@ -383,13 +410,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112Protein48975> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_RXN3O-4108_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57427>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -403,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,21 +457,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '4-methyl-2-oxopentanoate &rarr; 3-methylbutanal + CO<SUB>2</SUB>' 'null' '3-methylbutanal + NADH &rarr; 3-methylbutanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000066_reaction_RXN3O-4109_location_lociGO_0005829_null_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002413_RXN3O-4109_null_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4109> ;
+          <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4109_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-4109>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -447,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -479,20 +517,22 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16526_RXN3O-4108_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000066_reaction_RXN3O-4108_location_lociGO_0005829_null_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN3O-4108>
+          <http://model.geneontology.org/reaction_RXN3O-4108_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -501,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,11 +554,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YGL256W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YBR145W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +566,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4109_controller>
+          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4109_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -541,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,10 +593,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "THI3" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -576,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -600,20 +642,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4109_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000050_PWY3O-4112/PWY3O-4112_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16638_RXN3O-4109>
+          <http://model.geneontology.org/PWY3O-4112/PWY3O-4112>
 ] .
+
+<http://identifiers.org/sgd/S000002238>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16638_RXN3O-4109>
         a       <http://purl.obolibrary.org/obo/CHEBI_16638> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -624,16 +669,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112SmallMolecule48892> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PWY3O-4112>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -644,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "leucine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -652,12 +694,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002413_RXN3O-4109_null_PWY3O-4112>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -679,19 +724,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000050_PWY3O-4112/PWY3O-4112_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-71_RXN3O-4108_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4109> ;
+          <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4112/PWY3O-4112>
+          <http://model.geneontology.org/CPLX3O-71_RXN3O-4108_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -700,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -736,19 +781,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002233_CHEBI_17865_RXN3O-4108_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000050_PWY3O-4112/PWY3O-4112_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17865_RXN3O-4108>
+          <http://model.geneontology.org/PWY3O-4112/PWY3O-4112>
 ] .
 
 <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
@@ -758,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -774,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,19 +835,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YDL168W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_57540_RXN3O-4109_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4109_controller>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-4109>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16638_RXN3O-4108_SGD_PWY3O-4112>
@@ -810,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -821,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -846,9 +891,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002788> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -860,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -892,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,22 +958,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '4-methyl-2-oxopentanoate &rarr; 3-methylbutanal + CO<SUB>2</SUB>' 'null' '3-methylbutanal + NADH &rarr; 3-methylbutanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002413_RXN3O-4109_null_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4109>
+          <http://model.geneontology.org/CPLX3O-110_RXN3O-4108_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -928,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,6 +994,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-110_RXN3O-4108_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4109_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004918> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -949,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,22 +1039,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000066_reaction_RXN3O-4108_location_lociGO_0005829_null_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_RXN3O-4108_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4108> ;
+          <http://model.geneontology.org/CPLX3O-71_RXN3O-4108_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4108_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR083W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112>
@@ -999,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1035,19 +1096,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YBR145W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_15837_RXN3O-4109_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4109_controller>
+          <http://model.geneontology.org/CHEBI_15837_RXN3O-4109>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1065,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1100,9 +1161,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002238> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1111,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1143,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,6 +1243,23 @@
 
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YOL086C-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4109> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4109_controller>
+] .
 
 <http://model.geneontology.org/RXN3O-4109>
         a       <http://purl.obolibrary.org/obo/GO_0004022> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1191,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,19 +1294,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-71_RXN3O-4108_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16638_RXN3O-4108_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4108> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-71_RXN3O-4108_controller>
+          <http://model.geneontology.org/CHEBI_16638_RXN3O-4108>
 ] .
 
 <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY3O-4112>
@@ -1227,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1242,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,11 +1342,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YOL086C-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR083W-MONOMER_RXN3O-4109_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,7 +1354,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4109_controller>
+          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4109_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
@@ -1284,28 +1371,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000050_PWY3O-4112/PWY3O-4112_SGD_PWY3O-4112> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4108> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4112/PWY3O-4112>
-] .
 
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
@@ -1314,13 +1384,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112Protein49082> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-110_RXN3O-4108_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY3O-4112> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-110_RXN3O-4108_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
+] .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1330,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1338,19 +1425,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_57540_RXN3O-4109_SGD_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_57945_RXN3O-4109_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4109> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-4109>
+          <http://model.geneontology.org/CHEBI_57945_RXN3O-4109>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_57945_RXN3O-4109_SGD_PWY3O-4112>
@@ -1358,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-4115-PWY3O-4115.ttl
+++ b/models/PWY3O-4115-PWY3O-4115.ttl
@@ -1,38 +1,42 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YBR145W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000066_reaction_RXN3O-163_location_lociGO_0005829_null_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-163_controller>
+          <http://model.geneontology.org/reaction_RXN3O-163_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000066_reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829_null_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0050177>
@@ -43,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -85,36 +89,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR083W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
+          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-163_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
+          <http://model.geneontology.org/CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
@@ -126,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,43 +141,73 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0016212>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+        a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-163_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4115> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004400>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004400>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000066_reaction_RXN3O-163_location_lociGO_0005829_null_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-163> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-163_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -184,29 +218,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000066_reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829_null_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115>
@@ -214,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -240,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,10 +287,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -299,19 +333,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR083W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_49000_RXN3O-163_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-163_controller>
+          <http://model.geneontology.org/CHEBI_49000_RXN3O-163>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY3O-4115>
@@ -319,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -366,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -387,19 +421,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
+          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_PWY3O-4115>
@@ -407,31 +441,42 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
+          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -441,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,20 +508,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-phenylalanine + 2-oxoglutarate &harr; 3-phenyl-2-oxopropanoate + L-glutamate' 'null' '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_49000_RXN3O-163_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_null_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-163> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_49000_RXN3O-163>
+          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115>
@@ -484,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -493,21 +540,32 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
+          <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY3O-4115>
@@ -515,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -557,47 +615,50 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YDL168W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
+          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-163_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
+          <http://model.geneontology.org/CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_49000>
@@ -612,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,14 +686,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/2.6.1.58-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0016212> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -650,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,22 +761,37 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-phenylalanine + 2-oxoglutarate &harr; 3-phenyl-2-oxopropanoate + L-glutamate' 'null' '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_null_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_PWY3O-4115> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_PWY3O-4115>
@@ -723,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -755,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -776,10 +852,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,19 +867,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YDL168W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_16424_RXN3O-163_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-163_controller>
+          <http://model.geneontology.org/CHEBI_16424_RXN3O-163>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004022>
@@ -809,19 +887,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -829,36 +907,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR303C-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
+          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-163_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
+          <http://model.geneontology.org/CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000001378>
@@ -869,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -895,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +1009,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -943,25 +1032,33 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY3O-4115> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
+] .
 
 <http://model.geneontology.org/CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,36 +1068,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_16424_RXN3O-163_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-163> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16424_RXN3O-163>
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YDL168W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115>
@@ -1008,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1046,16 +1143,29 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115Complex49191> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-163_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005446> ;
@@ -1064,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1085,19 +1195,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR303C-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_57540_RXN3O-163_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-163_controller>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-163>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1105,19 +1215,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
@@ -1129,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1147,38 +1257,45 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
+          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
+          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
 ] .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1189,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1202,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1221,19 +1338,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_57540_RXN3O-163_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-163>
+          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_57540_RXN3O-163_SGD_PWY3O-4115>
@@ -1241,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1249,19 +1366,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
+          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -1274,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1291,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,42 +1416,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YGL256W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-163_controller>
 ] .
+
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1356,22 +1486,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000002327>
@@ -1379,6 +1507,17 @@
 
 <http://identifiers.org/sgd/S000004918>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1388,18 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1407,19 +1535,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-163> ;
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
+          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_PWY3O-4115> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10814> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
@@ -1434,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1444,23 +1600,26 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000050_PWY3O-4115/PWY3O-4115_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4115/PWY3O-4115>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000000349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1469,10 +1628,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,36 +1643,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YGL256W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_57945_RXN3O-163_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-163_controller>
+          <http://model.geneontology.org/CHEBI_57945_RXN3O-163>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_18005_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_18005_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001179>
@@ -1526,13 +1687,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115SmallMolecule49330> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -1543,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,36 +1717,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YOL086C-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
+          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-163_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' 'null' 'phenylacetaldehyde + NADH &rarr; 2-phenylethanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002413_RXN3O-163_null_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
+          <http://model.geneontology.org/RXN3O-163>
 ] .
 
 <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-163_controller>
@@ -1592,16 +1761,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115Protein49379> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1615,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1643,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1651,12 +1817,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine' 'null' '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_null_PWY3O-4115> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_49000_RXN3O-163_SGD_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1664,20 +1849,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_57945_RXN3O-163_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-163> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN3O-163>
+          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
+
+<http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002788> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-10814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004400> ;
@@ -1698,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1708,20 +1902,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_18005_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005446>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1735,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1745,11 +1948,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YOL086C-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YBR145W-MONOMER_RXN3O-163_controller_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,26 +1960,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-163> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-163_controller>
+          <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-163_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' 'null' 'phenylacetaldehyde + NADH &rarr; 2-phenylethanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002413_RXN3O-163_null_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-163>
+          <http://model.geneontology.org/CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_18005_RXN-10814>
@@ -1788,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1801,9 +2002,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1812,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1822,39 +2034,37 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine' 'null' '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_null_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
+          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58095>
@@ -1865,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1878,13 +2088,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115Protein49373> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://identifiers.org/sgd/S000002788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/PWY3O-4120-PWY3O-4120.ttl
+++ b/models/PWY3O-4120-PWY3O-4120.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,12 +18,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_PWY3O-4120>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -34,19 +37,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/CHORISMATEMUT-RXN>
@@ -68,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -109,19 +112,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4120/PWY3O-4120>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58315>
@@ -133,7 +136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,11 +149,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +161,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
@@ -169,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +228,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -234,16 +248,8 @@
 <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -254,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,19 +297,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4157>
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY3O-4120>
@@ -311,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -330,10 +336,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,19 +354,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -367,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -391,19 +399,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120>
@@ -411,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -459,19 +467,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY3O-4120>
@@ -479,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -501,39 +509,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
+          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120>
@@ -541,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -583,19 +593,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
+          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
 ] .
 
 <http://model.geneontology.org/PWY3O-4120>
@@ -607,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tyrosine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -648,11 +658,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +670,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -671,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,13 +705,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +730,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
@@ -719,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -777,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -792,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,11 +840,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,26 +852,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_null_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-4120/PWY3O-4120>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120>
@@ -858,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -890,11 +909,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +921,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -913,7 +932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,20 +944,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120>
@@ -946,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,15 +1023,38 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0016212>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002411_RXN3O-4157_SGD_PWY3O-4120> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-4157>
+] .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1020,20 +1064,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
+          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -1041,19 +1087,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
+          <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4120/PWY3O-4120>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
@@ -1065,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1114,19 +1160,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57972>
@@ -1141,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,29 +1203,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_null_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-4120/PWY3O-4120>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
@@ -1191,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1211,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1234,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,19 +1288,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002411_RXN3O-4157_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4157>
+          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -1267,29 +1311,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-4120/PWY3O-4120>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1300,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,19 +1358,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/GO_0004665>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,11 +1381,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+          <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/GO_0004665>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1354,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,11 +1409,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,14 +1421,14 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4157> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
+          <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/RXN3O-4157>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016212> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1404,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,19 +1456,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_PWY3O-4120/PWY3O-4120_SGD_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4120/PWY3O-4120>
+          <http://model.geneontology.org/RXN3O-4157>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY3O-4120>
@@ -1434,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-4153-PWY3O-4153.ttl
+++ b/models/PWY3O-4153-PWY3O-4153.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,18 +51,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY3O-4153>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -84,11 +87,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +99,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/CHORISMATEMUT-RXN>
@@ -118,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,19 +131,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_RXN-10814_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-10814>
+          <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -152,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,11 +174,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,7 +186,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY3O-4153>
@@ -191,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -201,13 +204,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005260> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "prephenate dehydratase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,13 +250,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +267,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
+          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
 ] .
 
 <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN>
@@ -283,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,12 +303,15 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000005260>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_PWY3O-4153>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -341,19 +350,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
@@ -365,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -405,20 +414,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
+          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_PWY3O-4153>
@@ -426,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,23 +471,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_RXN-10814>
+          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
 ] .
 
 <http://model.geneontology.org/2.6.1.58-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0016212> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -492,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -532,41 +543,56 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
+          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_null_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29748_CHORISMATEMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29748> ;
@@ -577,24 +603,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4153SmallMolecule50036> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006264>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -604,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -615,11 +630,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +642,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -636,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -663,29 +678,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_null_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -702,18 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -721,11 +723,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,15 +735,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58095_RXN-10814>
+          <http://model.geneontology.org/CHEBI_16810_RXN-10814>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_PWY3O-4153>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -752,21 +765,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_PWY3O-4153>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -775,16 +796,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_29934_PREPHENATEDEHYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29934> ;
@@ -795,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -821,22 +834,20 @@
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_null_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
@@ -848,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,22 +868,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_null_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_PWY3O-4153>
@@ -880,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -929,11 +938,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +950,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -952,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -982,19 +991,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
+          <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
+          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_null_PWY3O-4153>
@@ -1002,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1042,8 +1051,31 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0016212>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY3O-4153> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
+] .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1057,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,19 +1099,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_2.6.1.58-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
+          <http://model.geneontology.org/2.6.1.58-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -1087,19 +1119,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY3O-4153>
@@ -1107,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,10 +1162,10 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
+<http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
+<http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_null_PWY3O-4153>
@@ -1141,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1164,14 +1196,19 @@
 <http://identifiers.org/sgd/S000001378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,24 +1216,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_29934_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_2.6.1.58-RXN_SGD_PWY3O-4153>
@@ -1204,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1254,11 +1288,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1300,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
@@ -1278,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,31 +1331,42 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_2.6.1.58-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002411_RXN-10814_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1374,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.6.1.58-RXN>
+          <http://model.geneontology.org/RXN-10814>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1340,7 +1385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,23 +1398,26 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.6.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16810_RXN-10814>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1380,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1388,19 +1436,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_29748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1408,7 +1453,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_PREPHENATEDEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -1423,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,19 +1478,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
+          <http://model.geneontology.org/CHEBI_29985_RXN-10814>
 ] .
 
 <http://model.geneontology.org/CHEBI_18005_RXN-10814>
@@ -1457,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-4158-PWY3O-4158.ttl
+++ b/models/PWY3O-4158-PWY3O-4158.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,7 +82,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of NAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,6 +357,9 @@
           <http://model.geneontology.org/PWY3O-4158/PWY3O-4158>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0008936>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -366,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,15 +377,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0008936>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -811,7 +811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,29 +884,12 @@
           <http://model.geneontology.org/PWY3O-4158/PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/a5600628-35ac-4df9-8ba1-15563a9033bc_RXN-15025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,24 +933,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35484> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_2fd29e79-3c67-4c97-a783-a1689f1ca7dd_RXN-15025_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -977,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1000,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1046,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,7 +1159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1246,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,7 +1240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1302,7 +1274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,17 +1285,6 @@
           <http://model.geneontology.org/CHEBI_58629_RXN-8665>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1333,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1346,22 +1307,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_a5600628-35ac-4df9-8ba1-15563a9033bc_RXN-15025_SGD_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001116>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1369,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,6 +1344,17 @@
           <http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025_SGD_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1389,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1470,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1481,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1493,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1521,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,20 +1512,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glutamine-dependent NAD synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,7 +1561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1665,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1677,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1708,17 +1683,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_null_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005735> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1726,13 +1690,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35528> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_null_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1742,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,7 +1734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1778,7 +1753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1798,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1812,7 +1787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1856,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1870,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1893,7 +1868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,7 +1887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1903,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1939,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1952,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1965,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1976,7 +1962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2007,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2022,7 +2008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2039,7 +2025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,20 +2041,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-4139_RXN-8443_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005073> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "nicotinic acid riboside kinase / nicotinamide ribose kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2096,7 +2082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,7 +2099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2140,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2152,7 +2138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,7 +2185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2211,13 +2197,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000005073> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "nicotinic acid riboside kinase / nicotinamide ribose kinase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2230,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2252,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2263,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2278,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2292,7 +2278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2312,7 +2298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2343,27 +2329,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://identifiers.org/sgd/S000005073>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2371,7 +2338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,6 +2349,28 @@
           <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_2.7.7.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2391,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2399,22 +2388,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-205> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-214>
-] .
+<http://model.geneontology.org/67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57540_2.7.7.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -2425,13 +2414,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35385> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-205> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-214>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16988>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2441,11 +2447,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2453,7 +2476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2470,7 +2493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2511,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2524,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2553,7 +2576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2593,7 +2616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2610,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2627,7 +2650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2644,7 +2667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2660,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2671,7 +2694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2686,13 +2709,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35350> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000002836>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000004320>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2703,7 +2729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2722,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2737,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2753,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2768,7 +2794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2787,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2799,7 +2825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2816,7 +2842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2832,7 +2858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2844,7 +2870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,7 +2889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2886,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2899,7 +2925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2910,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2926,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2940,7 +2966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2957,7 +2983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2974,7 +3000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2990,7 +3016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3004,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3015,7 +3041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3026,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3040,7 +3066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3057,7 +3083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3073,11 +3099,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '1-(&beta;-D ribofuranosyl)nicotinamide + H<sub>2</sub>O &rarr; D-ribofuranose + nicotinamide + H<SUP>+</SUP>' 'null' 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_NICOTINAMID-RXN_null_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8441> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NICOTINAMID-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
+] .
 
 <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
@@ -3100,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3108,41 +3170,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '1-(&beta;-D ribofuranosyl)nicotinamide + H<sub>2</sub>O &rarr; D-ribofuranose + nicotinamide + H<SUP>+</SUP>' 'null' 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_NICOTINAMID-RXN_null_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8441> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NICOTINAMID-RXN>
-] .
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_17154_NICOTINAMID-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17154> ;
@@ -3153,16 +3182,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35433> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_30616_RXN-8443>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3173,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3187,7 +3213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3204,7 +3230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3224,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3243,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3254,7 +3280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3269,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3282,28 +3308,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_RXN0-7092>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3313,7 +3322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3324,13 +3333,30 @@
           <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/CHEBI_15378_RXN0-7092>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,7 +3376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3363,7 +3389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3374,7 +3400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3389,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3402,7 +3428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3417,7 +3443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3430,7 +3456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3445,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3458,7 +3484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3469,7 +3495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3483,7 +3509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3500,7 +3526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3516,7 +3542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3530,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3545,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3563,24 +3589,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35335> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YLR209C-MONOMER_RXN0-7092_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004199> ;
@@ -3589,13 +3604,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35302> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32544_RXN3O-205>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32544> ;
@@ -3606,7 +3632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3619,7 +3645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3636,7 +3662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3652,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3663,7 +3689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3674,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3689,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3707,7 +3733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,7 +3746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3735,7 +3761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3748,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3760,7 +3786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,7 +3803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3793,7 +3819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3804,7 +3830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3819,7 +3845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3836,7 +3862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3861,7 +3887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3874,7 +3900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3889,7 +3915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3905,7 +3931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3919,7 +3945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3935,7 +3961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3947,25 +3973,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_null_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3974,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3988,7 +4014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4007,7 +4033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4027,7 +4053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4040,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4055,7 +4081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4068,11 +4094,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_a5600628-35ac-4df9-8ba1-15563a9033bc_RXN-15025_SGD_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4080,7 +4106,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a5600628-35ac-4df9-8ba1-15563a9033bc_RXN-15025>
+          <http://model.geneontology.org/d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004502>
@@ -4092,7 +4118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4109,7 +4135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4147,7 +4173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4160,7 +4186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4171,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4183,7 +4209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4199,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4211,7 +4237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4231,7 +4257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4243,13 +4269,13 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000002836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "Arylformamidase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4269,7 +4295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4286,7 +4312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4302,7 +4328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4322,7 +4348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4352,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4365,7 +4391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4376,7 +4402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4391,7 +4417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4405,7 +4431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4424,7 +4450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4436,7 +4462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4452,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4467,7 +4493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4480,7 +4506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4495,7 +4521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4503,14 +4529,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4158" ;
+                "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4520,7 +4546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4540,7 +4566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4553,20 +4579,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4575,7 +4601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4595,7 +4621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4612,7 +4638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4628,7 +4654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4643,7 +4669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4656,7 +4682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4668,7 +4694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4684,7 +4710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4696,7 +4722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4716,7 +4742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4736,7 +4762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4749,7 +4775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4760,7 +4786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4772,7 +4798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4791,7 +4817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,7 +4837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4828,7 +4854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4841,14 +4867,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57502>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4858,7 +4892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4875,7 +4909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4891,13 +4925,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58629>
+<http://purl.obolibrary.org/obo/CHEBI_57502>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4906,7 +4940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4926,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4953,7 +4987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4961,13 +4995,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/CHEBI_58629>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4978,23 +5015,23 @@
           <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5005,18 +5042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5031,7 +5057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5045,7 +5071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5065,7 +5091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5082,7 +5108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5101,7 +5127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5121,7 +5147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5134,7 +5160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5145,7 +5171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5156,7 +5182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5168,7 +5194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5188,7 +5214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5205,7 +5231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5214,23 +5240,6 @@
           <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_2.7.7.1-RXN_SGD_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.7.1-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_14649_2.7.7.1-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-8441>
@@ -5242,7 +5251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5250,12 +5259,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_2.7.7.1-RXN_SGD_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.7.1-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_14649_2.7.7.1-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5266,7 +5292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5280,7 +5306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5300,7 +5326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5316,7 +5342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5327,7 +5353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5338,7 +5364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5350,7 +5376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5367,7 +5393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5378,23 +5404,6 @@
           <http://model.geneontology.org/CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/2fd29e79-3c67-4c97-a783-a1689f1ca7dd_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -5403,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5421,7 +5430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5438,7 +5447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5459,7 +5468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5474,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5488,7 +5497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5505,7 +5514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5524,7 +5533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5535,7 +5544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5546,7 +5555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5561,7 +5570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5578,7 +5587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5594,7 +5603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5610,7 +5619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5627,7 +5636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5654,7 +5663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5681,7 +5690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5695,7 +5704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5718,7 +5727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5734,7 +5743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5746,7 +5755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5762,7 +5771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5774,7 +5783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5800,7 +5809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5813,7 +5822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5825,16 +5834,13 @@
 <http://purl.obolibrary.org/obo/GO_0004515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57720>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5854,7 +5860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5871,7 +5877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5898,7 +5904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5906,7 +5912,7 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
+<http://purl.obolibrary.org/obo/CHEBI_57720>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57502_RXN-8443>
@@ -5918,7 +5924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5934,7 +5940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5948,7 +5954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5962,7 +5968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5979,7 +5985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5999,7 +6005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6016,7 +6022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6032,7 +6038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6052,7 +6058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6069,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6085,7 +6091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6105,7 +6111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6118,7 +6124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6129,7 +6135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6141,7 +6147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6158,7 +6164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6188,7 +6194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6205,7 +6211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6223,7 +6229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6243,7 +6249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6257,7 +6263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6274,7 +6280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6290,7 +6296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6305,7 +6311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6322,7 +6328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6339,7 +6345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6352,7 +6358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6364,7 +6370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6381,7 +6387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6401,7 +6407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6414,7 +6420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6429,7 +6435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6437,22 +6443,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6462,7 +6462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6479,7 +6479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6495,11 +6495,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_994_RXN-5721>
         a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6510,7 +6527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6518,24 +6535,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6558,7 +6564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6571,7 +6577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6582,7 +6588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6597,7 +6603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6610,7 +6616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6627,7 +6633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6647,7 +6653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6664,7 +6670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6679,7 +6685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6696,7 +6702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6710,7 +6716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6724,13 +6730,16 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000002200>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6749,7 +6758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6760,7 +6769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6772,7 +6781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6789,7 +6798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6815,7 +6824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6829,7 +6838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6845,7 +6854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6860,7 +6869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6880,7 +6889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6894,7 +6903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6911,7 +6920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6927,7 +6936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6942,7 +6951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6959,7 +6968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6975,7 +6984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6986,7 +6995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7000,7 +7009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7019,7 +7028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7035,7 +7044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7046,7 +7055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7060,7 +7069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7072,7 +7081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7091,7 +7100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7114,7 +7123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7129,7 +7138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7142,7 +7151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7154,7 +7163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7187,7 +7196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7203,7 +7212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7219,7 +7228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7237,9 +7246,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/2fd29e79-3c67-4c97-a783-a1689f1ca7dd_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/a5600628-35ac-4df9-8ba1-15563a9033bc_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7247,7 +7256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7280,7 +7289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7293,7 +7302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7311,7 +7320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7325,7 +7334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7341,7 +7350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7356,7 +7365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7373,7 +7382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7392,7 +7401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7407,7 +7416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7424,7 +7433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7447,7 +7456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7460,7 +7469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7472,7 +7481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7489,7 +7498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7509,7 +7518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7526,7 +7535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7539,7 +7548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7551,7 +7560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7583,7 +7592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7597,7 +7606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7613,7 +7622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7624,7 +7633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7636,7 +7645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7654,7 +7663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7668,7 +7677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7684,7 +7693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7698,7 +7707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7716,7 +7725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7729,7 +7738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7741,7 +7750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7758,7 +7767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7771,11 +7780,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_2fd29e79-3c67-4c97-a783-a1689f1ca7dd_RXN-15025_SGD_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7783,7 +7792,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2fd29e79-3c67-4c97-a783-a1689f1ca7dd_RXN-15025>
+          <http://model.geneontology.org/67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
@@ -7795,7 +7804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7822,7 +7831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7839,7 +7848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7852,7 +7861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7864,7 +7873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7876,13 +7885,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "NAD-dependent histone deacetylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7899,7 +7908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7929,7 +7938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7943,7 +7952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7960,7 +7969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7976,7 +7985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7988,7 +7997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8004,7 +8013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8019,7 +8028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8034,7 +8043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8047,7 +8056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4300-PWY3O-4300.ttl
+++ b/models/PWY3O-4300-PWY3O-4300.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,17 +422,6 @@
           <http://model.geneontology.org/CHEBI_30616_ACETATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/PWY3O-4300>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -442,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ethanol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -450,13 +439,24 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15377_RXN66-3_SGD_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1120,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1293,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1304,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1379,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,13 +1407,24 @@
           <http://model.geneontology.org/CHEBI_29888_ACETATE--COA-LIGASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,17 +1435,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-3>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_ACETATE--COA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1486,7 +1486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1541,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-440-PWY3O-440.ttl
+++ b/models/PWY3O-440-PWY3O-440.ttl
@@ -1,24 +1,30 @@
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_9d054219-f5e5-4c47-9ef6-703cee96beb2_RXN0-2022_SGD_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_null_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-440/PWY3O-440>
+] .
 
 <http://model.geneontology.org/RXN0-2022>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -31,13 +37,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9d054219-f5e5-4c47-9ef6-703cee96beb2_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
+                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -45,12 +51,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,39 +101,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,39 +113,59 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
+          <http://model.geneontology.org/CHEBI_16526_RXN-6161>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-2022>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_09abca24-9aa8-4306-a497-c5c7c94a17bd_RXN3O-470_SGD_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+] .
+
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-2022> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -157,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -179,39 +197,53 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_null_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
 ] .
 
 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,8 +251,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
+] .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -230,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -240,10 +298,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,16 +332,27 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440Complex37563> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+        a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -294,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -302,46 +373,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
+          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-6161>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
 <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,19 +424,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller>
+          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -375,24 +448,57 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_null_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-440/PWY3O-440>
+          <http://model.geneontology.org/reaction_RXN0-2022_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-6161>
@@ -404,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -426,12 +532,51 @@
 <http://purl.obolibrary.org/obo/CHEBI_15343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -441,20 +586,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' '2 acetaldehyde &rarr; acetoin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_null_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
+          <http://model.geneontology.org/RXN3O-470>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -462,40 +609,34 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
-] .
 
 <http://model.geneontology.org/PWY3O-440/PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
@@ -506,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -516,11 +657,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +669,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+          <http://model.geneontology.org/CHEBI_15378_RXN-6161>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_RXN-6161>
@@ -540,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -561,19 +719,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
+          <http://model.geneontology.org/5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -584,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -599,13 +757,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyruvate fermentation to acetoin III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -615,54 +776,56 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/09abca24-9aa8-4306-a497-c5c7c94a17bd_RXN3O-470>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller>
+          <http://model.geneontology.org/PWY3O-440/PWY3O-440>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470>
 ] .
 
 <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,28 +869,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,7 +881,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
+          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_15343_RXN3O-470>
@@ -747,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,10 +922,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,24 +935,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_null_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-2022_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/CHEBI_15343_RXN-6161>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-470>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -800,7 +963,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/09abca24-9aa8-4306-a497-c5c7c94a17bd_RXN3O-470> ;
+                <http://model.geneontology.org/055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -808,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,40 +979,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_15343_RXN-6161>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_null_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/RXN-6161>
@@ -871,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,21 +1040,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440>
@@ -901,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -914,10 +1086,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,12 +1105,29 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN3O-470_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15343_RXN3O-470>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -947,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -969,39 +1160,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_9d054219-f5e5-4c47-9ef6-703cee96beb2_RXN0-2022_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9d054219-f5e5-4c47-9ef6-703cee96beb2_RXN0-2022>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_null_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,19 +1172,47 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
+          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_null_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1032,6 +1223,17 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_15343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1041,13 +1243,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1058,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,20 +1283,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_null_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-440/PWY3O-440>
+          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY3O-440>
@@ -1088,58 +1306,89 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-440/PWY3O-440>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
+<http://model.geneontology.org/5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_09abca24-9aa8-4306-a497-c5c7c94a17bd_RXN3O-470_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/09abca24-9aa8-4306-a497-c5c7c94a17bd_RXN3O-470>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN0-2022>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1148,12 +1397,23 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_null_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1178,11 +1438,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_null_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
+] .
 
 <http://purl.obolibrary.org/obo/GO_0004737>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1191,10 +1470,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,19 +1488,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
+          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
@@ -1227,46 +1508,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN-6161>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://model.geneontology.org/9d054219-f5e5-4c47-9ef6-703cee96beb2_RXN0-2022>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-2022> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller>
+] .
 
 <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1275,22 +1558,20 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' '2 acetaldehyde &rarr; acetoin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_null_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_PWY3O-440/PWY3O-440_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-470>
+          <http://model.geneontology.org/PWY3O-440/PWY3O-440>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -1298,28 +1579,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN3O-470_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN3O-470>
+          <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller>
+] .

--- a/models/PWY3O-45-PWY3O-45.ttl
+++ b/models/PWY3O-45-PWY3O-45.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,24 +35,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_88f88587-74a8-4780-85dd-b26f11ffaeac_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,30 +201,13 @@
           <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/88f88587-74a8-4780-85dd-b26f11ffaeac_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_PWY3O-45/PWY3O-45_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,24 +218,13 @@
           <http://model.geneontology.org/PWY3O-45/PWY3O-45>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,6 +235,17 @@
           <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_73083_H2PTEROATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_73083> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -283,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,7 +444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -510,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -548,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -592,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -876,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -898,28 +870,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65402> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -929,7 +884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,6 +895,23 @@
           <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65402> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0046820>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -949,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1175,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,11 +1175,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_ced2bc8f-9312-4eb6-9f49-8d7cd587eb53_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,7 +1187,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ced2bc8f-9312-4eb6-9f49-8d7cd587eb53_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_PWY3O-45/PWY3O-45_SGD_PWY3O-45>
@@ -1223,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1234,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,13 +1260,13 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "aminodeoxychorismate lyase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,7 +1282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1464,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1554,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1568,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1601,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1616,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1629,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1640,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1668,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1683,7 +1655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,7 +1672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,7 +1691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1732,11 +1704,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_88f88587-74a8-4780-85dd-b26f11ffaeac_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1716,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/88f88587-74a8-4780-85dd-b26f11ffaeac_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
@@ -1754,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1779,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1795,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1810,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1847,7 +1819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1863,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1878,7 +1850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,7 +1921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,19 +1932,19 @@
           <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
         a       <http://identifiers.org/sgd/S000004719> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1981,7 +1953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1998,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2013,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2030,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2047,13 +2019,24 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2083,13 +2066,30 @@
           <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,15 +2100,12 @@
           <http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2122,7 +2119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2153,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2186,7 +2183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2213,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2227,7 +2224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2241,6 +2238,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_null_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2249,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,17 +2268,6 @@
           <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_null_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
@@ -2280,7 +2277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2324,12 +2321,15 @@
 <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2353,7 +2353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2370,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2418,7 +2418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2446,7 +2446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2465,7 +2465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2486,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2516,7 +2516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2524,28 +2524,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY3O-45> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_PWY3O-45/PWY3O-45_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2565,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2573,33 +2556,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY3O-45> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ced2bc8f-9312-4eb6-9f49-8d7cd587eb53_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -2610,7 +2593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2625,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2641,7 +2624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2661,7 +2644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2675,7 +2658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2695,7 +2678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2718,7 +2701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,7 +2715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2748,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2760,7 +2743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2780,7 +2763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,7 +2777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2812,7 +2795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,7 +2812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2843,7 +2826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2859,7 +2842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2874,7 +2857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2887,7 +2870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2902,7 +2885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2922,7 +2905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2935,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2950,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2963,7 +2946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2977,7 +2960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +2993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,7 +3009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3042,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3053,7 +3036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3065,7 +3048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3081,7 +3064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3093,7 +3076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3115,7 +3098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3135,7 +3118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3152,7 +3135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3171,7 +3154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3185,7 +3168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3210,7 +3193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3230,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3244,7 +3227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3277,24 +3260,13 @@
           <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_ced2bc8f-9312-4eb6-9f49-8d7cd587eb53_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,7 +3282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3322,7 +3294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3341,7 +3313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3354,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3365,12 +3337,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3385,7 +3374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3401,9 +3390,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3416,7 +3416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3432,7 +3432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3444,7 +3444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,7 +3461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3477,7 +3477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3489,7 +3489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3509,7 +3509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3522,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3537,7 +3537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3550,7 +3550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3565,15 +3565,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ced2bc8f-9312-4eb6-9f49-8d7cd587eb53_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/88f88587-74a8-4780-85dd-b26f11ffaeac_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3598,7 +3598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3614,7 +3614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3626,7 +3626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3642,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3654,7 +3654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3671,7 +3671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3694,7 +3694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3711,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3727,7 +3727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3741,7 +3741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3752,7 +3752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3766,7 +3766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-450-PWY3O-450.ttl
+++ b/models/PWY3O-450-PWY3O-450.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylcholine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,6 +167,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_295975_2.7.7.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphocholine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450SmallMolecule21848> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHOLINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004103> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -187,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,29 +212,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_295975_2.7.7.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphocholine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450SmallMolecule21848> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_RXN-5781_SGD_PWY3O-450>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,35 +789,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY3O-450> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5781> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17815_RXN-5781>
-] .
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_PWY3O-450/PWY3O-450_SGD_PWY3O-450>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -832,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,27 +834,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY3O-450>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY3O-450> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5781> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17815_RXN-5781>
+] .
 
 <http://model.geneontology.org/RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004142> ;
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-48-PWY3O-48.ttl
+++ b/models/PWY3O-48-PWY3O-48.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,13 +300,24 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY3O-48>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_15378_1.1.1.8-RXN_SGD_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,24 +328,13 @@
           <http://model.geneontology.org/CHEBI_15378_1.1.1.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY3O-48>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-5-PWY3O-5.ttl
+++ b/models/PWY3O-5-PWY3O-5.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylulose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-50-PWY3O-50.ttl
+++ b/models/PWY3O-50-PWY3O-50.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,13 +475,30 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52276> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,15 +509,12 @@
           <http://model.geneontology.org/CHEBI_15378_PORPHOBILSYNTH-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_28938>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_null_PWY3O-50>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -511,28 +525,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52276> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_28938>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrapyrrole biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_PWY3O-50/PWY3O-50_SGD_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1348,7 +1359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,17 +1369,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57845_OHMETHYLBILANESYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_PWY3O-50/PWY3O-50_SGD_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/UROGENIIISYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004852> ;
@@ -1387,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1401,7 +1401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-5268-PWY3O-5268.ttl
+++ b/models/PWY3O-5268-PWY3O-5268.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "oleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,7 +244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -298,7 +298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-592-PWY3O-592.ttl
+++ b/models/PWY3O-592-PWY3O-592.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin system - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-5962-PWY3O-5962.ttl
+++ b/models/PWY3O-5962-PWY3O-5962.ttl
@@ -1,5 +1,5 @@
 <http://model.geneontology.org/RXN3O-1803>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a palmitoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctadecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,18 +135,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_null_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9515>
+] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -212,48 +231,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; palmitoleoyl-CoA + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_RXN-10664_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-10664>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-9780_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9634_SGD_PWY3O-5962>
@@ -261,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -280,19 +295,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
@@ -304,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,53 +329,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-9624>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1803> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-1803>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1803> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-5962>
@@ -368,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,11 +408,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,7 +420,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10662> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN-10662>
+          <http://model.geneontology.org/CHEBI_15378_RXN-10662>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962>
@@ -413,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,19 +478,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002411_RXN3O-5304_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Octadec-2-enoyl-ACPs_RXN3O-5293_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-5304>
+          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN3O-5293>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -486,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,20 +548,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetyl-coenzyme A carboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -651,36 +671,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_3-oxo-stearoyl-ACPs_RXN-9633_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9634> ;
+          <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN-9633>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_57783_RXN3O-5293_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5293_controller>
+          <http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN>
@@ -692,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,19 +739,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ACP_4.2.1.58-RXN>
@@ -743,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,21 +788,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'palmitoyl-CoA + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; palmitoleoyl-CoA + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' 'palmitoleoyl-CoA + H<sub>2</sub>O &rarr; palmitoleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
+          <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-10662>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY3O-5962>
@@ -790,27 +810,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-9780>
+          <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
@@ -828,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,27 +863,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962>
@@ -869,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -902,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -913,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -921,19 +945,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1803> ;
+          <http://model.geneontology.org/RXN-9666> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/CHEBI_30823_RXN-9666>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
@@ -945,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -977,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1014,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1027,18 +1051,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004315>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_1.14.19.1-RXN_null_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1049,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,41 +1108,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
-] .
-
 <http://purl.obolibrary.org/obo/CHEBI_17544>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9515>
 ] .
 
 <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
@@ -1127,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,36 +1181,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.14.19.1-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_1.14.19.1-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.14.19.1-RXN> ;
+          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57387_1.14.19.1-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10662> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/Crotonyl-ACPs_RXN-9515>
@@ -1195,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,20 +1231,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
+          <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
@@ -1225,19 +1254,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_58349_RXN3O-5293_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN3O-5293>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1248,7 +1277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,37 +1289,39 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61540_RXN-10664>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN-10664>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9624>
@@ -1302,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1329,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1344,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1423,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1451,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,53 +1492,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN-10664_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+          <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57379_RXN-10664>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10664> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-10664>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5304_controller>
+          <http://model.geneontology.org/ACP_RXN3O-5304>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9515>
@@ -1519,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1529,11 +1560,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1541,24 +1572,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_57783_RXN3O-5293_SGD_PWY3O-5962>
@@ -1566,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1574,38 +1605,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
+          <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002411_RXN3O-5293_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9666> ;
+          <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9666_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-5293>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY3O-5962>
@@ -1613,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1628,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1641,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1660,19 +1689,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.14.19.1-RXN>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/YGL055W-MONOMER_RXN-10664_controller>
@@ -1682,7 +1711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1692,23 +1721,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 2,3,4-saturated fatty acyl-[acp] + NADP<sup>+</sup> &larr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1726,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1739,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1754,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1767,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1833,36 +1862,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9624>
+          <http://model.geneontology.org/CHEBI_15377_RXN-9624>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-5962>
@@ -1870,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1878,11 +1907,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1890,7 +1919,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
+          <http://model.geneontology.org/ACP_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY3O-5962>
@@ -1898,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1917,38 +1946,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+          <http://model.geneontology.org/RXN-10662> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_null_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10664> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-10664_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_RXN-10662>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962>
@@ -1956,48 +1983,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002411_RXN3O-5304_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5304> ;
+          <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-5304>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2006,7 +2029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2018,20 +2041,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-9634>
+          <http://model.geneontology.org/reaction_RXN-9634_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY3O-5962>
@@ -2039,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2054,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2067,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2082,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2099,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2112,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2123,21 +2148,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008659>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN-10664_SGD_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2145,36 +2167,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9634_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9634>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-10662>
@@ -2186,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2196,36 +2218,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_58349_RXN-9514_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9514>
+          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962>
@@ -2233,18 +2238,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_null_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9514> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2255,19 +2279,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
+          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-9780>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
@@ -2275,19 +2299,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962>
@@ -2295,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2306,7 +2330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2317,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2325,53 +2349,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9515> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9515>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-1803>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/RXN-9666>
@@ -2389,7 +2413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2406,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2426,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2439,14 +2463,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9634>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2464,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2477,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2488,7 +2512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2501,7 +2525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2518,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2531,7 +2555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2542,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2553,14 +2577,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9514>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2578,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2588,19 +2612,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL055W-MONOMER_1.14.19.1-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57387_1.14.19.1-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962>
@@ -2608,7 +2632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2619,14 +2643,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2644,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2654,36 +2678,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10662> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10662> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-10662>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_57783_RXN-9633_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9633>
+          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
 ] .
 
 <http://model.geneontology.org/ACETYL-COA-CARBOXYLTRANSFER-RXN>
@@ -2705,7 +2729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2715,19 +2739,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_15378_RXN3O-5293_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_58349_RXN3O-5293_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-5293>
+          <http://model.geneontology.org/CHEBI_58349_RXN3O-5293>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY3O-5962>
@@ -2735,7 +2759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2747,7 +2771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2763,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2774,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2782,36 +2806,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL055W-MONOMER_RXN-10664_controller>
+          <http://model.geneontology.org/CHEBI_61540_RXN-10664>
 ] .
 
 <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
@@ -2823,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2836,44 +2860,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' 'stearoyl-CoA + H<sub>2</sub>O &rarr; stearate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9780> ;
+          <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/RXN-9624>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_PWY3O-5962>
@@ -2881,14 +2907,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9780>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2906,7 +2932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2926,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2946,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2963,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2993,7 +3019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3009,22 +3035,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' '2 a ferrocytochrome <i>b<SUB>5</SUB></i> + stearoyl-CoA + oxygen + 2 H<SUP>+</SUP> &rarr; 2 a ferricytochrome <i>b<sub>5</sub></i> + oleoyl-CoA + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_1.14.19.1-RXN_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.14.19.1-RXN>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5304_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_PWY3O-5962>
@@ -3032,7 +3056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3040,72 +3064,72 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9780>
+          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9515> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9514>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_RXN-9666_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9666> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57387_RXN-9666>
+          <http://model.geneontology.org/reaction_RXN-9666_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -3116,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3127,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3140,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3150,11 +3174,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_1.14.19.1-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3162,7 +3186,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57394_1.14.19.1-RXN>
+          <http://model.geneontology.org/CHEBI_15378_1.14.19.1-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY3O-5962>
@@ -3170,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3181,19 +3205,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_PWY3O-5962>
@@ -3201,7 +3225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3209,19 +3233,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002411_RXN-9633_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9633>
+          <http://model.geneontology.org/YER061C-MONOMER_RXN3O-1803_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_PWY3O-5962>
@@ -3229,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3244,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3258,7 +3282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3287,7 +3311,7 @@
                 "org.biopax.paxtools.model.level3.Pathway" .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004321> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004315> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 2,3,4-saturated fatty acyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; acyl-carrier protein + a 3-oxoacyl-[acp] + CO<SUB>2</SUB>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3305,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3318,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3343,7 +3367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3364,7 +3388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3374,19 +3398,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_4.2.1.58-RXN>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
@@ -3396,7 +3420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3406,11 +3430,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3418,7 +3442,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN-9624>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9624>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_PWY3O-5962>
@@ -3426,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3437,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3445,39 +3469,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002411_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN-10664>
+          <http://model.geneontology.org/reaction_RXN-10664_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY3O-5962>
@@ -3485,27 +3511,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5304_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5304>
+          <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9666>
@@ -3517,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3526,20 +3554,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
@@ -3549,7 +3579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3562,36 +3592,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_57783_RXN-9514_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3599,24 +3631,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9514>
+          <http://model.geneontology.org/ACP_RXN-9514>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9634_controller>
+          <http://model.geneontology.org/CHEBI_15377_RXN-9634>
 ] .
 
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962>
@@ -3624,7 +3656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3635,7 +3667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3646,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3657,7 +3689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3672,7 +3704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3688,7 +3720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3699,7 +3731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3710,7 +3742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3725,7 +3757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3742,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3757,7 +3789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3770,20 +3802,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004820> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3792,7 +3850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3803,7 +3861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3819,7 +3877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3836,7 +3894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3846,75 +3904,73 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_58349_RXN-9514_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_15378_RXN-9514_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9514>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9514>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
@@ -3926,7 +3982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3939,7 +3995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3947,47 +4003,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
+          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9624> ;
+          <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3995,7 +4049,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
+          <http://model.geneontology.org/ACP_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY3O-5962>
@@ -4003,7 +4057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4014,38 +4068,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '2 a ferrocytochrome <i>b<SUB>5</SUB></i> + stearoyl-CoA + oxygen + 2 H<SUP>+</SUP> &rarr; 2 a ferricytochrome <i>b<sub>5</sub></i> + oleoyl-CoA + 2 H<sub>2</sub>O' 'null' 'oleoyl-CoA + H<sub>2</sub>O &rarr; oleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+          <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9666>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10662_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10662> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32372_RXN-10662>
+          <http://model.geneontology.org/CHEBI_61540_RXN-10662>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_3-oxo-stearoyl-ACPs_RXN-9633_SGD_PWY3O-5962>
@@ -4053,7 +4107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4064,7 +4118,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4075,7 +4140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4087,7 +4152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4107,7 +4172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4120,7 +4185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4131,7 +4196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4142,7 +4207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4157,7 +4222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4174,7 +4239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4191,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4207,7 +4272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4224,7 +4289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4235,7 +4300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4243,28 +4308,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002411_RXN-9634_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_57783_RXN-9633_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9634>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9633>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Octadec-2-enoyl-ACPs_RXN3O-5293_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_15378_RXN3O-5293_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4272,7 +4337,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN3O-5293>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-5293>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4281,7 +4346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4292,6 +4357,9 @@
           <http://model.geneontology.org/CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0102132>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_7896> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4301,7 +4369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4311,53 +4379,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+          <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
+          <http://model.geneontology.org/YGL055W-MONOMER_RXN-10664_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN3O-9780>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003989>
@@ -4365,28 +4433,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4394,7 +4462,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9666> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN-9666>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9666>
 ] .
 
 <http://model.geneontology.org/ACP_RXN3O-9780>
@@ -4406,7 +4474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4419,7 +4487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4432,7 +4500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4449,7 +4517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4466,7 +4534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4482,7 +4550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4497,7 +4565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4510,7 +4578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4525,7 +4593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4538,7 +4606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4553,7 +4621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4566,14 +4634,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/4.2.1.58-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -4591,7 +4659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4611,7 +4679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4621,21 +4689,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9514>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5304_SGD_PWY3O-5962>
@@ -4643,7 +4711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4651,11 +4719,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_RXN-9515_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4663,24 +4731,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Crotonyl-ACPs_RXN-9515>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_RXN-9666_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9666> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30823_RXN-9666>
+          <http://model.geneontology.org/CHEBI_57387_RXN-9666>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -4691,7 +4759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4699,19 +4767,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_1.14.19.1-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_1.14.19.1-RXN>
+          <http://model.geneontology.org/CHEBI_57394_1.14.19.1-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_PWY3O-5962>
@@ -4719,7 +4787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4734,7 +4802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4744,11 +4812,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4756,7 +4824,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_RXN-10664>
@@ -4768,7 +4836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4778,41 +4846,39 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_58349_RXN-9633_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9633>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002411_RXN-9633_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5293> ;
+          <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9633>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002411_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962>
@@ -4820,7 +4886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4831,7 +4897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4843,7 +4909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4862,7 +4928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4877,7 +4943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4894,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4907,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4932,7 +4998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4945,7 +5011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4959,7 +5025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4970,7 +5036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4981,7 +5047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4992,7 +5058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5003,29 +5069,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002411_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30823>
@@ -5033,11 +5097,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5045,7 +5109,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN-10664>
+          <http://model.geneontology.org/CHEBI_15379_RXN-10664>
 ] .
 
 <http://model.geneontology.org/CHEBI_30823_RXN-9666>
@@ -5057,7 +5121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5074,7 +5138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5084,19 +5148,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5304_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
+          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5304>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_RXN-9633>
@@ -5108,7 +5172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5125,7 +5189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5135,55 +5199,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_57783_RXN-9514_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_null_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.2.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9514>
 ] .
 
 <http://identifiers.org/sgd/S000006152>
@@ -5191,57 +5253,57 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9666> ;
+          <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9634_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; palmitoleoyl-CoA + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_RXN-10664_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.14.19.1-RXN> ;
+          <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.14.19.1-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-10664>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_1.14.19.1-RXN_location_lociGO_0005829>
@@ -5252,7 +5314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5263,7 +5325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5278,7 +5340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5295,7 +5357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5308,7 +5370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5319,7 +5381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5334,7 +5396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5343,58 +5405,60 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.14.19.1-RXN> ;
+          <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002411_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -5412,7 +5476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5421,74 +5485,78 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN-9624_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9624> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9624> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57394_RXN-9624>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN3O-1803>
+          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+          <http://model.geneontology.org/RXN-10662> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10664> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/CHEBI_32372_RXN-10662>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
@@ -5496,19 +5564,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5304> ;
+          <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5293_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_null_PWY3O-5962>
@@ -5516,7 +5584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5524,19 +5592,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
@@ -5548,7 +5616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5562,7 +5630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5582,7 +5650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5595,7 +5663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5606,7 +5674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5621,7 +5689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5634,7 +5702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5649,7 +5717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5657,12 +5725,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://identifiers.org/sgd/S000004820>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5673,7 +5744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5681,38 +5752,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
+          <http://model.geneontology.org/ACP_4.2.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002411_RXN-9634_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9634> ;
+          <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9634_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9634>
 ] .
 
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
@@ -5722,7 +5791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5739,7 +5808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5749,19 +5818,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002411_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
+          <http://model.geneontology.org/YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-5962>
@@ -5769,7 +5838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5777,19 +5846,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN-9514>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-9666_location_lociGO_0005829>
@@ -5804,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5817,7 +5886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5825,32 +5894,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-9780>
+          <http://model.geneontology.org/CHEBI_57287_RXN3O-9780>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -5859,15 +5928,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -5879,7 +5948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5890,7 +5959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5901,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5909,38 +5978,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
+          <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1803> ;
+          <http://model.geneontology.org/RXN-9666> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_RXN-9666>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962>
@@ -5948,7 +6015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5963,7 +6030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5980,7 +6047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5993,7 +6060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6008,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6024,7 +6091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6044,7 +6111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6069,7 +6136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6082,7 +6149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6096,7 +6163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6110,7 +6177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6125,7 +6192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6134,37 +6201,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_RXN-9515_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9515>
+          <http://model.geneontology.org/Crotonyl-ACPs_RXN-9515>
 ] .
 
 <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
@@ -6176,7 +6245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6186,11 +6255,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6198,7 +6267,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_1.14.19.1-RXN>
+          <http://model.geneontology.org/CHEBI_15377_1.14.19.1-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY3O-5962>
@@ -6206,29 +6275,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10662> ;
+          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-10662_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002411_RXN-9634_SGD_PWY3O-5962>
@@ -6236,7 +6303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6244,39 +6311,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_15378_RXN-9633_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_58349_RXN-9633_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9633>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9633>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
+          <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6285,7 +6354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6298,23 +6367,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acyl-carrier protein + acetyl-CoA &rarr; an acetyl-[acp] + coenzyme A" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -6332,7 +6401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6342,11 +6411,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6354,7 +6423,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN-10664>
+          <http://model.geneontology.org/CHEBI_15377_RXN-10664>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_58349_RXN-9514_SGD_PWY3O-5962>
@@ -6362,7 +6431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6372,10 +6441,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "biotin carboxylase / acetyl-CoA carboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6388,7 +6459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6403,7 +6474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6416,7 +6487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6427,11 +6498,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005299>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
@@ -6440,7 +6514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6457,7 +6531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6474,7 +6548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6487,7 +6561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6498,7 +6572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6513,7 +6587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6522,92 +6596,90 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' 'stearoyl-CoA + H<sub>2</sub>O &rarr; stearate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-5304> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_null_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5304> ;
+          <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9624>
+          <http://model.geneontology.org/4.2.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_null_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9666> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-9666>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962>
@@ -6615,7 +6687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6629,44 +6701,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_1.14.19.1-RXN>
+          <http://model.geneontology.org/reaction_1.14.19.1-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
@@ -6680,7 +6756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6688,19 +6764,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_RXN3O-1803_controller>
+          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6709,7 +6785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6725,7 +6801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6736,7 +6812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6747,7 +6823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6762,7 +6838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6777,7 +6853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6794,7 +6870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6807,7 +6883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6818,7 +6894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6833,7 +6909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6850,7 +6926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6867,7 +6943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6884,7 +6960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6897,7 +6973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6910,7 +6986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6923,7 +6999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6938,7 +7014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated and unsaturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6947,43 +7023,41 @@
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002411_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN-9624_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_25629_RXN-9624>
+          <http://model.geneontology.org/CHEBI_57394_RXN-9624>
 ] .
 
 <http://model.geneontology.org/RXN3O-5293>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -7001,7 +7075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7011,19 +7085,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER061C-MONOMER_RXN3O-1803_controller>
+          <http://model.geneontology.org/CHEBI_16526_RXN3O-1803>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_7896>
@@ -7031,36 +7105,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-10664>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN>
@@ -7072,7 +7146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7085,7 +7159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7093,19 +7167,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN3O-5304>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
@@ -7113,19 +7187,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7134,7 +7208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7150,7 +7224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7158,19 +7232,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9634_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
+          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9634>
 ] .
 
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-5962>
@@ -7178,7 +7252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7193,7 +7267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7206,7 +7280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7220,7 +7294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7231,7 +7305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7251,7 +7325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7262,7 +7336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7278,7 +7352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7291,7 +7365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7306,7 +7380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7321,22 +7395,20 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9515>
+          <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962>
@@ -7344,7 +7416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7354,35 +7426,33 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002411_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -7394,19 +7464,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-9780_controller>
+          <http://model.geneontology.org/ACP_RXN3O-9780>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962>
@@ -7414,7 +7484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7422,28 +7492,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
+          <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7451,7 +7521,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
+          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
@@ -7463,7 +7533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7473,39 +7543,41 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9624> ;
+          <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
+          <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY3O-5962>
@@ -7513,7 +7585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7528,7 +7600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7538,19 +7610,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+          <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YGL055W-MONOMER_1.14.19.1-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000001538>
@@ -7565,7 +7637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7575,19 +7647,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10662> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-10662>
+          <http://model.geneontology.org/CHEBI_15377_RXN-10662>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
@@ -7599,7 +7671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7616,7 +7688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7629,7 +7701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7650,7 +7722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7663,7 +7735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7675,7 +7747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7691,7 +7763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7702,7 +7774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7717,7 +7789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7739,7 +7811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7753,14 +7825,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9515>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -7778,7 +7850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7787,7 +7859,7 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004321> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102132> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] + NADP<sup>+</sup> &larr; a 3-oxoacyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -7805,7 +7877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7818,29 +7890,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '2 a ferrocytochrome <i>b<SUB>5</SUB></i> + stearoyl-CoA + oxygen + 2 H<SUP>+</SUP> &rarr; 2 a ferricytochrome <i>b<sub>5</sub></i> + oleoyl-CoA + 2 H<sub>2</sub>O' 'null' 'oleoyl-CoA + H<sub>2</sub>O &rarr; oleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9666>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_1.14.19.1-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002411_RXN-9633_SGD_PWY3O-5962>
@@ -7848,27 +7918,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10662_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10662> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61540_RXN-10662>
+          <http://model.geneontology.org/reaction_RXN-10662_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -7876,11 +7948,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_3-oxo-stearoyl-ACPs_RXN-9633_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_15378_RXN-9633_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7888,24 +7960,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN-9633>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9633>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_57783_RXN3O-5293_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
+          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_PWY3O-5962>
@@ -7913,7 +7985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7925,7 +7997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7941,7 +8013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7949,11 +8021,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7961,26 +8033,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'palmitoyl-CoA + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; palmitoleoyl-CoA + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' 'palmitoleoyl-CoA + H<sub>2</sub>O &rarr; palmitoleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-10662>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN-10664>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_null_PWY3O-5962>
@@ -7988,7 +8058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7996,40 +8066,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' '2 a ferrocytochrome <i>b<SUB>5</SUB></i> + stearoyl-CoA + oxygen + 2 H<SUP>+</SUP> &rarr; 2 a ferricytochrome <i>b<sub>5</sub></i> + oleoyl-CoA + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_1.14.19.1-RXN_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9780> ;
+          <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
+          <http://model.geneontology.org/1.14.19.1-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-9780>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY3O-5962>
@@ -8037,7 +8105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8048,7 +8116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8059,7 +8127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8070,7 +8138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8081,7 +8149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8092,7 +8160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8103,7 +8171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8114,7 +8182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8125,7 +8193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8138,7 +8206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8151,44 +8219,55 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
-] .
+<http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
+        a       <http://identifiers.org/sgd/S000005299> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_null_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9515>
+          <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962>
@@ -8196,7 +8275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8204,28 +8283,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9666> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9666>
+          <http://model.geneontology.org/CHEBI_15377_RXN-9666>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8233,24 +8312,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.14.19.1-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_1.14.19.1-RXN>
+          <http://model.geneontology.org/CHEBI_15379_1.14.19.1-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY3O-5962>
@@ -8258,46 +8348,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_null_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9633> ;
+          <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_RXN-9624>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5293> ;
+          <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YPL231W-MONOMER_RXN3O-1803_controller>
 ] .
 
 <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
@@ -8307,7 +8395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8323,7 +8411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8342,7 +8430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8353,7 +8441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8366,7 +8454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8383,7 +8471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8396,11 +8484,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -8414,7 +8505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8427,7 +8518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8445,7 +8536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8462,7 +8553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8475,7 +8566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8490,7 +8581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8503,44 +8594,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
+          <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9633> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/CHEBI_25629_RXN-9624>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004768>
@@ -8551,7 +8644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8559,28 +8652,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_PWY3O-5962/PWY3O-5962_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-5962/PWY3O-5962>
+          <http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN-10664_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8588,7 +8681,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10664> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57379_RXN-10664>
+          <http://model.geneontology.org/CHEBI_15378_RXN-10664>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
@@ -8596,19 +8689,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-5304>
+          <http://model.geneontology.org/CHEBI_57287_RXN3O-5304>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_RXN-10662>
@@ -8620,7 +8713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8630,19 +8723,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY3O-5962>
@@ -8650,7 +8743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8661,7 +8754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8669,15 +8762,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -8686,36 +8779,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_15378_RXN-9514_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9514>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002411_RXN3O-5293_SGD_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-5293>
+          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
 ] .
 
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-5962>
@@ -8723,7 +8816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8738,7 +8831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-6-1-PWY3O-6-1.ttl
+++ b/models/PWY3O-6-1-PWY3O-6-1.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -28,11 +28,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_15378_RXN3O-9798_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_13392_RXN3O-9798_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9798> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-9798>
+          <http://model.geneontology.org/CHEBI_13392_RXN3O-9798>
 ] .
 
 <http://model.geneontology.org/CHEBI_17803_1.1.3.37-RXN>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,19 +62,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_57540_RXN3O-9797_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-9797>
+          <http://model.geneontology.org/CHEBI_57540_RXN3O-9797>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -141,19 +141,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_16292_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_15379_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +164,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.3.37-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16292_1.1.3.37-RXN>
+          <http://model.geneontology.org/CHEBI_15379_1.1.3.37-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-9797_location_lociGO_0005829>
@@ -175,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -220,28 +223,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_13392_RXN3O-9798_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_17108_RXN3O-9798_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9798> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13392_RXN3O-9798>
+          <http://model.geneontology.org/CHEBI_17108_RXN3O-9798>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_57540_RXN3O-9797_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_17108_RXN3O-9797_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +252,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN3O-9797>
+          <http://model.geneontology.org/CHEBI_17108_RXN3O-9797>
 ] .
 
 <http://model.geneontology.org/CHEBI_17108_RXN3O-9798>
@@ -261,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,10 +276,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "D-arabinose dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000353_CPLX3O-20_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -316,20 +321,22 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_15379_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000066_reaction_1.1.3.37-RXN_location_lociGO_0005829_null_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.3.37-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_1.1.3.37-RXN>
+          <http://model.geneontology.org/reaction_1.1.3.37-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9797>
@@ -341,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,42 +394,42 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-arabinose + NAD(P)<sup>+</sup> &rarr; D-arabinono-1,4-lactone + NAD(P)H + H<SUP>+</SUP>' 'null' 'D-arabinono-1,4-lactone + oxygen &rarr; hydrogen peroxide + dehydro-D-arabinono-1,4-lactone' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000050_PWY3O-6-1/PWY3O-6-1_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_null_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.3.37-RXN> ;
+          <http://model.geneontology.org/RXN3O-9798> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6-1/PWY3O-6-1>
+          <http://model.geneontology.org/1.1.3.37-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-arabinose + NAD<sup>+</sup> &rarr; D-arabinono-1,4-lactone + NADH + H<SUP>+</SUP>' 'null' 'D-arabinono-1,4-lactone + oxygen &rarr; hydrogen peroxide + dehydro-D-arabinono-1,4-lactone' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002413_1.1.3.37-RXN_null_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002333_MONOMER3O-32_RXN3O-9797_controller_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.1.3.37-RXN>
+          <http://model.geneontology.org/MONOMER3O-32_RXN3O-9797_controller>
 ] .
 
 <http://model.geneontology.org/PWY3O-6-1>
@@ -434,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dehydro-D-arabinono-1,4-lactone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -442,12 +449,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://identifiers.org/sgd/S000004644>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000050_PWY3O-6-1/PWY3O-6-1_SGD_PWY3O-6-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -458,11 +468,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_17108_RXN3O-9798_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_13390_RXN3O-9798_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,34 +480,36 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9798> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17108_RXN3O-9798>
+          <http://model.geneontology.org/CHEBI_13390_RXN3O-9798>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_17108_RXN3O-9797_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000066_reaction_RXN3O-9797_location_lociGO_0005829_null_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17108_RXN3O-9797>
+          <http://model.geneontology.org/reaction_RXN3O-9797_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-32_RXN3O-9797_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000004644> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "D-arabinose dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,13 +526,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6-1SmallMolecule28494> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002333_YML086C-MONOMER_1.1.3.37-RXN_controller_SGD_PWY3O-6-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.3.37-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YML086C-MONOMER_1.1.3.37-RXN_controller>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -544,13 +573,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6-1BiochemicalReaction28482> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/SGD_S000000353_CPLX3O-20_component>
+        a       <http://identifiers.org/sgd/S000000353> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -563,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -573,22 +611,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000066_reaction_1.1.3.37-RXN_location_lociGO_0005829_null_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000050_PWY3O-6-1/PWY3O-6-1_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.3.37-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.1.3.37-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-6-1/PWY3O-6-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_16292_1.1.3.37-RXN_SGD_PWY3O-6-1>
@@ -596,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -645,86 +681,95 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-arabinose + NAD(P)<sup>+</sup> &rarr; D-arabinono-1,4-lactone + NAD(P)H + H<SUP>+</SUP>' 'null' 'D-arabinono-1,4-lactone + oxygen &rarr; hydrogen peroxide + dehydro-D-arabinono-1,4-lactone' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_null_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002333_CPLX3O-20_RXN3O-9798_controller_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9798> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.1.3.37-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002333_MONOMER3O-32_RXN3O-9797_controller_SGD_PWY3O-6-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9798> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-20_RXN3O-9798_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_57945_RXN3O-9797_SGD_PWY3O-6-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-32_RXN3O-9797_controller>
+          <http://model.geneontology.org/CHEBI_57945_RXN3O-9797>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-20_RXN3O-9798_controller_BFO_0000051_SGD_S000000353_CPLX3O-20_component_SGD_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002333_MONOMER3O-32_RXN3O-9797_controller_SGD_PWY3O-6-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_13390_RXN3O-9798_SGD_PWY3O-6-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9798> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_13390_RXN3O-9798>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000066_reaction_RXN3O-9797_location_lociGO_0005829_null_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000066_reaction_RXN3O-9798_location_lociGO_0005829_null_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9798> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-9798_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000050_PWY3O-6-1/PWY3O-6-1_SGD_PWY3O-6-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9797_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-6-1/PWY3O-6-1>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
@@ -732,19 +777,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002333_YML086C-MONOMER_1.1.3.37-RXN_controller_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_17803_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.3.37-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML086C-MONOMER_1.1.3.37-RXN_controller>
+          <http://model.geneontology.org/CHEBI_17803_1.1.3.37-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
@@ -769,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,11 +827,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000353>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0047816>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -804,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -839,28 +887,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002333_CPLX3O-20_RXN3O-9798_controller_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_16292_RXN3O-9798_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9798> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-20_RXN3O-9798_controller>
+          <http://model.geneontology.org/CHEBI_16292_RXN3O-9798>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_57945_RXN3O-9797_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_16292_RXN3O-9797_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,14 +916,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN3O-9797>
+          <http://model.geneontology.org/CHEBI_16292_RXN3O-9797>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -887,39 +932,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000066_reaction_RXN3O-9798_location_lociGO_0005829_null_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000050_PWY3O-6-1/PWY3O-6-1_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9798> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9798_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000050_PWY3O-6-1/PWY3O-6-1_SGD_PWY3O-6-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9797> ;
+          <http://model.geneontology.org/RXN3O-9798> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-6-1/PWY3O-6-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-20_RXN3O-9798_controller_BFO_0000051_SGD_S000000353_CPLX3O-20_component_SGD_PWY3O-6-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-20_RXN3O-9798_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000353_CPLX3O-20_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16240>
@@ -927,11 +970,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_17803_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_16240_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +982,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.3.37-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17803_1.1.3.37-RXN>
+          <http://model.geneontology.org/CHEBI_16240_1.1.3.37-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002413_1.1.3.37-RXN_null_PWY3O-6-1>
@@ -947,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -976,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1049,11 +1092,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_16292_RXN3O-9798_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_15378_RXN3O-9798_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1104,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9798> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16292_RXN3O-9798>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-9798>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_17803_1.1.3.37-RXN_SGD_PWY3O-6-1>
@@ -1069,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1077,11 +1120,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_16292_RXN3O-9797_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1132,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16292_RXN3O-9797>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-9797>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15379>
@@ -1100,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1128,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1143,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1156,27 +1199,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-arabinose + NAD<sup>+</sup> &rarr; D-arabinono-1,4-lactone + NADH + H<SUP>+</SUP>' 'null' 'D-arabinono-1,4-lactone + oxygen &rarr; hydrogen peroxide + dehydro-D-arabinono-1,4-lactone' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000050_PWY3O-6-1/PWY3O-6-1_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002413_1.1.3.37-RXN_null_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9798> ;
+          <http://model.geneontology.org/RXN3O-9797> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6-1/PWY3O-6-1>
+          <http://model.geneontology.org/1.1.3.37-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -1184,19 +1229,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_16240_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_16292_1.1.3.37-RXN_SGD_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.1.3.37-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16240_1.1.3.37-RXN>
+          <http://model.geneontology.org/CHEBI_16292_1.1.3.37-RXN>
 ] .
 
 <http://model.geneontology.org/1.1.3.37-RXN>
@@ -1216,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-6336-PWY3O-6336.ttl
+++ b/models/PWY3O-6336-PWY3O-6336.ttl
@@ -1,20 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9633> ;
+          <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_RXN-9624>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336>
@@ -22,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,20 +55,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9633>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,19 +138,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 <http://geneontology.org/lego/evidence>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,51 +190,49 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002411_RXN3O-5304_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-5293> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-5304>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9634_controller>
+          <http://model.geneontology.org/CHEBI_15377_RXN-9634>
 ] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_null_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5304> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_null_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -245,40 +243,49 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_57783_RXN-9514_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.2.1.58-RXN>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9514>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -289,46 +296,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9514>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
@@ -340,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -364,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -379,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -427,36 +436,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
+          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-9780>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002411_RXN-9633_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9633>
+          <http://model.geneontology.org/YER061C-MONOMER_RXN3O-1803_controller>
 ] .
 
 <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN3O-5293>
@@ -468,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,14 +525,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/4.2.1.58-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -541,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,36 +560,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-9624>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN>
@@ -592,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -609,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +627,7 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -636,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,36 +655,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
+          <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-9780_controller>
+          <http://model.geneontology.org/ACP_RXN3O-9780>
 ] .
 
 <http://identifiers.org/sgd/S000005747>
@@ -686,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -722,36 +731,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002411_RXN-9634_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_57783_RXN-9633_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9633> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9634>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9633> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9633>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
+          <http://model.geneontology.org/ACP_4.2.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY3O-6336>
@@ -759,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -768,60 +777,62 @@
 <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN-9514>
-] .
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9514> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336>
@@ -829,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +850,7 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acyl-carrier protein + acetyl-CoA &rarr; an acetyl-[acp] + coenzyme A" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -857,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,19 +895,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_57783_RXN3O-5293_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
+          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
 ] .
 
 <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
@@ -908,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,19 +1036,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57384>
@@ -1048,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1063,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1076,36 +1087,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9780> ;
+          <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5304_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-1803>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336>
@@ -1113,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1154,19 +1165,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_RXN-9515_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9515>
+          <http://model.geneontology.org/Crotonyl-ACPs_RXN-9515>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336>
@@ -1174,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,22 +1229,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-9780>
 ] .
 
 <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
@@ -1241,19 +1250,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9633>
@@ -1265,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1282,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1303,19 +1312,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
+          <http://model.geneontology.org/OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001538>
@@ -1326,19 +1335,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_58349_RXN-9633_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9633>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
@@ -1350,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,19 +1386,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001665>
@@ -1402,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1418,14 +1427,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008659>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1433,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1463,19 +1469,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002411_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
+          <http://model.geneontology.org/YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336>
@@ -1483,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1494,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1505,19 +1511,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN3O-5304>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/RXN-9633>
@@ -1537,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,19 +1553,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002411_RXN3O-5293_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-5293>
+          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1573,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1581,19 +1587,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
+          <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_null_PWY3O-6336>
@@ -1601,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1626,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1634,12 +1640,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000004820>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1650,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1658,19 +1667,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336>
@@ -1678,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1695,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1703,19 +1712,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5293> ;
+          <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YPL231W-MONOMER_RXN3O-1803_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1726,7 +1735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1753,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1785,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1798,44 +1807,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN-9624_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57394_RXN-9624>
+          <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
+          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
@@ -1851,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1861,38 +1874,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_3-oxo-stearoyl-ACPs_RXN-9633_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9633> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN-9633>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY3O-6336>
@@ -1900,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1909,38 +1937,24 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9634> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
-] .
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Octadec-2-enoyl-ACPs_RXN3O-5293_SGD_PWY3O-6336>
@@ -1948,7 +1962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1959,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1972,37 +1986,39 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_58349_RXN-9514_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9514> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-9514>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9514>
@@ -2014,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2027,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2045,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2058,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2069,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2080,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2092,7 +2108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2105,11 +2121,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Octadec-2-enoyl-ACPs_RXN3O-5293_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_15378_RXN3O-5293_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,26 +2133,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN3O-5293>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-5293>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002411_RXN-9634_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9634> ;
+          <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9634_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9634>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336>
@@ -2144,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2152,15 +2166,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2172,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2183,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2194,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2208,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2221,19 +2235,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
@@ -2243,7 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2256,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2269,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2279,39 +2293,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' 'stearoyl-CoA + H<sub>2</sub>O &rarr; stearate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9780> ;
+          <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9624>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN3O-1803>
+          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
 ] .
+
+<http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004820> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2322,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2335,7 +2358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2343,19 +2366,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
+          <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
 ] .
 
 <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
@@ -2365,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2379,7 +2402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2395,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2406,36 +2429,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002411_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-6336>
@@ -2443,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2458,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2471,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2479,19 +2502,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336>
@@ -2499,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2510,27 +2533,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
+          <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336>
@@ -2538,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2549,7 +2574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2560,7 +2585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2571,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2579,19 +2604,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-6336>
@@ -2599,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2613,7 +2638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2629,19 +2654,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
@@ -2653,7 +2678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2666,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2677,7 +2702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2686,19 +2711,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0004314>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_null_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9634>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2716,7 +2744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2729,52 +2757,57 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5304_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5304>
+          <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1803> ;
+          <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9634_controller>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2782,40 +2815,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
+          <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
+          <http://model.geneontology.org/4.2.1.58-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002411_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-6336>
@@ -2823,7 +2854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2831,36 +2862,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-5304>
+          <http://model.geneontology.org/CHEBI_57287_RXN3O-5304>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_null_PWY3O-6336>
@@ -2868,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2879,7 +2910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2890,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2905,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2920,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2937,7 +2968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2954,7 +2985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,7 +3011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2993,29 +3024,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002411_RXN-9633_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5293> ;
+          <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-9633>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3024,7 +3053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3047,7 +3076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3057,19 +3086,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9624>
+          <http://model.geneontology.org/CHEBI_15377_RXN-9624>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
@@ -3081,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3094,7 +3123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3102,15 +3131,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3124,7 +3153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3137,46 +3166,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+          <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-9780_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336>
@@ -3184,7 +3211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3202,7 +3229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3219,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3235,29 +3262,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9515>
+          <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY3O-6336>
@@ -3265,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3276,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3287,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3298,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3306,19 +3331,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN>
@@ -3330,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3347,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3360,7 +3385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3368,36 +3393,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_57783_RXN3O-5293_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5293_controller>
+          <http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9634_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9634>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-6336>
@@ -3405,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3416,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3431,13 +3456,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68524> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57384> ;
@@ -3448,7 +3484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3458,34 +3494,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_15378_RXN-9514_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_58349_RXN-9514_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9514>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/RXN-9514>
-        a       <http://purl.obolibrary.org/obo/GO_0004321> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3503,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3516,7 +3541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3527,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3542,7 +3567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3559,7 +3584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3569,36 +3594,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
@@ -3610,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3623,7 +3648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3637,36 +3662,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN3O-9780>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3674,7 +3710,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
+          <http://model.geneontology.org/ACP_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002411_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336>
@@ -3682,7 +3718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3693,7 +3729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3701,19 +3737,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9515>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
@@ -3728,7 +3764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3744,7 +3780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3755,27 +3791,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9624>
@@ -3787,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3797,19 +3835,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3825,7 +3863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3835,19 +3873,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002411_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_null_PWY3O-6336>
@@ -3855,7 +3893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3870,7 +3908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3880,19 +3918,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_15378_RXN-9633_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_58349_RXN-9633_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9633>
+          <http://model.geneontology.org/CHEBI_58349_RXN-9633>
 ] .
 
 <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
@@ -3904,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3914,11 +3952,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +3964,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336>
@@ -3934,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3945,9 +3983,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
+        a       <http://identifiers.org/sgd/S000005299> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3956,7 +4003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3967,7 +4014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3979,7 +4026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3999,7 +4046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4016,7 +4063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4029,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4047,7 +4094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4064,7 +4111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4077,29 +4124,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002411_RXN3O-5293_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1803> ;
+          <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-5293>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_57783_RXN3O-5293_SGD_PWY3O-6336>
@@ -4107,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4118,7 +4163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4129,7 +4174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4145,7 +4190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4155,36 +4200,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
@@ -4194,7 +4239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4207,7 +4252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4218,7 +4263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4229,7 +4274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4237,11 +4282,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4249,24 +4294,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5304_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
+          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5304>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY3O-6336>
@@ -4274,7 +4319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4285,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4296,7 +4341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4311,7 +4356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4338,7 +4383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4351,19 +4396,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_58349_RXN3O-5293_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN3O-5293>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4372,7 +4417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4388,7 +4433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4396,36 +4441,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN-9624_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_25629_RXN-9624>
+          <http://model.geneontology.org/CHEBI_57394_RXN-9624>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY3O-6336>
@@ -4433,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4446,7 +4491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4456,38 +4501,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
+          <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9515>
@@ -4499,7 +4544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4509,11 +4554,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4521,7 +4566,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN-9624>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9624>
 ] .
 
 <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
@@ -4533,7 +4578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4549,21 +4594,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY3O-6336>
@@ -4571,7 +4633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4586,7 +4648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4603,7 +4665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4617,7 +4679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4633,7 +4695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4641,11 +4703,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4653,7 +4715,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
@@ -4665,7 +4727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4682,7 +4744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4695,7 +4757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4710,7 +4772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4720,36 +4782,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002411_RXN3O-5304_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Octadec-2-enoyl-ACPs_RXN3O-5293_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5293> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-5304>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-5293> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN3O-5293>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_null_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-9634>
+          <http://model.geneontology.org/reaction_RXN-9634_location_lociGO_0005829>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -4760,7 +4824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4771,7 +4835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4789,7 +4853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4799,11 +4863,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_57783_RXN-9514_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,14 +4875,14 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9514>
+          <http://model.geneontology.org/ACP_RXN-9514>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN-9515>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -4836,7 +4900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4849,7 +4913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4860,7 +4924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4871,51 +4935,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9514>
+          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829>
@@ -4926,7 +4986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4937,44 +4997,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9780> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-9780>
+          <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER061C-MONOMER_RXN3O-1803_controller>
+          <http://model.geneontology.org/CHEBI_16526_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336>
@@ -4982,7 +5044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4996,7 +5058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5009,7 +5071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5019,19 +5081,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9624> ;
+          <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-5293>
@@ -5043,7 +5105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5056,7 +5118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5064,15 +5126,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -5080,39 +5142,37 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002411_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
@@ -5127,7 +5187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5140,7 +5200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5151,7 +5211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5166,7 +5226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5189,7 +5249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5199,36 +5259,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_57783_RXN-9633_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9633> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9633>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9633> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/4.2.1.58-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_4.2.1.58-RXN>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_RXN-9514_SGD_PWY3O-6336>
@@ -5236,7 +5296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5244,38 +5304,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
+          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002411_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
+          <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
@@ -5283,28 +5341,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5293> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5315,6 +5356,25 @@
           <http://model.geneontology.org/CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_null_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-5293> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -5323,7 +5383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5337,7 +5397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5348,39 +5408,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1803> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-1803>
-] .
 
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1803> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+] .
 
 <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -5390,44 +5450,48 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN-9515>
+          <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+          <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336>
@@ -5435,7 +5499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5446,7 +5510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5456,10 +5520,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetyl-coenzyme A carboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5486,7 +5552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5499,7 +5565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5507,36 +5573,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5304_controller>
+          <http://model.geneontology.org/ACP_RXN3O-5304>
 ] .
 
 <http://model.geneontology.org/CHEBI_57379_PALMITOYL-COA-HYDROLASE-RXN>
@@ -5548,7 +5614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5565,7 +5631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5578,7 +5644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5590,7 +5656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5606,7 +5672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5617,7 +5683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5632,26 +5698,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68737> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fatty acid synthase, beta subunit" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68432> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -5660,18 +5711,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "fatty acid synthase, beta subunit" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68432> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5682,11 +5748,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5694,7 +5760,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
+          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57394>
@@ -5702,19 +5768,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OH-ACYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/ACP_ACP-S-ACETYLTRANSFER-RXN>
@@ -5726,7 +5792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5739,7 +5805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5750,50 +5816,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a palmitoyl-[acp]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68737> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY3O-6336/PWY3O-6336> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN> , <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN> , <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller> , <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336BiochemicalReaction68593> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5814,7 +5836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5822,8 +5844,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004314> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY3O-6336/PWY3O-6336> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN> , <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN> , <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller> , <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336BiochemicalReaction68593> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
+        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a palmitoyl-[acp]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68737> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/RXN3O-5293>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -5841,7 +5907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5851,19 +5917,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9633> ;
+          <http://model.geneontology.org/RXN-9624> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/CHEBI_25629_RXN-9624>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336>
@@ -5871,7 +5937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5886,7 +5952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5896,19 +5962,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY3O-6336>
@@ -5916,18 +5982,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_null_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9515>
+] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5948,7 +6033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5961,7 +6046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5973,7 +6058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5989,7 +6074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5997,19 +6082,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
@@ -6021,7 +6106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6031,36 +6116,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5304> ;
+          <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5293_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9634_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9634> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
+          <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9634>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN>
@@ -6072,7 +6157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6085,7 +6170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6093,45 +6178,6 @@
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9634>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6142,7 +6188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6150,57 +6196,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_null_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-6336" ;
+                "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6208,36 +6220,109 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_15378_RXN-9514_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9780> ;
+          <http://model.geneontology.org/RXN-9514> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-9780>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9514>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+] .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_null_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9780> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57287_RXN3O-9780>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL231W-MONOMER_RXN3O-1803_controller>
+          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_RXN3O-5304>
@@ -6249,7 +6334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6269,7 +6354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6284,7 +6369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6293,39 +6378,40 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9624> ;
+          <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000005299>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
+          <http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
@@ -6340,7 +6426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6350,11 +6436,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_3-oxo-stearoyl-ACPs_RXN-9633_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_15378_RXN-9633_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6362,7 +6448,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9633> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN-9633>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9633>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4.2.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336>
@@ -6370,28 +6475,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4.2.1.58-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
-] .
 
 <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
@@ -6400,7 +6488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6413,7 +6501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6424,7 +6512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6438,7 +6526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6453,7 +6541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6466,46 +6554,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
+          <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
+          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_15378_RXN3O-5293_SGD_PWY3O-6336>
@@ -6513,7 +6599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6525,7 +6611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6538,19 +6624,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_15378_RXN3O-5293_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_58349_RXN3O-5293_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5293> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-5293>
+          <http://model.geneontology.org/CHEBI_58349_RXN3O-5293>
 ] .
 
 <http://model.geneontology.org/CHEBI_57394_RXN-9624>
@@ -6562,7 +6648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6571,20 +6657,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
+          <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9634_SGD_PWY3O-6336>
@@ -6592,7 +6680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6605,7 +6693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6618,45 +6706,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_RXN-9515_SGD_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Crotonyl-ACPs_RXN-9515>
-] .
 
 <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -6667,13 +6721,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68759> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9515> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
+] .
 
 <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN-9633>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -6684,7 +6772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6697,7 +6785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6708,47 +6796,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9780>
+          <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' 'stearoyl-CoA + H<sub>2</sub>O &rarr; stearate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_null_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5304> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9624>
+          <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6756,7 +6842,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1803> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
+          <http://model.geneontology.org/ACP_RXN3O-1803>
 ] .
 
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9634_controller>
@@ -6766,7 +6852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6781,7 +6867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6798,7 +6884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6811,7 +6897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6822,7 +6908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6833,7 +6919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6841,26 +6927,26 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
+          <http://model.geneontology.org/CHEBI_57783_RXN-9515>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 2,3,4-saturated fatty acyl-[acp] + NADP<sup>+</sup> &larr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -6878,7 +6964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6892,7 +6978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6912,7 +6998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6925,36 +7011,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+          <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
+          <http://model.geneontology.org/YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
+          <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002411_RXN3O-5304_SGD_PWY3O-6336>
@@ -6962,7 +7048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6977,7 +7063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6990,27 +7076,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_null_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
+          <http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ACP_RXN3O-1803>
@@ -7022,7 +7110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7037,7 +7125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7050,14 +7138,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9780>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -7075,7 +7163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7087,10 +7175,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "biotin carboxylase / acetyl-CoA carboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-64-PWY3O-64.ttl
+++ b/models/PWY3O-64-PWY3O-64.ttl
@@ -1,54 +1,52 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5.3.1.23-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5.3.1.23-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58533_5.3.1.23-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5.3.1.23-RXN> ;
+          <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
+          <http://model.geneontology.org/YHR208W-MONOMER_R15-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' 'null' '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_null_PWY3O-64> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3.1.3.77-RXN>
+          <http://model.geneontology.org/CHEBI_58828_R145-RXN>
 ] .
 
 <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
@@ -58,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -90,31 +88,29 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' 'null' '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R147-RXN>
+          <http://model.geneontology.org/CHEBI_58795_3.1.3.77-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,7 +118,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16723_R147-RXN>
+          <http://model.geneontology.org/CHEBI_15378_R147-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_null_PWY3O-64>
@@ -130,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -192,29 +188,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' 'null' '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5.3.1.23-RXN>
+          <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY3O-64>
@@ -222,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -230,19 +224,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_83813_R15-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_83813_R15-RXN>
+          <http://model.geneontology.org/CHEBI_57844_R15-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -252,22 +246,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R145-RXN> ;
+          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_R145-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
 ] .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,32 +288,53 @@
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' 'null' '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_null_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5.3.1.23-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/R145-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_3.1.3.77-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58828_3.1.3.77-RXN>
+          <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/PWY3O-64/PWY3O-64>
@@ -333,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -360,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,19 +423,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -430,23 +443,43 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R15-RXN> ;
+          <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
+          <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
+        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0046570>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -456,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -475,28 +508,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5.3.1.23-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5.3.1.23-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58533_5.3.1.23-RXN>
+          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +537,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR208W-MONOMER_R15-RXN_controller>
+          <http://model.geneontology.org/CPLX-9432_R15-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -515,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -523,29 +556,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_R145-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58828_R145-RXN>
+          <http://model.geneontology.org/CHEBI_58548_R145-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX-9432_R15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4-methylthio-2-oxobutyrate transaminase / aromatic amino acid aminotransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -572,11 +607,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,34 +619,34 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58795_3.1.3.77-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3.1.3.77-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_R147-RXN>
+          <http://model.geneontology.org/CHEBI_15379_R147-RXN>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004611> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acireductone dioxygenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,12 +654,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://identifiers.org/sgd/S000004007>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -638,19 +676,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_35910_R15-RXN>
@@ -662,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,20 +709,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57844_R15-RXN>
+          <http://model.geneontology.org/reaction_R15-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_16723_R147-RXN>
@@ -696,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -776,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -787,29 +827,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' 'null' '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5.3.1.23-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R145-RXN>
+          <http://model.geneontology.org/CHEBI_58548_5.3.1.23-RXN>
 ] .
 
 <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
@@ -819,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,49 +866,47 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
+          <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R147-RXN> ;
+          <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
+          <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000004007> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "5'-methylthioadenosine phosphorylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -883,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -897,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -905,19 +941,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
+          <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0052656>
@@ -925,19 +961,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15740_R147-RXN>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -951,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -971,36 +1007,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5.3.1.23-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY3O-64> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_16723_R15-RXN_SGD_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_R15-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16723_R15-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1011,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1036,19 +1072,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_R145-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58548_R145-RXN>
+          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_3.1.3.77-RXN_SGD_PWY3O-64>
@@ -1056,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1131,19 +1167,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3.1.3.77-RXN>
+          <http://model.geneontology.org/CHEBI_15377_3.1.3.77-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -1154,22 +1190,25 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_R147-RXN>
+          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17509>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000000764>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/R15-RXN>
@@ -1189,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1202,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1220,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1233,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1257,20 +1296,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+          <http://model.geneontology.org/reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_R147-RXN_SGD_PWY3O-64>
@@ -1278,29 +1319,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002411_R15-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R15-RXN> ;
+          <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_R15-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/R15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58533_5.3.1.23-RXN>
@@ -1312,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1339,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1367,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1382,20 +1421,22 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5.3.1.23-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58548_5.3.1.23-RXN>
+          <http://model.geneontology.org/reaction_5.3.1.23-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58828>
@@ -1403,11 +1444,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1456,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
+          <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_3.1.3.77-RXN>
@@ -1427,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1448,19 +1489,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_R145-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_83813>
@@ -1471,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1488,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1510,27 +1551,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
+          <http://model.geneontology.org/CHEBI_43474_3.1.3.77-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5.3.1.23-RXN_SGD_PWY3O-64>
@@ -1538,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1546,19 +1590,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_R147-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_R147-RXN>
+          <http://model.geneontology.org/CHEBI_58795_R147-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
@@ -1570,13 +1614,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64SmallMolecule50693> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1586,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1594,63 +1649,63 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_16723_R15-RXN_SGD_PWY3O-64> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R15-RXN> ;
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16723_R15-RXN>
+          <http://model.geneontology.org/CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_35910_R15-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R145-RXN> ;
+          <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
+          <http://model.geneontology.org/CHEBI_35910_R15-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX-9432_R15-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000764> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,3-dioxomethiopentane-1-phosphate enolase/phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1663,7 +1718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1678,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1691,18 +1746,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1717,7 +1775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1725,14 +1783,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5.3.1.23-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
+] .
+
 <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "methylthioribose-1 P isomerase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1742,38 +1819,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3.1.3.77-RXN>
+          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' 'null' '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/R147-RXN> ;
+          <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_R147-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/3.1.3.77-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY3O-64>
@@ -1781,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1799,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1829,38 +1906,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' 'null' '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/R147-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002411_R15-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/R15-RXN>
+          <http://model.geneontology.org/CHEBI_16723_R147-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -1877,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1888,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1933,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1941,38 +2018,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' 'null' '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_null_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5.3.1.23-RXN> ;
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_5.3.1.23-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/5.3.1.23-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_83813_R15-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
+          <http://model.geneontology.org/CHEBI_83813_R15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58795_R147-RXN>
@@ -1984,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1999,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2008,28 +2085,39 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_null_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R145-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_R145-RXN>
+          <http://model.geneontology.org/reaction_R145-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2054,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2067,36 +2155,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_3.1.3.77-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.1.3.77-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_3.1.3.77-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_R147-RXN_SGD_PWY3O-64> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.1.3.77-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58828_3.1.3.77-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_null_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R147-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58795_R147-RXN>
+          <http://model.geneontology.org/reaction_R147-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58548_R145-RXN>
@@ -2108,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2121,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2134,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2147,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2172,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2182,36 +2272,39 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_35910_R15-RXN_SGD_PWY3O-64> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
+] .
+
+<http://identifiers.org/sgd/S000004611>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_PWY3O-64/PWY3O-64_SGD_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/R15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35910_R15-RXN>
+          <http://model.geneontology.org/PWY3O-64/PWY3O-64>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_R145-RXN>
@@ -2223,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2239,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2264,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-6407-PWY3O-6407.ttl
+++ b/models/PWY3O-6407-PWY3O-6407.ttl
@@ -1,11 +1,11 @@
 <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,17 +78,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_b714a9cc-7972-4a56-a6ad-9a95df6a180d_RXN3O-9800_SGD_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -98,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,13 +96,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000000107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,11 +132,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001775>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -157,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,13 +223,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_57642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279_SGD_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,6 +253,9 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000000107>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -272,7 +278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,16 +312,13 @@
 <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://purl.obolibrary.org/obo/GO_0004806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -392,11 +395,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_8f0bd87a-13ca-42d1-bbea-25d961f23742_RXN3O-5279_SGD_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +407,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8f0bd87a-13ca-42d1-bbea-25d961f23742_RXN3O-5279>
+          <http://model.geneontology.org/dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
@@ -416,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,11 +469,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_b714a9cc-7972-4a56-a6ad-9a95df6a180d_RXN3O-9800_SGD_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +481,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b714a9cc-7972-4a56-a6ad-9a95df6a180d_RXN3O-9800>
+          <http://model.geneontology.org/32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002413_RXN3O-9800_null_PWY3O-6407>
@@ -486,20 +489,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -508,7 +500,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800_SGD_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +581,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/8f0bd87a-13ca-42d1-bbea-25d961f23742_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -575,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -644,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,7 +705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,38 +716,7 @@
           <http://model.geneontology.org/RXN-1623>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0016287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN-1623_SGD_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001386>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/b714a9cc-7972-4a56-a6ad-9a95df6a180d_RXN3O-9800>
+<http://model.geneontology.org/dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -742,13 +725,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0016287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN-1623_SGD_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001386>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/PWY3O-6407/PWY3O-6407>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -759,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -775,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,9 +835,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -836,13 +847,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20702> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PWY3O-6407>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -853,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidate biosynthesis I (the dihydroxyacetone pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -867,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,7 +898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,17 +940,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_8f0bd87a-13ca-42d1-bbea-25d961f23742_RXN3O-5279_SGD_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002210>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -949,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -973,6 +976,23 @@
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17984_RXN-1623>
         a       <http://purl.obolibrary.org/obo/CHEBI_17984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -983,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1051,7 @@
 ] .
 
 <http://model.geneontology.org/RXN3O-9800>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004806> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "1-acyl-dihydroxyacetone-phosphate + NADPH &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + NADP<sup>+</sup> + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1039,7 +1059,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b714a9cc-7972-4a56-a6ad-9a95df6a180d_RXN3O-9800> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
+                <http://model.geneontology.org/32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1049,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1118,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1158,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1183,29 +1203,12 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9800>
 ] .
 
-<http://model.geneontology.org/8f0bd87a-13ca-42d1-bbea-25d961f23742_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_PWY3O-6407/PWY3O-6407_SGD_PWY3O-6407>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-6499-PWY3O-6499.ttl
+++ b/models/PWY3O-6499-PWY3O-6499.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,6 +119,9 @@
           <http://model.geneontology.org/CHEBI_57642_1.1.1.8-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000001775>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -127,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,13 +266,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,6 +283,9 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000000107>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16975> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -289,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidate biosynthesis II (the glycerol-3-phosphate pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -366,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -538,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,20 +627,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000107> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -763,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,15 +818,12 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY3O-6499>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,26 +862,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6499Protein21431> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -889,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,13 +885,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6499Protein21431> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_PWY3O-6499/PWY3O-6499_SGD_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -977,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1013,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1084,7 +1087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1176,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-661-PWY3O-661.ttl
+++ b/models/PWY3O-661-PWY3O-661.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -28,19 +28,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,12 +66,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -83,6 +86,9 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000000056>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -91,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -99,11 +105,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +117,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -126,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -157,24 +163,52 @@
 <http://purl.obolibrary.org/obo/CHEBI_16982>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-661> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -185,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,19 +250,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
@@ -240,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,22 +283,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-661/PWY3O-661_SGD_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/PWY3O-661/PWY3O-661>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
@@ -282,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,13 +328,16 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,18 +345,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-661>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-661" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -343,19 +386,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-661/PWY3O-661_SGD_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-661/PWY3O-661>
+          <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -371,10 +414,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,3-butanediol dehydrogenase / diacetyl reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -429,11 +474,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +486,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/PWY3O-661/PWY3O-661>
@@ -453,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-6635-PWY3O-6635.ttl
+++ b/models/PWY3O-6635-PWY3O-6635.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,11 +208,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_0b708f55-3266-449f-82fa-541a129b18f8_RXN3O-5279_SGD_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279_SGD_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0b708f55-3266-449f-82fa-541a129b18f8_RXN3O-5279>
+          <http://model.geneontology.org/3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_PWY3O-6635>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,23 +285,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9800>
 ] .
 
-<http://model.geneontology.org/0b708f55-3266-449f-82fa-541a129b18f8_RXN3O-5279>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57945_1.1.1.8-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -311,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,6 +496,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800_SGD_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/RXN3O-5279>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016287> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -524,7 +518,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/0b708f55-3266-449f-82fa-541a129b18f8_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -532,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -545,7 +539,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279_SGD_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,13 +639,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,18 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_0b708f55-3266-449f-82fa-541a129b18f8_RXN3O-5279_SGD_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -742,7 +736,7 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/RXN3O-9800>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004806> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "1-acyl-dihydroxyacetone-phosphate + NADPH &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + NADP<sup>+</sup> + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -750,7 +744,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> , <http://model.geneontology.org/b06565dc-f965-475a-88a8-fddef29c3b01_RXN3O-9800> ;
+                <http://model.geneontology.org/117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -760,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,13 +762,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000001775>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -875,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -909,9 +906,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -920,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,7 +949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1030,20 +1024,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000000107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,16 +1062,13 @@
           <http://model.geneontology.org/CHEBI_16975_RXN3O-9800>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_PWY3O-6635/PWY3O-6635_SGD_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1095,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1119,28 +1110,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/b06565dc-f965-475a-88a8-fddef29c3b01_RXN3O-9800>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16975_RXN3O-9800>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16975> ;
@@ -1151,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1176,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1233,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,13 +1216,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1268,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1281,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,7 +1372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1431,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1457,13 +1431,16 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000000107>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,7 +1473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1508,7 +1485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,7 +1502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,23 +1513,12 @@
           <http://model.geneontology.org/PWY3O-6635/PWY3O-6635>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_b06565dc-f965-475a-88a8-fddef29c3b01_RXN3O-9800_SGD_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_PWY3O-6635/PWY3O-6635_SGD_PWY3O-6635>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1560,11 +1526,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_b06565dc-f965-475a-88a8-fddef29c3b01_RXN3O-9800_SGD_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800_SGD_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1538,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b06565dc-f965-475a-88a8-fddef29c3b01_RXN3O-9800>
+          <http://model.geneontology.org/117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1583,7 +1549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1610,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1621,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1681,7 +1647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,13 +1662,13 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000107> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1715,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1739,12 +1705,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_PWY3O-6635/PWY3O-6635_SGD_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1762,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1775,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1800,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1824,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1836,7 +1819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1856,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,7 +1853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1886,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1921,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1934,7 +1917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1948,7 +1931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1968,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +1964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1993,7 +1976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +1993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2037,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2048,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2056,3 +2039,20 @@
 
 <http://identifiers.org/sgd/S000005420>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PWY3O-69-PWY3O-69.ttl
+++ b/models/PWY3O-69-PWY3O-69.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,7 +827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -881,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -953,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1210,7 +1210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,7 +1243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1543,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of heme and siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1577,7 +1577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1662,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1692,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1706,7 +1706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,7 +1791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1851,7 +1851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1896,7 +1896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1916,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2043,7 +2043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2094,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2127,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2141,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2189,7 +2189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2200,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2214,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2240,7 +2240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2345,7 +2345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2361,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2373,7 +2373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2398,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2409,7 +2409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2421,7 +2421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,7 +2441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2465,7 +2465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2480,7 +2480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2496,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2511,7 +2511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2530,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2542,7 +2542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2560,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2596,7 +2596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2616,7 +2616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2643,7 +2643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2660,7 +2660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2687,7 +2687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2699,7 +2699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2716,7 +2716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2732,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2744,7 +2744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,7 +2788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2811,7 +2811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2825,7 +2825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,7 +2841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2863,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2877,7 +2877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2896,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2907,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2920,7 +2920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2933,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2948,7 +2948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2967,7 +2967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2978,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2990,7 +2990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,7 +3022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3042,7 +3042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3059,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3076,7 +3076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3089,7 +3089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3103,7 +3103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3119,7 +3119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3130,7 +3130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3141,7 +3141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3158,7 +3158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3181,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3198,7 +3198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3218,7 +3218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3234,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3246,7 +3246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3263,7 +3263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3283,7 +3283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3300,7 +3300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3316,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3331,7 +3331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3347,7 +3347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3362,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3382,7 +3382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3395,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3410,7 +3410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3426,7 +3426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3441,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3455,7 +3455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3475,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3488,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3505,7 +3505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3521,7 +3521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3533,7 +3533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3553,7 +3553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3569,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3583,7 +3583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3595,7 +3595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3615,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3628,7 +3628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3653,7 +3653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3695,7 +3695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3708,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3720,7 +3720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3738,7 +3738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3755,7 +3755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3769,7 +3769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3795,7 +3795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3809,7 +3809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3825,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3837,7 +3837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,7 +3856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3879,7 +3879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3895,7 +3895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3920,7 +3920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3934,7 +3934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3954,7 +3954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3987,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4012,7 +4012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4026,7 +4026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4046,7 +4046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4062,7 +4062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4074,7 +4074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4093,7 +4093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4104,7 +4104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4132,7 +4132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4145,7 +4145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4156,7 +4156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4167,7 +4167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-697-PWY3O-697.ttl
+++ b/models/PWY3O-697-PWY3O-697.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
+          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003093>
@@ -23,19 +23,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.20-RXN>
+          <http://model.geneontology.org/d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -59,22 +59,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_PWY3O-697>
@@ -82,18 +80,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -102,214 +117,13 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/957d6a50-8796-4602-b7bc-9ef217a8428d_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_15378_1.5.1.20-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN>
-] .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.15-RXN_null_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/9806d5eb-8138-46ce-8d04-99414182cb3b_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_77c24fc3-4427-4a6a-a657-4aca17b3237b_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/77c24fc3-4427-4a6a-a657-4aca17b3237b_GLYOHMETRANS-RXN>
-] .
-
-<http://model.geneontology.org/46fad84f-1692-4c15-a23f-7318229c521e_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,41 +134,13 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/e7f3347a-7628-42f1-93e2-92496dfaf19c_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,13 +151,38 @@
           <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.15-RXN_null_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_0507733d-5f2f-4821-a4b1-7907ec9fae5e_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,41 +190,165 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0507733d-5f2f-4821-a4b1-7907ec9fae5e_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+<http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/5c16409c-a398-4ef5-b008-243ee8d01f8f_GCVMULTI-RXN>
+<http://identifiers.org/sgd/S000004801>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1.5.1.20-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -422,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,21 +365,125 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
+        a       <http://identifiers.org/sgd/S000001788> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57945_1.5.1.20-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
@@ -459,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -495,20 +534,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_e2fcdb24-06fe-47e5-abd5-2ab5a1d68b56_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e2fcdb24-06fe-47e5-abd5-2ab5a1d68b56_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
+
+<http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004487>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -520,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,27 +578,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_null_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,23 +641,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_36df0fd2-0273-442d-a664-1a55c9d31ccc_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -611,29 +657,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
@@ -641,30 +685,59 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_246422>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -674,45 +747,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ac7d3599-4204-42f4-b5b8-f7a5c2fd5a86_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
@@ -723,9 +790,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/ac7d3599-4204-42f4-b5b8-f7a5c2fd5a86_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/0507733d-5f2f-4821-a4b1-7907ec9fae5e_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -733,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -781,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,43 +857,67 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' 'null' 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57945_1.5.1.20-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
+          <http://model.geneontology.org/8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -838,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -855,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -865,64 +956,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
+          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/36df0fd2-0273-442d-a664-1a55c9d31ccc_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY3O-697>
@@ -930,7 +1002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -938,26 +1010,26 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_6ca9f202-047a-4cbb-8621-9fa96b5085f4_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6ca9f202-047a-4cbb-8621-9fa96b5085f4_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004329> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -965,9 +1037,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/9806d5eb-8138-46ce-8d04-99414182cb3b_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/36df0fd2-0273-442d-a664-1a55c9d31ccc_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -975,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,19 +1057,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
 <http://model.geneontology.org/THYMIDYLATESYN-RXN>
@@ -1009,9 +1081,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6ca9f202-047a-4cbb-8621-9fa96b5085f4_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/957d6a50-8796-4602-b7bc-9ef217a8428d_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1019,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1049,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1068,21 +1140,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' 'null' 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_PWY3O-697>
@@ -1090,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1102,66 +1174,34 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/6ca9f202-047a-4cbb-8621-9fa96b5085f4_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_fc397770-8d36-4e8a-9d86-20a9fce9b099_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fc397770-8d36-4e8a-9d86-20a9fce9b099_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
-
-<http://model.geneontology.org/0507733d-5f2f-4821-a4b1-7907ec9fae5e_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1172,63 +1212,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_e7f3347a-7628-42f1-93e2-92496dfaf19c_1.5.1.15-RXN_SGD_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1236,19 +1259,72 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
+] .
+
+<http://model.geneontology.org/6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY3O-697>
@@ -1256,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1284,192 +1360,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY3O-697/PWY3O-697> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/fc397770-8d36-4e8a-9d86-20a9fce9b099_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/335e8623-ee2b-4849-b577-0de76a12e6ea_METHENYLTHFCYCLOHYDRO-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697BiochemicalReaction66510> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
-] .
-
-<http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.15-RXN_null_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.15-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/77c24fc3-4427-4a6a-a657-4aca17b3237b_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_63528>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,48 +1375,24 @@
           <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "thymidylate synthase" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697Complex66173> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_57aedf85-4440-4f22-959d-f25192050ec4_1.5.1.20-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,19 +1400,52 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/57aedf85-4440-4f22-959d-f25192050ec4_1.5.1.20-RXN>
+          <http://model.geneontology.org/f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_388538db-2214-449d-aee3-2f6cd95bb7d5_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY3O-697/PWY3O-697> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002411>
+                <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697BiochemicalReaction66510> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1551,7 +1455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,12 +1467,37 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_b2584f39-6f32-4b9c-b100-0b3cd97532b6_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,7 +1505,205 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b2584f39-6f32-4b9c-b100-0b3cd97532b6_GCVMULTI-RXN>
+          <http://model.geneontology.org/74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+] .
+
+<http://model.geneontology.org/5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_63528>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
+] .
+
+<http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "thymidylate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697Complex66173> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://identifiers.org/sgd/S000002426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
+] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000004048>
@@ -1590,7 +1717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1598,19 +1725,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
@@ -1620,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1628,12 +1755,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_57aedf85-4440-4f22-959d-f25192050ec4_1.5.1.20-RXN_SGD_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1641,19 +1768,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697>
@@ -1661,45 +1788,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.15-RXN_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
-
-<http://model.geneontology.org/e2fcdb24-06fe-47e5-abd5-2ab5a1d68b56_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1713,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate interconversions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1721,34 +1833,21 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_957d6a50-8796-4602-b7bc-9ef217a8428d_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY3O-697>
@@ -1756,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1769,7 +1868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1782,27 +1881,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_335e8623-ee2b-4849-b577-0de76a12e6ea_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/335e8623-ee2b-4849-b577-0de76a12e6ea_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/PWY3O-697/PWY3O-697>
@@ -1814,7 +1915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1825,48 +1926,57 @@
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_28938>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0004477>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_a0ad5adb-5fbe-48ce-8563-01414dd0ba6e_1.5.1.20-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004477>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_28938>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000004801> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1879,9 +1989,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/77c24fc3-4427-4a6a-a657-4aca17b3237b_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/46fad84f-1692-4c15-a23f-7318229c521e_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1891,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1899,12 +2009,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1919,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1932,29 +2059,126 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
+] .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1963,7 +2187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,107 +2198,6 @@
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004489>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
-] .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_fc397770-8d36-4e8a-9d86-20a9fce9b099_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_3938a8b7-2314-4cd7-b42b-802a01b99382_1.5.1.15-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3938a8b7-2314-4cd7-b42b-802a01b99382_1.5.1.15-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_null_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.5.1.15-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ac7d3599-4204-42f4-b5b8-f7a5c2fd5a86_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ac7d3599-4204-42f4-b5b8-f7a5c2fd5a86_FORMATETHFLIG-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_77c24fc3-4427-4a6a-a657-4aca17b3237b_GLYOHMETRANS-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2084,7 +2207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,32 +2215,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000005600>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
+          <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
@@ -2129,7 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2142,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2150,19 +2278,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000467>
@@ -2173,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2184,7 +2312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2207,29 +2335,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_46fad84f-1692-4c15-a23f-7318229c521e_GLYOHMETRANS-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2248,9 +2374,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3938a8b7-2314-4cd7-b42b-802a01b99382_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/e7f3347a-7628-42f1-93e2-92496dfaf19c_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2258,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2266,38 +2392,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_388538db-2214-449d-aee3-2f6cd95bb7d5_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/388538db-2214-449d-aee3-2f6cd95bb7d5_DIHYDROFOLATEREDUCT-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_957d6a50-8796-4602-b7bc-9ef217a8428d_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/957d6a50-8796-4602-b7bc-9ef217a8428d_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_null_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
@@ -2310,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,19 +2459,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_46fad84f-1692-4c15-a23f-7318229c521e_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/46fad84f-1692-4c15-a23f-7318229c521e_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
@@ -2340,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2351,7 +2490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2359,19 +2498,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -2381,7 +2520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2394,7 +2533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2409,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2422,76 +2561,53 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
+
+<http://identifiers.org/sgd/S000001788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_e2fcdb24-06fe-47e5-abd5-2ab5a1d68b56_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/a0ad5adb-5fbe-48ce-8563-01414dd0ba6e_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -2502,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2512,19 +2628,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -2535,20 +2651,37 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
+
+<http://model.geneontology.org/29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2562,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2575,50 +2708,84 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/b2584f39-6f32-4b9c-b100-0b3cd97532b6_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
+] .
+
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2633,7 +2800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2641,68 +2808,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/57aedf85-4440-4f22-959d-f25192050ec4_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN>
+] .
+
+<http://model.geneontology.org/26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
-] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ac7d3599-4204-42f4-b5b8-f7a5c2fd5a86_FORMATETHFLIG-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY3O-697>
@@ -2710,7 +2864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2721,11 +2875,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_33695>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -2735,18 +2903,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_0507733d-5f2f-4821-a4b1-7907ec9fae5e_FORMATETHFLIG-RXN_SGD_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2754,36 +2922,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
+          <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY3O-697>
@@ -2791,7 +2959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2804,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2812,21 +2980,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY3O-697>
@@ -2834,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2845,7 +3024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2856,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2864,36 +3043,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9806d5eb-8138-46ce-8d04-99414182cb3b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9806d5eb-8138-46ce-8d04-99414182cb3b_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN>
+] .
+
+<http://model.geneontology.org/c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY3O-697>
@@ -2901,7 +3097,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2909,75 +3116,75 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
 
-<http://model.geneontology.org/388538db-2214-449d-aee3-2f6cd95bb7d5_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_6ca9f202-047a-4cbb-8621-9fa96b5085f4_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
@@ -2989,7 +3196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3005,7 +3212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3020,7 +3227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3037,11 +3244,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66412> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3057,9 +3281,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/b2584f39-6f32-4b9c-b100-0b3cd97532b6_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/5c16409c-a398-4ef5-b008-243ee8d01f8f_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3067,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3076,20 +3300,22 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
@@ -3097,28 +3323,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/3938a8b7-2314-4cd7-b42b-802a01b99382_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -3127,7 +3336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3135,23 +3344,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_335e8623-ee2b-4849-b577-0de76a12e6ea_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3162,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3170,19 +3368,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -3190,19 +3388,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
@@ -3214,9 +3412,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/388538db-2214-449d-aee3-2f6cd95bb7d5_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/e2fcdb24-06fe-47e5-abd5-2ab5a1d68b56_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3224,7 +3422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3232,12 +3430,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3245,48 +3454,42 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_a0ad5adb-5fbe-48ce-8563-01414dd0ba6e_1.5.1.20-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
+          <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a0ad5adb-5fbe-48ce-8563-01414dd0ba6e_1.5.1.20-RXN>
+          <http://model.geneontology.org/4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
-] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3295,30 +3498,73 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_3938a8b7-2314-4cd7-b42b-802a01b99382_1.5.1.15-RXN_SGD_PWY3O-697>
+<http://model.geneontology.org/ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3333,15 +3579,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a0ad5adb-5fbe-48ce-8563-01414dd0ba6e_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/57aedf85-4440-4f22-959d-f25192050ec4_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3350,22 +3596,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
@@ -3375,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3390,7 +3634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3402,10 +3646,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3415,19 +3661,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
@@ -3435,7 +3681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3446,37 +3692,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_null_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_5c16409c-a398-4ef5-b008-243ee8d01f8f_GCVMULTI-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3485,7 +3720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3493,6 +3728,23 @@
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004799>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3506,7 +3758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3516,41 +3768,39 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_e7f3347a-7628-42f1-93e2-92496dfaf19c_1.5.1.15-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.15-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e7f3347a-7628-42f1-93e2-92496dfaf19c_1.5.1.15-RXN>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
@@ -3558,7 +3808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3569,28 +3819,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/335e8623-ee2b-4849-b577-0de76a12e6ea_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -3601,7 +3834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3611,19 +3844,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697>
@@ -3631,29 +3864,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9806d5eb-8138-46ce-8d04-99414182cb3b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3668,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3681,19 +3920,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_PWY3O-697>
@@ -3701,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3712,27 +3951,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_15378_1.5.1.20-RXN_SGD_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_null_PWY3O-697>
@@ -3740,7 +3998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3751,19 +4009,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_36df0fd2-0273-442d-a664-1a55c9d31ccc_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36df0fd2-0273-442d-a664-1a55c9d31ccc_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -3773,10 +4031,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "NAD-dependent 5,10-methylenetetrahydrafolate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3789,7 +4049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3804,7 +4064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3817,7 +4077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3825,19 +4085,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
@@ -3849,7 +4109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3857,50 +4117,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_b2584f39-6f32-4b9c-b100-0b3cd97532b6_GCVMULTI-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_5c16409c-a398-4ef5-b008-243ee8d01f8f_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5c16409c-a398-4ef5-b008-243ee8d01f8f_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/fc397770-8d36-4e8a-9d86-20a9fce9b099_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3911,10 +4143,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66480> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PWY3O-7-PWY3O-7.ttl
+++ b/models/PWY3O-7-PWY3O-7.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -690,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -817,7 +817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1083,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1194,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1229,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,7 +1283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1428,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1509,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1522,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,41 +1584,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39337> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-7> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1629,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,12 +1609,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-7> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1654,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,7 +1671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1691,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1736,7 +1736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,7 +1773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1801,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1842,7 +1842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1853,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1940,7 +1940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1973,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1990,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2005,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2022,7 +2022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2035,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2047,7 +2047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2063,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2078,7 +2078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2098,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2145,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2162,7 +2162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,7 +2179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2229,7 +2229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2245,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2265,25 +2265,25 @@
 <http://identifiers.org/sgd/S000000854>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_null_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_null_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2292,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2303,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2334,7 +2334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2362,7 +2362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2399,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2464,7 +2464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,7 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2514,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2535,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,7 +2551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2607,7 +2607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2635,7 +2635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2648,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2660,7 +2660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2688,7 +2688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2718,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2734,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2745,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2756,7 +2756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2785,7 +2785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2815,7 +2815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,7 +2829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2849,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2863,7 +2863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2882,7 +2882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2893,7 +2893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2908,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2935,7 +2935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2946,7 +2946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-70-PWY3O-70.ttl
+++ b/models/PWY3O-70-PWY3O-70.ttl
@@ -13,7 +13,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,18 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/111f82e5-f624-47e3-bcac-fbbf7b25b724_CHITIN-DEACETYLASE-RXN>
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_PWY3O-70>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -47,24 +58,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69333> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_PWY3O-70>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17029_CHITIN-DEACETYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17029> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,24 +195,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69310> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_111f82e5-f624-47e3-bcac-fbbf7b25b724_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -226,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -240,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,13 +343,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15377_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_17029_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/111f82e5-f624-47e3-bcac-fbbf7b25b724_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> ;
+                <http://model.geneontology.org/0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> , <http://model.geneontology.org/YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,12 +377,23 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000066_reaction_CHITIN-DEACETYLASE-RXN_location_lociGO_0005829_null_PWY3O-70>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -427,11 +427,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_111f82e5-f624-47e3-bcac-fbbf7b25b724_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CHITIN-DEACETYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/111f82e5-f624-47e3-bcac-fbbf7b25b724_CHITIN-DEACETYLASE-RXN>
+          <http://model.geneontology.org/0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/PWY3O-70>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitosan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-743-PWY3O-743.ttl
+++ b/models/PWY3O-743-PWY3O-743.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,13 +408,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002397> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "guanine deaminase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,9 +819,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -834,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -922,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of guanine, xanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -938,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,13 +982,24 @@
           <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,16 +1010,8 @@
           <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://identifiers.org/sgd/S000002397>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58115_GUANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1046,18 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1060,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1083,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-8-PWY3O-8.ttl
+++ b/models/PWY3O-8-PWY3O-8.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,30 +284,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_53455_RXN-8773>
-        a       <http://purl.obolibrary.org/obo/CHEBI_53455> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "D-xylopyranose" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61240> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000050_PWY3O-8/PWY3O-8_SGD_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,12 +301,29 @@
           <http://model.geneontology.org/PWY3O-8/PWY3O-8>
 ] .
 
+<http://model.geneontology.org/CHEBI_53455_RXN-8773>
+        a       <http://purl.obolibrary.org/obo/CHEBI_53455> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "D-xylopyranose" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002411_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY3O-8>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylose metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,6 +510,17 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-8773>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_53455_RXN-8773_SGD_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -518,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,17 +539,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_D-XYLULOSE-REDUCTASE-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_53455_RXN-8773_SGD_PWY3O-8>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -808,7 +808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-8514-PWY3O-8514.ttl
+++ b/models/PWY3O-8514-PWY3O-8514.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,15 +133,12 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004321>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000066_reaction_4.2.1.61-RXN_location_lociGO_0005829_null_PWY3O-8514>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,14 +195,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9539>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004321> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a myristoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxohexadecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -223,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +511,7 @@
 ] .
 
 <http://model.geneontology.org/RXN-9542>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008659> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a palmitoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-hexadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -532,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -545,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -718,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -731,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -884,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -918,7 +915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -961,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1040,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1126,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1143,7 +1140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1330,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1350,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,14 +1366,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/4.2.1.61-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a (3<i>R</i>)-3-hydroxyhexadecanoyl-[acp] &rarr; a (2<i>E</i>)-hexadec-2-enoyl-[acp] + H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1394,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1441,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1481,7 +1478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1549,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1566,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1583,13 +1580,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8514Protein18893> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -1599,14 +1599,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008659>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1614,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1681,7 +1678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1726,7 +1723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1746,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1759,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1785,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1802,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1832,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1847,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1863,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1874,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1888,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1921,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1931,7 +1928,7 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/RXN3O-9780>
-        a       <http://purl.obolibrary.org/obo/GO_0008659> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1949,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1980,7 +1977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2017,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,7 +2031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2054,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2068,7 +2065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2084,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2115,7 +2112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2127,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2178,7 +2175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-862-PWY3O-862.ttl
+++ b/models/PWY3O-862-PWY3O-862.ttl
@@ -1,21 +1,10 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,12 +15,23 @@
           <http://model.geneontology.org/CHEBI_12876_RXN3O-1118>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_PWY3O-862/PWY3O-862_SGD_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,12 +483,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000005651>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -739,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,13 +830,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-164_RXN3O-75_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005651> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "monooxygenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,7 +892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -937,7 +940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -995,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,7 +1075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1126,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1137,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,13 +1163,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_RXN3O-73_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,17 +1190,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57916_RXN3O-73>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1207,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1248,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1260,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1276,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1363,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1392,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1408,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1419,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1442,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1500,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1515,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1557,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1570,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1584,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1595,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1643,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1691,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1711,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,7 +1733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,7 +1767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1821,7 +1824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,7 +1841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,7 +1857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1869,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1897,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1920,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1940,7 +1943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,28 +1953,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/4-COUMARATE--COA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,12 +1968,29 @@
           <http://model.geneontology.org/CHEBI_57287_RXN3O-1120>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/4-COUMARATE--COA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_FPPSYN-RXN_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2005,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2018,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2032,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2046,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2058,7 +2061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2075,7 +2078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2095,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2108,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2140,7 +2143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2174,7 +2177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2191,7 +2194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2221,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2233,7 +2236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2264,7 +2267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2281,7 +2284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2298,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2328,7 +2331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2356,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2368,7 +2371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2384,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2399,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2412,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2424,7 +2427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,7 +2444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2458,7 +2461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2475,7 +2478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2492,7 +2495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2508,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2521,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2535,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2551,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2562,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2577,7 +2580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,7 +2593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2602,7 +2605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2618,7 +2621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2641,7 +2644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2654,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2665,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2690,7 +2693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2706,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2717,7 +2720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2732,7 +2735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2751,7 +2754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2762,7 +2765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2777,7 +2780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,7 +2797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2813,7 +2816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2834,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2847,7 +2850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2868,7 +2871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2885,7 +2888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2905,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2918,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2941,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2957,7 +2960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2974,7 +2977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2990,7 +2993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3004,7 +3007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3016,7 +3019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3033,7 +3036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3053,7 +3056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3080,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3093,7 +3096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3107,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3139,7 +3142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3153,7 +3156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3173,7 +3176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3186,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3199,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3213,7 +3216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3224,13 +3227,24 @@
           <http://model.geneontology.org/HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3240,17 +3254,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_2.1.1.114-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-54>
         a       <http://purl.obolibrary.org/obo/GO_0043333> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3271,7 +3274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3290,7 +3293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,7 +3313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3335,7 +3338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3349,7 +3352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3365,7 +3368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3392,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3406,7 +3409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3422,7 +3425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3434,7 +3437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3450,7 +3453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3458,6 +3461,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15499>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_null_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3467,7 +3481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3478,23 +3492,12 @@
           <http://model.geneontology.org/reaction_RXN3O-54_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_null_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3506,7 +3509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3522,7 +3525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3533,7 +3536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3550,7 +3553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3562,7 +3565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3592,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3608,7 +3611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3623,7 +3626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3640,7 +3643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3656,7 +3659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3668,7 +3671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3687,7 +3690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3703,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3721,7 +3724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3738,7 +3741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3752,7 +3755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3771,7 +3774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3787,7 +3790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3802,7 +3805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3818,7 +3821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3838,7 +3841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3854,7 +3857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3874,7 +3877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3890,7 +3893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3901,7 +3904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3911,7 +3914,7 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/2.1.1.114-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008689> ;
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3929,7 +3932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3943,7 +3946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3963,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3980,7 +3983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3993,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4005,7 +4008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,7 +4025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4040,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4059,7 +4062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4087,7 +4090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4106,7 +4109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4117,29 +4120,23 @@
           <http://model.geneontology.org/reaction_RXN3O-1121_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52090> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4162,7 +4159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4170,23 +4167,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52090> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4204,7 +4207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4218,7 +4221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4234,7 +4237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4248,7 +4251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4264,7 +4267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4279,7 +4282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4293,7 +4296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4312,7 +4315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4328,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4343,7 +4346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4363,7 +4366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4380,7 +4383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4397,7 +4400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4417,7 +4420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4431,7 +4434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4448,7 +4451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4471,7 +4474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4485,7 +4488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4502,7 +4505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4513,17 +4516,6 @@
           <http://model.geneontology.org/PWY3O-862/PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002411_RXN3O-1118_SGD_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57288_RXN3O-1120>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4533,7 +4525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4541,12 +4533,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002411_RXN3O-1118_SGD_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4563,7 +4566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4579,7 +4582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4594,7 +4597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4607,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4618,7 +4621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4633,7 +4636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4653,7 +4656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4669,7 +4672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4689,7 +4692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4706,7 +4709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4722,7 +4725,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4740,7 +4754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4748,29 +4762,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1120> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_RXN3O-1120>
-] .
-
 <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4781,7 +4778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4793,7 +4790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4804,23 +4801,29 @@
           <http://model.geneontology.org/CHEBI_59789_RXN3O-54>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1120> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57288_RXN3O-1120>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4833,7 +4836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4841,12 +4844,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_null_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4871,7 +4885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4879,30 +4893,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_RXN3O-1118_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4910,7 +4913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4932,7 +4935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4944,7 +4947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4963,7 +4966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4986,7 +4989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5001,7 +5004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5016,7 +5019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5030,7 +5033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5047,7 +5050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5076,7 +5079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ubiquinone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5092,7 +5095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5108,7 +5111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5120,7 +5123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5136,7 +5139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5148,7 +5151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5164,7 +5167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5178,7 +5181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5194,7 +5197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5208,7 +5211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5222,7 +5225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5239,7 +5242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5255,7 +5258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5266,7 +5269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5280,7 +5283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5297,7 +5300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5314,7 +5317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5331,7 +5334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5347,7 +5350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5358,7 +5361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5373,7 +5376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5387,7 +5390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5407,7 +5410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5424,7 +5427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5437,7 +5440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5449,7 +5452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5466,7 +5469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5486,7 +5489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5513,7 +5516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5541,7 +5544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5555,7 +5558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5572,7 +5575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5588,7 +5591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5599,7 +5602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5610,7 +5613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5628,7 +5631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5645,7 +5648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5661,7 +5664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5676,7 +5679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5693,7 +5696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5709,7 +5712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5724,7 +5727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5737,7 +5740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5751,7 +5754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5771,7 +5774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5788,7 +5791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5807,7 +5810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5819,7 +5822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5835,7 +5838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5846,7 +5849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5857,7 +5860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5874,7 +5877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5890,7 +5893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5901,7 +5904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5922,7 +5925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5939,7 +5942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5959,7 +5962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5976,7 +5979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5989,7 +5992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6000,7 +6003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6014,7 +6017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6029,7 +6032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6043,7 +6046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6060,7 +6063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6076,7 +6079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6091,7 +6094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6108,7 +6111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6128,7 +6131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6141,7 +6144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6155,7 +6158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6172,7 +6175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6188,28 +6191,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58179> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "all-<i>trans</i>-hexaprenyl diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51794> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6217,7 +6203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6234,7 +6220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6244,6 +6230,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN3O-12>
 ] .
+
+<http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58179> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "all-<i>trans</i>-hexaprenyl diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51794> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_84492>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6257,7 +6260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6270,7 +6273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6282,7 +6285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6298,7 +6301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6309,7 +6312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6320,7 +6323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6331,7 +6334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6343,7 +6346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6366,7 +6369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6386,35 +6389,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51596> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_52970_RXN3O-102>
         a       <http://purl.obolibrary.org/obo/CHEBI_52970> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6425,7 +6406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6433,15 +6414,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_null_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6455,7 +6458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6469,7 +6472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6480,7 +6483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6498,7 +6501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6515,7 +6518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6532,7 +6535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6548,7 +6551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6559,7 +6562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6570,7 +6573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6582,7 +6585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6601,7 +6604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6621,7 +6624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6634,7 +6637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6652,7 +6655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6671,7 +6674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6688,7 +6691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6708,7 +6711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6721,7 +6724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6732,7 +6735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6743,7 +6746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6758,7 +6761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6771,7 +6774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6782,7 +6785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6797,7 +6800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6811,7 +6814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6827,7 +6830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6842,7 +6845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6869,7 +6872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6885,7 +6888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6897,7 +6900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6914,7 +6917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6934,7 +6937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6951,7 +6954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6968,7 +6971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6996,7 +6999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7012,7 +7015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7028,7 +7031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7040,7 +7043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7056,7 +7059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7068,7 +7071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7084,7 +7087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7095,7 +7098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7110,7 +7113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7127,7 +7130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7141,7 +7144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7155,22 +7158,16 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CHORPYRLY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-1121>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004337> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7191,7 +7188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7199,16 +7196,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CHORPYRLY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-1121>
+] .
 
 <http://model.geneontology.org/CHEBI_175763_FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_175763> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7219,7 +7222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7233,7 +7236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7250,7 +7253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7266,7 +7269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7281,7 +7284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7301,7 +7304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7314,7 +7317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-94-PWY3O-94.ttl
+++ b/models/PWY3O-94-PWY3O-94.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16,20 +16,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_null_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/reaction_MALSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000006205>
@@ -37,29 +39,42 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller>
+          <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "peroxisome malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,12 +82,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://identifiers.org/sgd/S000005668>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component>
+        a       <http://identifiers.org/sgd/S000003964> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_SUCCCOASYN-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -112,38 +139,47 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000001631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_456216_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94>
@@ -151,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,21 +227,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_null_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CITSYN-RXN>
+          <http://model.geneontology.org/reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -216,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -255,19 +291,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FUMHYDR-RXN>
+          <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30031_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30031_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/FUMHYDR-RXN>
@@ -289,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,13 +350,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,24 +370,21 @@
           <http://model.geneontology.org/PWY3O-94/PWY3O-94>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004451>
@@ -339,40 +392,81 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MALATE-DEH-RXN>
+          <http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_2OXOGLUTARATEDEH-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "NAD-dependent isocitrate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component> , <http://model.geneontology.org/SGD_S000004982_CPLX3O-679_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,36 +491,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_57287_MALSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15589_FUMHYDR-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30031>
@@ -444,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,19 +621,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
@@ -534,13 +645,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63545> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000422> ;
@@ -549,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,12 +679,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -577,13 +708,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63274> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component>
+        a       <http://identifiers.org/sgd/S000003476> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -593,61 +733,68 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_null_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
+          <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
+<http://identifiers.org/sgd/S000004982>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_MALSYN-RXN>
+          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -656,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,6 +816,9 @@
 
 <http://model.geneontology.org/reaction_FUMHYDR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://identifiers.org/sgd/S000001387>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008177> ;
@@ -689,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,23 +848,24 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FUMHYDR-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-33_component>
 ] .
+
+<http://identifiers.org/sgd/S000001568>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -725,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -742,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,12 +962,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+] .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,19 +1027,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94>
@@ -879,44 +1047,63 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' 'null' 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MALSYN-RXN>
+          <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
 ] .
+
+<http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component>
+        a       <http://identifiers.org/sgd/S000005668> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001387> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -924,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,20 +1130,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16810_2OXOGLUTARATEDEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -967,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -999,19 +1197,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57292_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57292_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
@@ -1023,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1033,19 +1231,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ISOCIT-CLEAV-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/CHEBI_15562_ISOCIT-CLEAV-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1054,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1074,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1118,19 +1316,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30616_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/CHEBI_30616_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_PWY3O-94>
@@ -1138,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1180,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,13 +1406,15 @@
 ] .
 
 <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "KGDC" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component> , <http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-33_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1223,39 +1423,54 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_PWY3O-94>
@@ -1263,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1274,29 +1489,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YIR031C-MONOMER_MALSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_null_PWY3O-94>
@@ -1304,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,11 +1549,20 @@
 <http://identifiers.org/sgd/S000005061>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005486> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -1350,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1360,10 +1582,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "mitochondrial malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1373,19 +1597,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15377_FUMHYDR-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_15377_FUMHYDR-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008177>
@@ -1400,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1419,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1432,36 +1673,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30031_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/YNL117W-MONOMER_MALSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
@@ -1475,19 +1716,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_29806_FUMHYDR-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_29806_FUMHYDR-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004108>
@@ -1505,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1519,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1539,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,38 +1788,49 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller>
+          <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16810_2OXOGLUTARATEDEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
@@ -1590,7 +1842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1647,13 +1899,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63704> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003994>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1669,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1677,19 +1940,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_MALSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16383_ACONITATEHYDR-RXN>
@@ -1701,7 +1964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1714,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1725,7 +1988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1739,7 +2002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1758,19 +2021,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_FUMHYDR-RXN>
+          <http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_null_PWY3O-94>
@@ -1778,7 +2041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1793,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1801,12 +2064,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000001624>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1820,7 +2105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1842,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1850,19 +2135,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_MALSYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_36655_MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829>
@@ -1871,12 +2156,15 @@
 <http://identifiers.org/sgd/S000006183>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000003964>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1887,19 +2175,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94>
@@ -1907,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1918,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1929,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1947,7 +2235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1967,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1990,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2003,46 +2291,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY3O-94>
@@ -2050,9 +2339,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
+        a       <http://identifiers.org/sgd/S000001568> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2061,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2072,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2108,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,22 +2415,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_30031_ISOCIT-CLEAV-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
@@ -2144,13 +2440,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63231> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -2161,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of TCA cycle and glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2174,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2186,7 +2493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,19 +2506,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57292_SUCCCOASYN-RXN_SGD_PWY3O-94>
@@ -2219,7 +2526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2233,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2243,22 +2550,20 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57287_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_SUCCCOASYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2267,7 +2572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2280,19 +2585,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_16947_CITSYN-RXN>
@@ -2304,7 +2609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2317,7 +2622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2328,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2343,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2351,35 +2656,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_null_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829>
-] .
-
 <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SUCCCOASYN-RXN>
+] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2392,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2407,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2420,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2433,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2453,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2466,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2481,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2494,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2509,13 +2829,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63366> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000001631>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_43474_SUCCCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -2526,7 +2879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2543,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2554,48 +2907,63 @@
 <http://identifiers.org/sgd/S000003030>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_2OXOGLUTARATEDEH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30616_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SUCCCOASYN-RXN>
-] .
-
-<http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "succinyl-CoA ligase" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_null_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MALATE-DEH-RXN>
+] .
+
+<http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "succinyl-CoA ligase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component> , <http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2611,7 +2979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2622,27 +2990,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000004982_CPLX3O-679_component>
+        a       <http://identifiers.org/sgd/S000004982> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2651,7 +3028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2669,7 +3046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2686,7 +3063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2703,7 +3080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2712,56 +3089,56 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57287_2OXOGLUTARATEDEH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_null_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/CITSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YIR031C-MONOMER_MALSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
@@ -2773,7 +3150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2781,13 +3158,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003581> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2803,27 +3189,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000003476>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15377_FUMHYDR-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FUMHYDR-RXN>
+          <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_null_PWY3O-94>
@@ -2831,7 +3220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2856,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2879,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2890,12 +3279,29 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_null_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2906,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2917,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2928,27 +3334,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94>
@@ -2956,7 +3371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2981,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2994,29 +3409,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94>
@@ -3024,7 +3437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3035,7 +3448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3050,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3063,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3074,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3086,7 +3499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,14 +3510,25 @@
           <http://model.geneontology.org/ACONITATEDEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000001876_CPLX3O-33_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "cytosolic malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3114,19 +3538,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30031_SUCCCOASYN-RXN>
@@ -3138,7 +3562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3146,21 +3570,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005662> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
+          <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
 ] .
 
 <http://model.geneontology.org/SUCCCOASYN-RXN>
@@ -3182,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3195,7 +3628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3210,7 +3643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3223,36 +3656,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_43474_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/CHEBI_43474_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_PWY3O-94>
@@ -3260,7 +3693,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3272,7 +3716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3283,40 +3727,57 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
-] .
+<http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63245> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3327,35 +3788,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63245> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_29806_FUMHYDR-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3366,7 +3810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3391,7 +3835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3401,46 +3845,67 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ISOCIT-CLEAV-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15562_ISOCIT-CLEAV-RXN>
+          <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_null_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CITSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "SDH" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3455,7 +3920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3471,19 +3936,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_ISOCIT-CLEAV-RXN>
+          <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3494,7 +3959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3510,44 +3975,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_null_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
+          <http://model.geneontology.org/reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57287_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -3558,7 +4025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3569,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3583,7 +4050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3597,7 +4064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3605,19 +4072,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/MALATE-DEH-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
@@ -3629,7 +4096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3645,7 +4112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3654,21 +4121,60 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57540_2OXOGLUTARATEDEH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3693,7 +4199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3710,7 +4216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,36 +4226,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL117W-MONOMER_MALSYN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_29806_FUMHYDR-RXN_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_FUMHYDR-RXN>
+          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94>
@@ -3757,7 +4263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3768,18 +4274,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3794,7 +4317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3807,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3815,29 +4338,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "minor succinate dehydrogenase (ubiquinone)" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3847,19 +4372,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
@@ -3871,7 +4413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3884,7 +4426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3899,7 +4441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3915,7 +4457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3928,19 +4470,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_456216_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_null_PWY3O-94>
@@ -3948,7 +4490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3961,7 +4503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3976,7 +4518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3989,7 +4531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3997,19 +4539,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
@@ -4021,7 +4563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4029,14 +4571,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000002585>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000003964> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4049,7 +4603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4062,7 +4616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4073,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4081,22 +4635,25 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_MALSYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36655_MALSYN-RXN>
+          <http://model.geneontology.org/YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_36655>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002555>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4105,7 +4662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4118,19 +4675,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/FUMHYDR-RXN>
 ] .
 
 <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
@@ -4140,7 +4697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4153,7 +4710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4162,13 +4719,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_15562>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002555> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4187,7 +4753,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4203,7 +4780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4216,7 +4793,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4227,7 +4815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4252,13 +4840,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94BiochemicalReaction63499> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004982_CPLX3O-679_component>
+] .
 
 <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -4269,7 +4874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4286,7 +4891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4302,27 +4907,30 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
 ] .
+
+<http://identifiers.org/sgd/S000005486>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_null_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4330,19 +4938,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
+          <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_MALSYN-RXN>
@@ -4354,7 +4962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4371,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4384,7 +4992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4395,7 +5003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4410,7 +5018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4421,12 +5029,21 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_null_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4437,7 +5054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4448,7 +5065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4459,7 +5076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4467,37 +5084,42 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_43474_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_null_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://identifiers.org/sgd/S000003581>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004295> ;
@@ -4506,7 +5128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4522,7 +5144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4533,19 +5155,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57292>
@@ -4560,7 +5182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4574,7 +5196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4590,7 +5212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4601,7 +5223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4609,19 +5231,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_2OXOGLUTARATEDEH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_36655_MALSYN-RXN>
@@ -4633,7 +5274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4642,22 +5283,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY3O-94>
@@ -4665,7 +5304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4680,7 +5319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4691,24 +5330,36 @@
 <http://identifiers.org/sgd/S000000867>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000001624> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
+          <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002236>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
@@ -4720,7 +5371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4732,22 +5383,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CITSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15589_MALSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94>
@@ -4755,30 +5404,52 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005662>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_null_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_FUMHYDR-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94>
@@ -4786,7 +5457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4797,7 +5468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4808,7 +5479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4819,7 +5490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4830,7 +5501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4841,7 +5512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4852,7 +5523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4866,7 +5537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4879,19 +5550,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57292_SUCCCOASYN-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/CHEBI_57292_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
@@ -4903,7 +5574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4911,12 +5582,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4931,7 +5613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4940,53 +5622,75 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_null_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886>
+          <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' 'null' 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_null_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
+          <http://model.geneontology.org/ISOCIT-CLEAV-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
+          <http://model.geneontology.org/MALSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16383>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5000,7 +5704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5013,53 +5717,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MALSYN-RXN>
+          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -5074,7 +5778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5088,7 +5792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5104,9 +5808,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002236> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5115,7 +5828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5123,19 +5836,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-94/PWY3O-94>
+          <http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30031_SUCCCOASYN-RXN_SGD_PWY3O-94>
@@ -5143,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5154,7 +5884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-954-PWY3O-954.ttl
+++ b/models/PWY3O-954-PWY3O-954.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,7 +87,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,6 +340,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22_SGD_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -348,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -783,9 +794,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/f89c8a6b-85e4-4307-8bd6-7678f98f5199_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/a7eb07b1-a789-4ed5-a0be-23501b12cf28_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -793,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,7 +941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -975,7 +986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +1006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1063,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1080,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,41 +1159,13 @@
 <http://purl.obolibrary.org/obo/GO_0004072>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_f89c8a6b-85e4-4307-8bd6-7678f98f5199_RXN3O-22_SGD_PWY3O-954> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f89c8a6b-85e4-4307-8bd6-7678f98f5199_RXN3O-22>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_PWY3O-954/PWY3O-954_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,6 +1176,34 @@
           <http://model.geneontology.org/PWY3O-954/PWY3O-954>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22_SGD_PWY3O-954> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004414>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1201,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1228,7 +1239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1282,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1319,7 +1330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1381,7 +1392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,17 +1402,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16136_ACETYLHOMOSER-CYS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_f89c8a6b-85e4-4307-8bd6-7678f98f5199_RXN3O-22_SGD_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1450,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,13 +1492,30 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
+<http://model.geneontology.org/b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1559,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1587,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1602,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1618,11 +1635,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_a7eb07b1-a789-4ed5-a0be-23501b12cf28_RXN3O-22_SGD_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,7 +1647,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a7eb07b1-a789-4ed5-a0be-23501b12cf28_RXN3O-22>
+          <http://model.geneontology.org/37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
@@ -1642,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1655,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1670,7 +1687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1686,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1698,7 +1715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,18 +1731,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_PWY3O-954/PWY3O-954_SGD_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1739,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1754,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1791,7 +1825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1807,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,28 +1879,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule64051> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/a7eb07b1-a789-4ed5-a0be-23501b12cf28_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1875,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1907,7 +1924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1943,7 +1960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1954,7 +1971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1979,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1992,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2027,7 +2044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2049,7 +2066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2090,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2107,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2123,7 +2140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2134,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2145,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2156,7 +2173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2167,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2181,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2193,7 +2210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2209,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2223,7 +2240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2256,7 +2273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2283,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2298,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2334,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2368,7 +2385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2391,7 +2408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2408,23 +2425,6 @@
 <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/f89c8a6b-85e4-4307-8bd6-7678f98f5199_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_13390> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2434,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2457,13 +2457,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-954/PWY3O-954_SGD_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_PWY3O-954/PWY3O-954_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2474,34 +2485,12 @@
           <http://model.geneontology.org/PWY3O-954/PWY3O-954>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-954/PWY3O-954_SGD_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_a7eb07b1-a789-4ed5-a0be-23501b12cf28_RXN3O-22_SGD_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2513,7 +2502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2529,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2540,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2552,7 +2541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2582,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2597,7 +2586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2610,7 +2599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2622,7 +2611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,7 +2627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2650,7 +2639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2666,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2680,7 +2669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2696,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2721,7 +2710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2734,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2746,7 +2735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2766,7 +2755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2777,13 +2766,24 @@
           <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22_SGD_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002411_HOMOSERDEHYDROG-RXN_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2799,7 +2799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2821,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2835,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2848,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-96-PWY3O-96.ttl
+++ b/models/PWY3O-96-PWY3O-96.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -638,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinamide riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-981-PWY3O-981.ttl
+++ b/models/PWY3O-981-PWY3O-981.ttl
@@ -1,48 +1,52 @@
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_96059ab8-3d6c-418c-b52a-c9bbddfda389_ACETOINDEHYDROG-RXN_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
+          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_null_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY3O-981>
@@ -50,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,10 +81,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,6 +122,23 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -124,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -132,19 +155,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
+          <http://model.geneontology.org/RXN0-2022>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
 ] .
 
 <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN>
@@ -164,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,19 +214,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
+          <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16583>
@@ -198,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,10 +256,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,10 +273,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -254,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,6 +309,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+        a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_ACETOLACTSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -274,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,38 +335,67 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN0-2022>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
+          <http://model.geneontology.org/ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022>
+] .
+
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
+        a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_RXN-6081_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6081> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58476_RXN-6081>
 ] .
 
 <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN>
@@ -325,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,20 +417,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -361,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,6 +468,9 @@
 <http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://identifiers.org/sgd/S000004714>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_16526_RXN-6081>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -384,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -423,57 +519,85 @@
 <http://purl.obolibrary.org/obo/CHEBI_15343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_a3a8e675-003b-4b63-9f3b-c57442d6c849_RXN0-2022_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a3a8e675-003b-4b63-9f3b-c57442d6c849_RXN0-2022>
+          <http://model.geneontology.org/e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_RXN-6081_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58476_RXN-6081>
+          <http://model.geneontology.org/CHEBI_15378_RXN-6161>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_8effb187-6236-4785-98b6-2ccf0d9e81f5_RXN3O-470_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
+] .
 
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,20 +632,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_8effb187-6236-4785-98b6-2ccf0d9e81f5_RXN3O-470_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_null_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8effb187-6236-4785-98b6-2ccf0d9e81f5_RXN3O-470>
+          <http://model.geneontology.org/reaction_RXN0-2022_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY3O-981>
@@ -529,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -537,19 +663,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-6161>
+          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_null_PWY3O-981>
@@ -557,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +723,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/96059ab8-3d6c-418c-b52a-c9bbddfda389_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -607,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,18 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_RXN-6081_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -642,7 +757,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_RXN-6081_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -650,17 +787,6 @@
 
 <http://model.geneontology.org/reaction_RXN0-2022_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_a3a8e675-003b-4b63-9f3b-c57442d6c849_RXN0-2022_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17499_RXN-6081>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
@@ -671,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,49 +806,69 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_null_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN0-2022_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
+          <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6081> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17499_RXN-6081>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004737>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,26 +876,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004737>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate decarboxylase / decarboxylase" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981Complex64682> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -757,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,6 +918,32 @@
           <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981Complex64682> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -777,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,38 +1033,78 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000515> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller>
+          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -896,19 +1112,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17499_RXN-6081>
+          <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_null_PWY3O-981>
@@ -916,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -928,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -966,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1005,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1027,19 +1243,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY3O-981>
@@ -1047,7 +1263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1055,19 +1271,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
+          <http://model.geneontology.org/CHEBI_15339_RXN-6081>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
@@ -1079,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,20 +1305,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
+
+<http://identifiers.org/sgd/S000000056>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1113,13 +1332,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of acetoin and butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1136,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1145,13 +1375,15 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetolactate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component> , <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,18 +1396,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_null_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1198,40 +1449,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_null_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
-] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1239,19 +1492,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15339_RXN-6081>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981>
@@ -1259,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,6 +1535,17 @@
           <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1291,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1318,21 +1582,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' '2 acetaldehyde &rarr; acetoin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_null_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_null_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN3O-470>
 ] .
 
 <http://model.geneontology.org/RXN-6161>
@@ -1354,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1363,23 +1627,32 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_null_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1387,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1437,6 +1710,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-2022> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
+] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1450,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1459,39 +1749,37 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' '2 acetaldehyde &rarr; acetoin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_null_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-470>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN-6081>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1503,7 +1791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1518,10 +1806,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,3-butanediol dehydrogenase / diacetyl reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,13 +1828,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "PWY3O-981" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1555,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,11 +1859,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_16526_RXN-6161>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1578,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1588,19 +1895,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
+          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-981>
@@ -1608,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,29 +1955,23 @@
           <http://model.geneontology.org/PWY3O-981/PWY3O-981>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN-6081>
-] .
-
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1695,7 +2013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1720,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1731,19 +2049,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
+          <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
 ] .
 
 <http://model.geneontology.org/RXN3O-470>
@@ -1757,7 +2075,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8effb187-6236-4785-98b6-2ccf0d9e81f5_RXN3O-470> ;
+                <http://model.geneontology.org/e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1765,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1775,36 +2093,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-981/PWY3O-981>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY3O-981>
@@ -1812,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1827,13 +2145,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64658> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-6161>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1844,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1852,137 +2173,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/8effb187-6236-4785-98b6-2ccf0d9e81f5_RXN3O-470>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_16583_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN>
-] .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/96059ab8-3d6c-418c-b52a-c9bbddfda389_ACETOINDEHYDROG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002411_ACETOINDEHYDROG-RXN_SGD_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,7 +2196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2012,11 +2209,172 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
+] .
+
+<http://model.geneontology.org/5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_16583_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002411_ACETOINDEHYDROG-RXN_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
+] .
+
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,10 +2389,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2047,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2061,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2069,19 +2429,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY3O-981>
@@ -2089,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2097,19 +2457,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
+          <http://model.geneontology.org/CHEBI_15378_RXN-6081>
 ] .
 
 <http://model.geneontology.org/CHEBI_58476_RXN-6081>
@@ -2121,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2131,44 +2491,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
-<http://model.geneontology.org/a3a8e675-003b-4b63-9f3b-c57442d6c849_RXN0-2022>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,10 +2549,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,3-butanediol dehydrogenase / diacetyl reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2215,13 +2571,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64521> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ACETOLACTSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003984> ;
@@ -2242,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2250,52 +2609,69 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN3O-470_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15343_RXN3O-470>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16982>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-6081>
+          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+] .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981>
@@ -2303,7 +2679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2347,10 +2723,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2362,10 +2740,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2378,7 +2758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2387,32 +2767,18 @@
 <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_58476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN3O-470_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN3O-470>
-] .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2420,19 +2786,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
+] .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
@@ -2444,7 +2838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2458,7 +2852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,7 +2871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2491,7 +2885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2500,12 +2894,15 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000000515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2514,12 +2911,29 @@
 <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-2022> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_null_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2529,10 +2943,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2542,36 +2958,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_16583_RXN-6081>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_ACETOLACTSYN-RXN>
@@ -2583,7 +2999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2593,11 +3009,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_96059ab8-3d6c-418c-b52a-c9bbddfda389_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2605,7 +3021,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/96059ab8-3d6c-418c-b52a-c9bbddfda389_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
@@ -2617,7 +3033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2630,7 +3046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2641,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2649,36 +3065,55 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2022> ;
+          <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
+          <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6081> ;
+          <http://model.geneontology.org/RXN-6161> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16583_RXN-6081>
+          <http://model.geneontology.org/CHEBI_16526_RXN-6161>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2689,7 +3124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2711,7 +3146,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/a3a8e675-003b-4b63-9f3b-c57442d6c849_RXN0-2022> ;
+                <http://model.geneontology.org/ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2719,7 +3154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,7 +3167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2750,7 +3185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2763,7 +3198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2774,7 +3209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2782,36 +3217,49 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-470> ;
+          <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
+          <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_null_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
+          <http://model.geneontology.org/RXN-6081> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN-6161>
+          <http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_15343_RXN-6161>
@@ -2823,7 +3271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2832,22 +3280,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_null_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY3O-981>
@@ -2855,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2866,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2874,3 +3320,20 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-470> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-981/PWY3O-981>
+] .

--- a/models/PWYQT-4432-PWYQT-4432.ttl
+++ b/models/PWYQT-4432-PWYQT-4432.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -53,137 +53,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWYQT-4432> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6622> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWYQT-4432> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6601> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61694_RXN-6601>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_61694>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/c0783e36-e696-4532-92c0-f98e0100fa1a_RXN-6601>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/RXN-6601>
-        a       <http://purl.obolibrary.org/obo/GO_0036374> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWYQT-4432/PWYQT-4432> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57925_RXN-6601> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_61694_RXN-6601> , <http://model.geneontology.org/c0783e36-e696-4532-92c0-f98e0100fa1a_RXN-6601> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/RXN-6622> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432BiochemicalReaction62571> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWYQT-4432>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_PWYQT-4432/PWYQT-4432_SGD_PWYQT-4432>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,12 +85,133 @@
           <http://model.geneontology.org/CHEBI_83813_RXN-6601>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_61694>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/RXN-6601>
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWYQT-4432/PWYQT-4432> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_57925_RXN-6601> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN-6622> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432BiochemicalReaction62571> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component>
+        a       <http://identifiers.org/sgd/S000001940> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_PWYQT-4432/PWYQT-4432_SGD_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWYQT-4432> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6622> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_35235_RXN-6622>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_PWYQT-4432> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6601> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57925_RXN-6601>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_null_PWYQT-4432>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -251,8 +246,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000001940>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -262,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -272,20 +287,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_PWYQT-4432/PWYQT-4432_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_null_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6622> ;
+          <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWYQT-4432/PWYQT-4432>
+          <http://model.geneontology.org/RXN-6622>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWYQT-4432>
@@ -293,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -315,36 +332,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6622_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6622> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35235_RXN-6622>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_PWYQT-4432> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6622> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61694_RXN-6622>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_null_PWYQT-4432> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57925_RXN-6601>
+          <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -355,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -410,22 +429,20 @@
                 "org.biopax.paxtools.model.level3.Pathway" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_null_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-6622>
+          <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
 ] .
 
 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
@@ -435,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,11 +462,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6622_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +474,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61694_RXN-6622>
+          <http://model.geneontology.org/CHEBI_15377_RXN-6622>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWYQT-4432>
@@ -465,48 +482,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_null_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_PWYQT-4432/PWYQT-4432_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829>
+          <http://model.geneontology.org/PWYQT-4432/PWYQT-4432>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_c0783e36-e696-4532-92c0-f98e0100fa1a_RXN-6601_SGD_PWYQT-4432>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_null_PWYQT-4432>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,24 +562,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601_SGD_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
+          <http://model.geneontology.org/0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -587,24 +602,23 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0036374>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_null_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-6622>
+          <http://model.geneontology.org/reaction_RXN-6622_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_61694_RXN-6622>
@@ -616,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,29 +640,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_PWYQT-4432/PWYQT-4432_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6601> ;
+          <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWYQT-4432/PWYQT-4432>
+          <http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component>
 ] .
 
 <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "DUG1" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,11 +712,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWYQT-4432> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6622> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_83813_RXN-6601>
         a       <http://purl.obolibrary.org/obo/CHEBI_83813> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -711,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,11 +754,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_c0783e36-e696-4532-92c0-f98e0100fa1a_RXN-6601_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +766,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c0783e36-e696-4532-92c0-f98e0100fa1a_RXN-6601>
+          <http://model.geneontology.org/CHEBI_61694_RXN-6601>
 ] .
 
 <http://model.geneontology.org/CHEBI_35235_RXN-6622>
@@ -745,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,22 +787,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_null_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_PWYQT-4432/PWYQT-4432_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6622> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6622_location_lociGO_0005829>
+          <http://model.geneontology.org/PWYQT-4432/PWYQT-4432>
 ] .
 
 <http://purl.org/dc/elements/1.1/title>
@@ -777,3 +808,14 @@
 
 <http://identifiers.org/sgd/S000004290>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .

--- a/models/PYRIMID-RNTSYN-PWY-PYRIMID-RNTSYN-PWY.ttl
+++ b/models/PYRIMID-RNTSYN-PWY-PYRIMID-RNTSYN-PWY.ttl
@@ -1,219 +1,106 @@
-<http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12002> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
+] .
+
+<http://identifiers.org/sgd/S000001507>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
+<http://identifiers.org/sgd/S000003666>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
-] .
-
-<http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004152> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-dihydroorotate + an electron-transfer quinone<SUB>[inner membrane]</SUB> &rarr; orotate + an electron-transfer quinol<SUB>[inner membrane]</SUB>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/8e179ae9-45b0-482e-a97b-5900a3f62d4b_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/c3526917-202d-43fd-83ea-87b68a2ff344_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46222> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/UDPKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "UDP + ATP &rarr; UTP + ADP" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN> , <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN> , <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/CTPSYN-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46392> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
+<http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "gln" ;
+                "CTP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46288> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
-] .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/CHEBI_29991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_32814> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-carbamoyl-L-aspartate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46492> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -224,7 +111,97 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58223> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "UDP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46211> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "Purine and pyrimidine nucleotides serve many diverse and essential roles in the cell. They are precursors to DNA, RNA, and many important metabolites (e.g. CDP-diacylglycerol). In addition, nucleotides can be used as an energy source (primarily as ATP), signaling molecules, and cofactor components (e.g. coenzyme A). In <i>S. cerevisiae</i>, the initial steps of de novo pyrimidine biosynthesis are catalyzed by the bifunctional carbamoylphosphate synthetase/aspartate transcarbamylase Ura2p. In the first step, Ura2p catalyzes the synthesis of carbamoylphosphate from CO2, ATP, and glutamine. In the second, Ura2p condenses carbamoylphosphate with aspartate to yield ureidosuccinate/carbamoyl-L-aspartate. Third, dihydroorotase (Ura4p) catalyzes closure of the pyrimidine ring of ureidosuccinate to form dihydroorotate (DHO). DHO, in turn, is oxidized to orotic acid (OA), condensed with phosphoribosyl pyrophosphate to form orotidine 5-monophosphate, and finally decarboxylated to yield UMP. These three steps are catalyzed by Ura1p, Ura5p/Ura10p, and Ura3p, respectively. UMP may then undergo further processing to form other pyrimidines. The de novo pyrimidine pathway is regulated at both the enzymatic and transcriptional levels. Ura2p, which catalyzes the first committed step of the pathway, is subject to end product feedback inhibition by UTP. Transcription of URA2 is repressed by UTP and uracil. Furthermore, transcription of URA2 and several other genes in the pathway is upregulated in response to pyrimidine starvation. Upregulation of URA1, URA3, and URA4 during pyrimidine starvation depends upon the zinc finger transcription factor Ppr1p. Two intermediates in the pyrimidine pathway regulate the transcriptional activity of Ppr1p: DHO and OA. At low concentrations, these intermediates convert Ppr1p into its active state, resulting in transcription of URA genes. High concentrations of DHO and OA, however, inhibit Ppr1p activity in vitro. References: |CITS:[22419079]||CITS: [(JONES]||CITS: [2283036]||CITS: [9858611]|" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "de novo biosynthesis of pyrimidine ribonucleotides" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "PYRIMID-RNTSYN-PWY" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,73 +211,132 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57865>
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0004088>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YJL130C-MONOMER_ASPCARBTRANS-RXN_controller>
+        a       <http://identifiers.org/sgd/S000003666> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "carbamyl phosphate synthase / aspartate transcarbamylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46538> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
+          <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000000747>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_32814>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,8 +359,8 @@
           <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -332,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,133 +376,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
+<http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
-] .
+<http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_46398> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_32814> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "UTP" ;
+                "<i>N</i>-carbamoyl-L-aspartate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46317> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46492> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "carbamoyl phosphate synthetase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYComplex46562> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
+          <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,218 +442,115 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "gln" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46288> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://purl.obolibrary.org/obo/GO_0003883>
+<http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004412> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dihydrooratase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46499> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "Purine and pyrimidine nucleotides serve many diverse and essential roles in the cell. They are precursors to DNA, RNA, and many important metabolites (e.g. CDP-diacylglycerol). In addition, nucleotides can be used as an energy source (primarily as ATP), signaling molecules, and cofactor components (e.g. coenzyme A). In <i>S. cerevisiae</i>, the initial steps of de novo pyrimidine biosynthesis are catalyzed by the bifunctional carbamoylphosphate synthetase/aspartate transcarbamylase Ura2p. In the first step, Ura2p catalyzes the synthesis of carbamoylphosphate from CO2, ATP, and glutamine. In the second, Ura2p condenses carbamoylphosphate with aspartate to yield ureidosuccinate/carbamoyl-L-aspartate. Third, dihydroorotase (Ura4p) catalyzes closure of the pyrimidine ring of ureidosuccinate to form dihydroorotate (DHO). DHO, in turn, is oxidized to orotic acid (OA), condensed with phosphoribosyl pyrophosphate to form orotidine 5-monophosphate, and finally decarboxylated to yield UMP. These three steps are catalyzed by Ura1p, Ura5p/Ura10p, and Ura3p, respectively. UMP may then undergo further processing to form other pyrimidines. The de novo pyrimidine pathway is regulated at both the enzymatic and transcriptional levels. Ura2p, which catalyzes the first committed step of the pathway, is subject to end product feedback inhibition by UTP. Transcription of URA2 is repressed by UTP and uracil. Furthermore, transcription of URA2 and several other genes in the pathway is upregulated in response to pyrimidine starvation. Upregulation of URA1, URA3, and URA4 during pyrimidine starvation depends upon the zinc finger transcription factor Ppr1p. Two intermediates in the pyrimidine pathway regulate the transcriptional activity of Ppr1p: DHO and OA. At low concentrations, these intermediates convert Ppr1p into its active state, resulting in transcription of URA genes. High concentrations of DHO and OA, however, inhibit Ppr1p activity in vitro. References: |CITS:[22419079]||CITS: [(JONES]||CITS: [2283036]||CITS: [9858611]|" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "de novo biosynthesis of pyrimidine ribonucleotides" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "PYRIMID-RNTSYN-PWY" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "PRPP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46463> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12002> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/UDPKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_RXN-12002>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002411_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_43474_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004550>
+<http://purl.obolibrary.org/obo/GO_0004590>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/CHEBI_58228>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
-] .
+<http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57538> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "orotidine 5'-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46409> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
-] .
+<http://purl.obolibrary.org/obo/CHEBI_58017>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/OROPRIBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004588> ;
@@ -719,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -727,102 +579,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46448> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46302> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+                "CO<SUB>2</SUB>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46424> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "asp" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46516> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -833,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,51 +642,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
+          <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -893,64 +672,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-] .
-
-<http://identifiers.org/sgd/S000003666>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,110 +684,120 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_58017>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
-] .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46376> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CTPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
 ] .
-
-<http://identifiers.org/sgd/S000004412>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_30839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12002> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_RXN-12002>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46302> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,47 +805,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CARBPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17544_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001507> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "uridylate kinase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46219> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0004127>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,45 +841,440 @@
           <http://model.geneontology.org/CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58223>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
+] .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "gln" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46288> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30864>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46302> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_30839> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "orotate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46265> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004412> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dihydrooratase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46499> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002411_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004884> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "orotate phosphoribosyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46476> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1180,20 +1282,66 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
+        a       <http://identifiers.org/sgd/S000003666> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "carbamyl phosphate synthase / aspartate transcarbamylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46538> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_37563>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "de novo biosynthesis of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1201,7 +1349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,256 +1360,73 @@
           <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/8e179ae9-45b0-482e-a97b-5900a3f62d4b_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_43474_CARBPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_57865_RXN-12002>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57865> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
+                "UMP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46345> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46180> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+<http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+                "diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57538> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "orotidine 5'-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46409> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004884> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "orotate phosphoribosyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46476> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://identifiers.org/sgd/S000000135>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30839> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "orotate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46265> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46448> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
+          <http://model.geneontology.org/OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57538> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "orotidine 5'-phosphate" ;
+                "glu" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46409> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46376> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0004590>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_c3526917-202d-43fd-83ea-87b68a2ff344_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c3526917-202d-43fd-83ea-87b68a2ff344_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_37563>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1469,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,6 +1444,29 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YJL130C-MONOMER_ASPCARBTRANS-RXN_controller>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004151>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/OROTPDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004590> ;
@@ -1499,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,603 +1495,61 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_32814> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_456216_RXN-12002>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-carbamoyl-L-aspartate" ;
+                "ADP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46492> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
-] .
-
-<http://model.geneontology.org/RXN-12002>
-        a       <http://purl.obolibrary.org/obo/GO_0004127> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP + UMP &rarr; ADP + UDP" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57865_RXN-12002> , <http://model.geneontology.org/CHEBI_30616_RXN-12002> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58223_RXN-12002> , <http://model.geneontology.org/CHEBI_456216_RXN-12002> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/UDPKIN-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46146> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001507>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0004151>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_46398> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "UTP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46317> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003864> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CTP synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46383> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
-] .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_null_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ASPCARBTRANS-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CTP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58228>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000001699>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/c3526917-202d-43fd-83ea-87b68a2ff344_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_57865_RXN-12002>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57865> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "UMP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46180> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46302> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://identifiers.org/sgd/S000003864>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN-12002>
+          <http://model.geneontology.org/CHEBI_57865_RXN-12002>
 ] .
-
-<http://purl.obolibrary.org/obo/GO_0004088>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/OROTPDECARB-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46302> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_CARBPSYN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004088> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2124,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2132,541 +1578,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_c3526917-202d-43fd-83ea-87b68a2ff344_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_30864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-dihydroorotate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46245> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58223>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_17544_CARBPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17544> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hydrogencarbonate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46556> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "asp" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46516> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-12002>
-] .
-
-<http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000747> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "orotidine-5'-phosphate decarboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46431> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_8e179ae9-45b0-482e-a97b-5900a3f62d4b_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8e179ae9-45b0-482e-a97b-5900a3f62d4b_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0004588>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "carbamoyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46530> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15378_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/UDPKIN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002411_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004070>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_456216_RXN-12002>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46376> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_30616_RXN-12002>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17544_CARBPSYN-RXN>
-] .
-
-<http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
-        a       <http://identifiers.org/sgd/S000003666> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "carbamyl phosphate synthase / aspartate transcarbamylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46538> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57865> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "UMP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46180> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_57538>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_46398>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_30839> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "orotate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46265> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2674,7 +1587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,13 +1598,424 @@
           <http://model.geneontology.org/CHEBI_32814_DIHYDROOROT-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glu" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46376> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
+] .
+
+<http://model.geneontology.org/CTPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003883> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller> , <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46275> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
+] .
+
+<http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003864> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CTP synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46383> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000747> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "orotidine-5'-phosphate decarboxylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46431> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004127>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "PRPP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46463> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17544>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_58223_RXN-12002>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58223> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "UDP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46211> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58228_ASPCARBTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58228> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "carbamoyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46530> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002411_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_30864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-dihydroorotate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46245> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2702,23 +2026,52 @@
           <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57538> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "orotidine 5'-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46409> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000000135>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+] .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2726,31 +2079,65 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002411_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+          <http://model.geneontology.org/DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004152>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004151> ;
@@ -2771,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2779,481 +2166,252 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN-12002>
+          <http://model.geneontology.org/CHEBI_456216_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002411_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58228_ASPCARBTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58228> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "carbamoyl phosphate" ;
+                "carbamoyl phosphate synthetase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component> , <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46530> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYComplex46562> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Complex" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002411_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIHYDROOROT-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_32814_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://identifiers.org/sgd/S000004574>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+<http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
+                "gln" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46345> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46288> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://identifiers.org/sgd/S000004884>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_30864>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+          <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_null_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CTPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003883> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN> , <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller> , <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46275> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004152>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_17544>
+<http://purl.obolibrary.org/obo/CHEBI_32814>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+          <http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/YJL130C-MONOMER_ASPCARBTRANS-RXN_controller>
-        a       <http://identifiers.org/sgd/S000003666> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "carbamyl phosphate synthase / aspartate transcarbamylase" ;
+<http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/RXN-12002>
+        a       <http://purl.obolibrary.org/obo/GO_0004127> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP + UMP &rarr; ADP + UDP" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_57865_RXN-12002> , <http://model.geneontology.org/CHEBI_30616_RXN-12002> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_58223_RXN-12002> , <http://model.geneontology.org/CHEBI_456216_RXN-12002> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/UDPKIN-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46538> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46146> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_30864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-dihydroorotate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46245> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
+] .
+
+<http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_46398> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "UTP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46317> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3261,7 +2419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3272,33 +2430,22 @@
           <http://model.geneontology.org/CHEBI_58228_ASPCARBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+<http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "de novo biosynthesis of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46302> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ASPCARBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004070> ;
@@ -3319,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3327,76 +2474,398 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_30864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-dihydroorotate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46245> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000004412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_RXN-12002>
+          <http://model.geneontology.org/RXN-12002>
 ] .
+
+<http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004152> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-dihydroorotate + an electron-transfer quinone<SUB>[inner membrane]</SUB> &rarr; orotate + an electron-transfer quinol<SUB>[inner membrane]</SUB>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002411>
+                <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46222> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_43474_CARBPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57538>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3408,7 +2877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3419,93 +2888,65 @@
           <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
-] .
-
-<http://identifiers.org/sgd/S000004574>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
+                "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58223> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "UDP" ;
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46211> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46424> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3518,7 +2959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3526,84 +2967,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_8e179ae9-45b0-482e-a97b-5900a3f62d4b_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPKIN-RXN> ;
+          <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58223_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3611,100 +3008,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
-] .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
+          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_30616_RXN-12002>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3712,53 +3065,233 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CARBPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/CHEBI_58223_RXN-12002>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58223> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "UDP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46211> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002411_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001507> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "uridylate kinase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46219> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_32814> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-carbamoyl-L-aspartate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46492> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_30839_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30839_OROPRIBTRANS-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
+] .
+
+<http://identifiers.org/sgd/S000003864>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_null_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3766,7 +3299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,19 +3310,571 @@
           <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+<http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
+                "carbamoyl phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46530> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
+] .
+
+<http://model.geneontology.org/UDPKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/GO_0004550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "UDP + ATP &rarr; UTP + ADP" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_58223_UDPKIN-RXN> , <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN> , <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/CTPSYN-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46392> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_null_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/CHEBI_17544_CARBPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17544> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hydrogencarbonate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46556> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002411_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_46398>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_null_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ASPCARBTRANS-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_57865>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
+] .
+
+<http://model.geneontology.org/716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15377_DIHYDROOROT-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003883>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12002> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
+] .
+
+<http://identifiers.org/sgd/S000001699>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004588>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004070>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002411_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
+] .
+
+<http://identifiers.org/sgd/S000004884>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58017_OROPRIBTRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46330> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30839> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "orotate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46265> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_46398> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "UTP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46317> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
+] .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPCARBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
+] .
+
+<http://identifiers.org/sgd/S000000747>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_null_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57865> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "UMP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46180> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PYRUVDEHYD-PWY-PYRUVDEHYD-PWY.ttl
+++ b/models/PYRUVDEHYD-PWY-PYRUVDEHYD-PWY.ttl
@@ -1,24 +1,30 @@
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_d8c647d1-cea6-4607-bd42-94e0c0d1b0ed_RXN0-1132_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000050_PYRUVDEHYD-PWY/PYRUVDEHYD-PWY_SGD_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-1134>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -29,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,11 +45,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_c3dd20ba-f045-4764-9d87-0a8f234bd0bc_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,8 +57,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c3dd20ba-f045-4764-9d87-0a8f234bd0bc_RXN0-1133>
+          <http://model.geneontology.org/27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134_SGD_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -60,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,6 +91,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/PYRUVDEHYD-PWY/PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -83,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -91,8 +111,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133_SGD_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_RXN0-1133>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -103,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,11 +156,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_0365a5d1-47b0-4d3e-97d6-8c31fb9617ee_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +168,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0365a5d1-47b0-4d3e-97d6-8c31fb9617ee_RXN0-1134>
+          <http://model.geneontology.org/f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_RXN0-1132>
@@ -152,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,18 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_324f2cd7-a9ff-4172-82f8-e0a6f6f74fba_RXN0-1133_SGD_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -188,12 +205,23 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133_SGD_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_57540_RXN0-1132_SGD_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,13 +247,24 @@
           <http://model.geneontology.org/CHEBI_57287_RXN0-1133>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134_SGD_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_b0ab308f-a0c5-4cf5-9713-41ef1b49979a_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +272,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0ab308f-a0c5-4cf5-9713-41ef1b49979a_RXN0-1132>
+          <http://model.geneontology.org/aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -242,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,23 +291,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN0-1133>
 ] .
-
-<http://model.geneontology.org/b0ab308f-a0c5-4cf5-9713-41ef1b49979a_RXN0-1132>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -284,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,9 +324,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1134_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/0365a5d1-47b0-4d3e-97d6-8c31fb9617ee_RXN0-1134> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/39c6aa90-6106-4db2-bc7b-58329166c953_RXN0-1134> , <http://model.geneontology.org/CHEBI_16526_RXN0-1134> ;
+                <http://model.geneontology.org/e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134> , <http://model.geneontology.org/CHEBI_16526_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER178W-MONOMER_RXN0-1134_controller> , <http://model.geneontology.org/YBR221C-MONOMER_RXN0-1134_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -312,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -325,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyruvate decarboxylation to acetyl CoA - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,6 +448,23 @@
 <http://model.geneontology.org/reaction_RXN0-1133_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN0-1132>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -435,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,27 +482,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_b0ab308f-a0c5-4cf5-9713-41ef1b49979a_RXN0-1132_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_324f2cd7-a9ff-4172-82f8-e0a6f6f74fba_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,19 +516,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/324f2cd7-a9ff-4172-82f8-e0a6f6f74fba_RXN0-1133>
+          <http://model.geneontology.org/f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_0365a5d1-47b0-4d3e-97d6-8c31fb9617ee_RXN0-1134_SGD_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -491,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,50 +553,27 @@
           <http://model.geneontology.org/YER178W-MONOMER_RXN0-1134_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002333_YNL071W-MONOMER_RXN0-1133_controller_SGD_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132_SGD_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/c3dd20ba-f045-4764-9d87-0a8f234bd0bc_RXN0-1133>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002333_YNL071W-MONOMER_RXN0-1133_controller_SGD_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/d8c647d1-cea6-4607-bd42-94e0c0d1b0ed_RXN0-1132>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -582,9 +593,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1133_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/324f2cd7-a9ff-4172-82f8-e0a6f6f74fba_RXN0-1133> , <http://model.geneontology.org/CHEBI_57288_RXN0-1133> ;
+                <http://model.geneontology.org/f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133> , <http://model.geneontology.org/CHEBI_57288_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN0-1133> , <http://model.geneontology.org/c3dd20ba-f045-4764-9d87-0a8f234bd0bc_RXN0-1133> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN0-1133> , <http://model.geneontology.org/27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -592,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +633,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132_SGD_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,30 +682,13 @@
           <http://model.geneontology.org/PYRUVDEHYD-PWY/PYRUVDEHYD-PWY>
 ] .
 
-<http://model.geneontology.org/39c6aa90-6106-4db2-bc7b-58329166c953_RXN0-1134>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002333_YFL018C-MONOMER_RXN0-1132_controller_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,29 +699,12 @@
           <http://model.geneontology.org/YFL018C-MONOMER_RXN0-1132_controller>
 ] .
 
-<http://model.geneontology.org/324f2cd7-a9ff-4172-82f8-e0a6f6f74fba_RXN0-1133>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000050_PYRUVDEHYD-PWY/PYRUVDEHYD-PWY_SGD_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,6 +726,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57288_RXN0-1133>
 ] .
+
+<http://model.geneontology.org/e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000980>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -750,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,7 +790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -832,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -858,9 +863,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b0ab308f-a0c5-4cf5-9713-41ef1b49979a_RXN0-1132> , <http://model.geneontology.org/CHEBI_57540_RXN0-1132> ;
+                <http://model.geneontology.org/aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132> , <http://model.geneontology.org/CHEBI_57540_RXN0-1132> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d8c647d1-cea6-4607-bd42-94e0c0d1b0ed_RXN0-1132> , <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> ;
+                <http://model.geneontology.org/35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132> , <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN0-1132_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -868,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,23 +890,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_39c6aa90-6106-4db2-bc7b-58329166c953_RXN0-1134_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_57287_RXN0-1133_SGD_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,11 +923,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_d8c647d1-cea6-4607-bd42-94e0c0d1b0ed_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +935,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d8c647d1-cea6-4607-bd42-94e0c0d1b0ed_RXN0-1132>
+          <http://model.geneontology.org/35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_RXN0-1132>
@@ -953,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -990,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,11 +1017,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_39c6aa90-6106-4db2-bc7b-58329166c953_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1029,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/39c6aa90-6106-4db2-bc7b-58329166c953_RXN0-1134>
+          <http://model.geneontology.org/e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000050_PYRUVDEHYD-PWY/PYRUVDEHYD-PWY_SGD_PYRUVDEHYD-PWY>
@@ -1043,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1061,28 +1055,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/0365a5d1-47b0-4d3e-97d6-8c31fb9617ee_RXN0-1134>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1091,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1100,12 +1077,29 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000066_reaction_RXN0-1133_location_lociGO_0005829_null_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,23 +1126,12 @@
 <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_c3dd20ba-f045-4764-9d87-0a8f234bd0bc_RXN0-1133_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000066_reaction_RXN0-1134_location_lociGO_0005829_null_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1157,12 +1140,29 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15378_RXN0-1134_SGD_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1174,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/SAM-PWY-SAM-PWY.ttl
+++ b/models/SAM-PWY-SAM-PWY.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,12 +231,15 @@
           <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000002910>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_SAM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "S-adenosyl-L-methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,20 +344,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002910> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "S-adenosylmethionine synthetase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/SERDEG-PWY-SERDEG-PWY.ttl
+++ b/models/SERDEG-PWY-SERDEG-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -574,14 +574,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_28938_RXN-15127_SGD_SERDEG-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000066_reaction_RXN-15125_location_lociGO_0005829_null_SERDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
+                "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,14 +602,14 @@
           <http://model.geneontology.org/CHEBI_28938_RXN-15127>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000066_reaction_RXN-15125_location_lociGO_0005829_null_SERDEG-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_28938_RXN-15127_SGD_SERDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:SERDEG-PWY" ;
+                "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/SERSYN-PWY-SERSYN-PWY.ttl
+++ b/models/SERSYN-PWY-SERSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -901,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -979,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1047,7 +1047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1162,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/SO4ASSIM-PWY-SO4ASSIM-PWY.ttl
+++ b/models/SO4ASSIM-PWY-SO4ASSIM-PWY.ttl
@@ -3,19 +3,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_17359_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_17359_SULFITE-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,15 +143,15 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -160,11 +160,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,33 +212,49 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_SO4ASSIM-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_null_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
 ] .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003771> ;
@@ -247,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,15 +290,12 @@
           <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_SO4ASSIM-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -297,13 +310,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SO4ASSIM-PWYProtein65260> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SO4ASSIM-PWYProtein65256> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -319,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -327,19 +351,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_15378_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
+          <http://model.geneontology.org/SO4ASSIM-PWY/SO4ASSIM-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
@@ -351,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,11 +391,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_SO4ASSIM-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
+] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -383,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,19 +434,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
+          <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -422,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,19 +471,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_17359_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17359_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -453,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,11 +553,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,24 +565,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
+          <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/SO4ASSIM-PWY/SO4ASSIM-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_SO4ASSIM-PWY>
@@ -549,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -605,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -637,21 +678,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_null_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_null_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
 ] .
 
 <http://model.geneontology.org/1.8.4.8-RXN>
@@ -673,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "assimilatory sulfate reduction I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -701,21 +742,30 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
+        a       <http://identifiers.org/sgd/S000003898> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SO4ASSIM-PWY/SO4ASSIM-PWY>
+          <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_SO4ASSIM-PWY>
@@ -723,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,36 +845,45 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58339_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58339_1.8.4.8-RXN>
+] .
+
+<http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001926> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
@@ -836,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -881,16 +940,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000003898>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -898,7 +960,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -909,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -983,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,47 +1071,49 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_null_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SO4ASSIM-PWY/SO4ASSIM-PWY>
+          <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
+          <http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_17359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
@@ -1064,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1087,22 +1151,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_null_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
@@ -1114,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1153,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1163,11 +1242,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,7 +1254,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004020>
@@ -1187,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1217,36 +1296,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58339_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58339_1.8.4.8-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_null_SO4ASSIM-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
@@ -1261,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1281,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1305,19 +1386,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/SO4ASSIM-PWY/SO4ASSIM-PWY>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1326,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1357,12 +1438,15 @@
 <http://identifiers.org/sgd/S000001484>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1373,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1386,23 +1470,24 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_null_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
+          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
 ] .
+
+<http://identifiers.org/sgd/S000001926>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1412,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1450,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1458,19 +1543,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002411_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
@@ -1482,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1492,19 +1577,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -1518,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1536,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1549,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1557,19 +1642,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1578,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1612,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,11 +1705,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58343_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_15378_1.8.4.8-RXN_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,7 +1717,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
+          <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
@@ -1644,7 +1729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1653,22 +1738,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_null_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
 ] .
 
 <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
@@ -1683,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1695,10 +1778,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "sulfite reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component> , <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1708,19 +1793,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFITE-REDUCT-RXN> ;
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SO4ASSIM-PWY/SO4ASSIM-PWY>
+          <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_SO4ASSIM-PWY/SO4ASSIM-PWY_SGD_SO4ASSIM-PWY>
@@ -1728,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1739,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/SPHINGOLIPID-SYN-PWY-1-SPHINGOLIPID-SYN-PWY-1.ttl
+++ b/models/SPHINGOLIPID-SYN-PWY-1-SPHINGOLIPID-SYN-PWY-1.ttl
@@ -1,18 +1,18 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-581> ;
+          <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_64124_RXN3O-504>
 ] .
 
 <http://model.geneontology.org/YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,23 +30,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000066_reaction_RXN3O-4042_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
+          <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4042_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_RXN3O-328>
 ] .
 
 <http://model.geneontology.org/YMR272C-MONOMER_RXN3O-4042_controller>
@@ -56,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,25 +79,70 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DHS-PHOSPHATASE-RXN>
+          <http://model.geneontology.org/SGD_S000000995_CPLX3O-78_component>
 ] .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + NADP<sup>+</sup> &larr; 3-dehydrosphinganine + NADPH + H<SUP>+</SUP>' 'null' 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_RXN3O-1380_null_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-1380>
+] .
+
+<http://model.geneontology.org/SGD_S000000240_CPLX3O-383_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000240> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16749_RXN3O-581>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16749> ;
@@ -93,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -131,36 +191,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_15378_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-663>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829>
@@ -171,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -185,29 +245,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000066_reaction_RXN3O-458_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-458> ;
+          <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-458_location_lociGO_0005829>
+          <http://model.geneontology.org/59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN>
@@ -229,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,19 +340,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_FERROCYTOCHROME-B5_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-1380>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829>
@@ -305,7 +363,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,23 +414,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -366,36 +441,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_30616_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_30616_SPHINGANINE-KINASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -407,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,20 +509,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phytosphingosine + ATP &rarr; phytosphingosine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'phytosphingosine 1-phosphate + H<sub>2</sub>O &rarr; phytosphingosine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002413_RXN3O-504_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-504> ;
+          <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64795_RXN3O-504>
+          <http://model.geneontology.org/RXN3O-504>
 ] .
 
 <http://model.geneontology.org/RXN3O-504>
@@ -469,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,36 +579,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_31998_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_31998_RXN3O-328>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57817_SPHINGANINE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller>
@@ -541,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -554,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +661,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/23a8d877-aa5f-4a88-abb3-f7b609355520_CERAMIDASE-YEAST-RXN> ;
+                <http://model.geneontology.org/ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_10283_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -594,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,23 +679,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://identifiers.org/sgd/S000000995>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_15378_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_ca3c29b1-f17e-4569-a213-f2001e1f5459_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,27 +712,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002333_MONOMER3O-630_RXN3O-581_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_16749_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-630_RXN3O-581_controller>
+          <http://model.geneontology.org/CHEBI_16749_RXN3O-581>
 ] .
+
+<http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component>
+        a       <http://identifiers.org/sgd/S000004913> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -671,36 +749,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4042> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-4042>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002411_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
@@ -711,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -722,62 +800,69 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'sphinganine 1-phosphate + H<sub>2</sub>O &rarr; D-<i>erythro</i>-sphinganine + phosphate' 'null' 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_57939_DHS-PHOSPHATASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/MONOMER3O-630_RXN3O-581_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001487> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "IPC synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19845> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/SGD_S000001491_CPLX3O-78_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001491> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004885>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -787,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -822,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -850,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -887,39 +972,37 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000066_reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
+          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_16749_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002333_CPLX3O-383_RXN3O-663_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-680> ;
+          <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16749_RXN3O-680>
+          <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-458_location_lociGO_0005829>
@@ -930,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -969,19 +1052,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YOR171C-MONOMER_RXN3O-458_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_15378_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR171C-MONOMER_RXN3O-458_controller>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-458>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -990,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,22 +1084,44 @@
           <http://model.geneontology.org/YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-328> ;
+          <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_64124_RXN3O-1380>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002469> ;
@@ -1025,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1038,27 +1143,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'sphinganine 1-phosphate + H<sub>2</sub>O &rarr; D-<i>erythro</i>-sphinganine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_DHS-PHOSPHATASE-RXN_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_SPHINGANINE-KINASE-RXN>
@@ -1070,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1110,22 +1217,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000066_reaction_RXN3O-581_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_MONOMER3O-419_RXN3O-504_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-581> ;
+          <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-581_location_lociGO_0005829>
+          <http://model.geneontology.org/MONOMER3O-419_RXN3O-504_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002413_RXN3O-663_null_SPHINGOLIPID-SYN-PWY-1>
@@ -1133,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1144,35 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/62c5704f-91ef-4aba-85bf-bad5f88d7537_RXN3O-680>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1180,27 +1257,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002333_CPLX3O-78_RXN3O-328_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
+          <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-4042>
+          <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_5cd28352-b23b-4cb7-a58c-6a3a8850d170_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,19 +1313,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000001491_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57939_DHS-PHOSPHATASE-RXN>
+          <http://model.geneontology.org/SGD_S000001491_CPLX3O-78_component>
 ] .
 
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-1380>
@@ -1260,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1280,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,63 +1365,85 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000000240_CPLX3O-383_component_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
+] .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000066_reaction_RXN3O-663_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_RXN3O-663>
+          <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000004913_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_30616_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-458> ;
+          <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN3O-458>
+          <http://model.geneontology.org/YMR272C-MONOMER_RXN3O-4042_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
@@ -1356,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1373,15 +1472,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/62c5704f-91ef-4aba-85bf-bad5f88d7537_RXN3O-680> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
+                <http://model.geneontology.org/71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17815_RXN3O-680> , <http://model.geneontology.org/5cd28352-b23b-4cb7-a58c-6a3a8850d170_RXN3O-680> ;
+                <http://model.geneontology.org/CHEBI_17815_RXN3O-680> , <http://model.geneontology.org/966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1397,28 +1496,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_15377_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000066_reaction_RXN3O-1380_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-1380>
+          <http://model.geneontology.org/reaction_RXN3O-1380_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-4042>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1429,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1473,22 +1591,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000066_reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_17815_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_17815_RXN3O-680>
 ] .
 
 <http://model.geneontology.org/CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
@@ -1500,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,7 +1632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1540,19 +1656,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_43474_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN3O-504>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_57817_DHS-PHOSPHATASE-RXN>
@@ -1564,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1581,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1611,44 +1727,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000066_reaction_RXN3O-328_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-328> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-328_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_15378_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-328> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN3O-328>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_SPHINGANINE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -1656,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1667,18 +1785,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a very long chain fatty acyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1691,22 +1837,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (2'R)-2'-hydroxy-phytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; an inositol-phospho-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' 'null' 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002413_RXN3O-663_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-663>
+          <http://model.geneontology.org/00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -1714,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1739,38 +1883,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_6b263ce8-4934-4937-9a25-744bbcb74f07_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15379_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4042> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-4042>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6b263ce8-4934-4937-9a25-744bbcb74f07_RXN3O-4042>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + NADP<sup>+</sup> &larr; 3-dehydrosphinganine + NADPH + H<SUP>+</SUP>' 'null' 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_RXN3O-1380_null_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-1380>
+          <http://model.geneontology.org/CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -1778,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1793,13 +1935,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19929> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1810,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,83 +1971,86 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_DHS-PHOSPHATASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_17815_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-663> ;
+          <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_17815_RXN3O-581>
 ] .
+
+<http://identifiers.org/sgd/S000001491>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR272C-MONOMER_RXN3O-4042_controller>
+          <http://model.geneontology.org/CHEBI_31998_RXN3O-4042>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008117>
@@ -1905,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1916,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1927,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1938,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1960,22 +2116,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000066_reaction_RXN3O-1380_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_57817_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
+          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-1380_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57817_DHS-PHOSPHATASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_null_SPHINGOLIPID-SYN-PWY-1>
@@ -1983,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1993,45 +2147,69 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' 'null' 'a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_30616_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002413_RXN3O-680_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SPHINGANINE-KINASE-RXN>
+          <http://model.geneontology.org/RXN3O-680>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_62c5704f-91ef-4aba-85bf-bad5f88d7537_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-680> ;
+          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/62c5704f-91ef-4aba-85bf-bad5f88d7537_RXN3O-680>
+          <http://model.geneontology.org/CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000005978_CPLX3O-383_component_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_58299_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2042,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2057,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,56 +2243,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_0d247cd1-536f-48ea-834f-f4cb19028c6e_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phytosphingosine + ATP &rarr; phytosphingosine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'phytosphingosine 1-phosphate + H<sub>2</sub>O &rarr; phytosphingosine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002413_RXN3O-504_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-504>
+          <http://model.geneontology.org/CHEBI_456216_RXN3O-458>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0050291>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_null_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0050291>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,23 +2301,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller>
 ] .
-
-<http://model.geneontology.org/84531ebb-3569-4855-b78e-057302a433e2_RXN3O-663>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000387>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2167,22 +2315,20 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000066_reaction_RXN3O-328_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_FERRICYTOCHROME-B5_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-328> ;
+          <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-328_location_lociGO_0005829>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-1380>
 ] .
 
 <http://model.geneontology.org/RXN3O-4042>
@@ -2196,17 +2342,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15378_RXN3O-4042> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_31998_RXN3O-4042> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> , <http://model.geneontology.org/6b263ce8-4934-4937-9a25-744bbcb74f07_RXN3O-4042> ;
+                <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> , <http://model.geneontology.org/59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR272C-MONOMER_RXN3O-4042_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-581> ;
-        <http://purl.obolibrary.org/obo/RO_0002629>
-                <http://model.geneontology.org/RXN3O-581> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2223,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2236,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2258,51 +2402,42 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'sphinganine 1-phosphate &rarr; palmitaldehyde + <i>O</i>-phosphoethanolamine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_31998>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_23a8d877-aa5f-4a88-abb3-f7b609355520_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_16749_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-581> ;
+          <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16749_RXN3O-581>
+          <http://model.geneontology.org/YKR053C-MONOMER_RXN3O-504_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-1380>
@@ -2314,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2327,19 +2462,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15379_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002411_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
+          <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-4042>
+          <http://model.geneontology.org/CERAMIDASE-YEAST-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -2347,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2355,19 +2490,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000004913_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_DHS-PHOSPHATASE-RXN>
+          <http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-1380_location_lociGO_0005829>
@@ -2381,20 +2516,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000003670> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "PHS-1-P phsophatase / DHS-1-P phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2405,39 +2540,53 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_57527_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_84531ebb-3569-4855-b78e-057302a433e2_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/84531ebb-3569-4855-b78e-057302a433e2_RXN3O-663>
+          <http://model.geneontology.org/CHEBI_57527_RXN3O-663>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_64124_RXN3O-328>
         a       <http://purl.obolibrary.org/obo/CHEBI_64124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2448,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2459,14 +2608,19 @@
 <http://identifiers.org/sgd/S000006008>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000005978>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ceramide synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001491_CPLX3O-78_component> , <http://model.geneontology.org/SGD_S000000995_CPLX3O-78_component> , <http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2475,20 +2629,22 @@
                 "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a phytoceramide + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; a (2'R)-2'-hydroxy-phytoceramide + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'a (2'R)-2'-hydroxy-phytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; an inositol-phospho-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_64124_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002413_RXN3O-581_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-458> ;
+          <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64124_RXN3O-458>
+          <http://model.geneontology.org/RXN3O-581>
 ] .
 
 <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1>
@@ -2500,7 +2656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sphingolipid biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2508,64 +2664,30 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.obolibrary.org/obo/CHEBI_64124>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002333_YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ca3c29b1-f17e-4569-a213-f2001e1f5459_RXN3O-663>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_64124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_17815_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_RXN3O-4042>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19487> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16749_RXN3O-680>
         a       <http://purl.obolibrary.org/obo/CHEBI_16749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2576,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2584,38 +2706,66 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_15377_RXN3O-4042>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19487> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15378_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64124_RXN3O-1380>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-1380>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002411_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
+          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
+          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002411_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -2623,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2634,7 +2784,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2652,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2662,19 +2823,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680>
 ] .
 
 <http://model.geneontology.org/CHEBI_57939_DHS-PHOSPHATASE-RXN>
@@ -2686,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2700,7 +2861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2728,36 +2889,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002629_RXN3O-581_null_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000066_reaction_RXN3O-504_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64124_RXN3O-504>
+          <http://model.geneontology.org/reaction_RXN3O-504_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-663>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2768,9 +2931,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ca3c29b1-f17e-4569-a213-f2001e1f5459_RXN3O-663> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
+                <http://model.geneontology.org/d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/84531ebb-3569-4855-b78e-057302a433e2_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
+                <http://model.geneontology.org/c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2778,7 +2941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2786,69 +2949,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002333_CPLX3O-78_RXN3O-328_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller>
+          <http://model.geneontology.org/CHEBI_64124_RXN3O-328>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'sphinganine 1-phosphate + H<sub>2</sub>O &rarr; D-<i>erythro</i>-sphinganine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_DHS-PHOSPHATASE-RXN_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_456216_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN>
+          <http://model.geneontology.org/CHEBI_456216_SPHINGANINE-KINASE-RXN>
 ] .
-
-<http://model.geneontology.org/36c08586-ccc5-43c6-8c47-11dd7c869ddc_RXN3O-581>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2858,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2873,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2886,11 +3019,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_58299_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58299_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_10283>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2900,7 +3050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2908,38 +3058,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000066_reaction_RXN3O-663_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-663> ;
+          <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829>
+          <http://model.geneontology.org/5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
@@ -2951,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2968,7 +3116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2977,22 +3125,20 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a phytoceramide + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; a (2'R)-2'-hydroxy-phytoceramide + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'a (2'R)-2'-hydroxy-phytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; an inositol-phospho-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002413_RXN3O-581_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_FERROCYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-581>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/CHEBI_64124_RXN3O-1380>
@@ -3004,7 +3150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3014,19 +3160,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15378_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
+          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-1380>
+          <http://model.geneontology.org/MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000066_reaction_RXN3O-1380_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1>
@@ -3034,7 +3180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3045,7 +3191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3060,7 +3206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3073,18 +3219,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3092,64 +3255,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002333_YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
+          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57817_SPHINGANINE-KINASE-RXN>
+          <http://model.geneontology.org/YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_17815_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-680> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17815_RXN3O-680>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_6b263ce8-4934-4937-9a25-744bbcb74f07_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-504> ;
+          <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_64795_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-458> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_64795_RXN3O-458>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002333_YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -3157,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3174,7 +3326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3190,44 +3342,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/6b263ce8-4934-4937-9a25-744bbcb74f07_RXN3O-4042>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-328> ;
+          <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64124_RXN3O-328>
+          <http://model.geneontology.org/YDR297W-MONOMER_RXN3O-1380_controller>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3241,7 +3376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3249,19 +3384,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/SPHINGANINE-KINASE-RXN>
@@ -3283,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3296,7 +3431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3307,7 +3442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3332,7 +3467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3345,7 +3480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3360,7 +3495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3369,20 +3504,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phytosphingosine 1-phosphate + H<sub>2</sub>O &rarr; phytosphingosine + phosphate' 'null' 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_0d247cd1-536f-48ea-834f-f4cb19028c6e_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-581> ;
+          <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0d247cd1-536f-48ea-834f-f4cb19028c6e_RXN3O-581>
+          <http://model.geneontology.org/RXN3O-328>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-504>
@@ -3394,7 +3531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3407,27 +3544,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' 'null' 'a phytoceramide + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; a (2'R)-2'-hydroxy-phytoceramide + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002413_RXN3O-4042_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
+          <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_31998_RXN3O-4042>
+          <http://model.geneontology.org/RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -3435,7 +3574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3446,38 +3585,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_62c5704f-91ef-4aba-85bf-bad5f88d7537_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_57817_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57817_DHS-PHOSPHATASE-RXN>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-458>
@@ -3489,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3505,7 +3633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3513,27 +3641,30 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002333_CPLX3O-383_RXN3O-663_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller>
+          <http://model.geneontology.org/d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663>
 ] .
+
+<http://identifiers.org/sgd/S000003670>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3544,7 +3675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3555,19 +3686,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_15378_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-458>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000066_reaction_RXN3O-680_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1>
@@ -3575,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3586,7 +3717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3595,71 +3726,60 @@
 <http://identifiers.org/sgd/S000002469>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_FERRICYTOCHROME-B5_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-1380>
-] .
-
 <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_ed90b9d5-67a2-44eb-8052-8f77498a31c9_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1380> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-1380>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+] .
 
 <http://identifiers.org/sgd/S000002705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3670,7 +3790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3678,27 +3798,27 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002333_YDR072C-MONOMER_RXN3O-680_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3709,7 +3829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3717,11 +3837,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_23a8d877-aa5f-4a88-abb3-f7b609355520_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3729,49 +3849,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CERAMIDASE-YEAST-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/23a8d877-aa5f-4a88-abb3-f7b609355520_CERAMIDASE-YEAST-RXN>
+          <http://model.geneontology.org/ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_MONOMER3O-419_RXN3O-504_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_15377_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-419_RXN3O-504_controller>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-504>
 ] .
-
-<http://model.geneontology.org/5cd28352-b23b-4cb7-a58c-6a3a8850d170_RXN3O-680>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3779,55 +3882,53 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002411_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CERAMIDASE-YEAST-RXN>
+          <http://model.geneontology.org/1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'sphinganine 1-phosphate &rarr; palmitaldehyde + <i>O</i>-phosphoethanolamine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-KINASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKR053C-MONOMER_RXN3O-504_controller>
+          <http://model.geneontology.org/CHEBI_64795_RXN3O-504>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -3835,7 +3936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3845,22 +3946,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' 'null' 'a phytoceramide + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; a (2'R)-2'-hydroxy-phytoceramide + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002413_RXN3O-4042_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-4042>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-328>
 ] .
 
 <http://model.geneontology.org/CHEBI_57817_RXN3O-1380>
@@ -3872,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3885,7 +3984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3903,7 +4002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3916,7 +4015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3927,7 +4026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3935,19 +4034,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000000240_CPLX3O-383_component_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/SGD_S000000240_CPLX3O-383_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002333_YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000066_reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1>
@@ -3955,7 +4071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3966,7 +4082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3974,36 +4090,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002333_MONOMER3O-630_RXN3O-581_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_57527_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-663> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_RXN3O-663>
+          <http://model.geneontology.org/MONOMER3O-630_RXN3O-581_controller>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -4013,22 +4129,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Entity Regulation Rule 3. The relation 'a phytoceramide + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; a (2'R)-2'-hydroxy-phytoceramide + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'a (2'R)-2'-hydroxy-phytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; an inositol-phospho-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is the enabler of reaction 2." ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002629_RXN3O-581_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002629> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-581>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/DHS-PHOSPHATASE-RXN>
@@ -4050,7 +4164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4063,7 +4177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4071,6 +4185,15 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000005978_CPLX3O-383_component>
+        a       <http://identifiers.org/sgd/S000005978> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17600> ;
@@ -4081,7 +4204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4091,19 +4214,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
+          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-1380>
+          <http://model.geneontology.org/YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
@@ -4112,38 +4235,43 @@
 <http://purl.obolibrary.org/obo/CHEBI_64795>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_15378_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SPHINGANINE-KINASE-RXN>
-] .
+<http://identifiers.org/sgd/S000004913>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_5cd28352-b23b-4cb7-a58c-6a3a8850d170_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000066_reaction_RXN3O-680_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5cd28352-b23b-4cb7-a58c-6a3a8850d170_RXN3O-680>
+          <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -4151,7 +4279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4165,7 +4293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4175,22 +4303,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000066_reaction_RXN3O-504_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YLR260W-MONOMER_RXN3O-458_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-504> ;
+          <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-504_location_lociGO_0005829>
+          <http://model.geneontology.org/YLR260W-MONOMER_RXN3O-458_controller>
 ] .
 
 <http://model.geneontology.org/YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller>
@@ -4200,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4209,13 +4335,13 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MONOMER3O-419_RXN3O-504_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003670> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "PHS-1-P phsophatase / DHS-1-P phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4223,42 +4349,68 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000001491_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_ed90b9d5-67a2-44eb-8052-8f77498a31c9_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-328_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-328> ;
+          <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ed90b9d5-67a2-44eb-8052-8f77498a31c9_RXN3O-328>
+          <http://model.geneontology.org/RXN3O-328>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000066_reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+          <http://model.geneontology.org/reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4268,7 +4420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4279,7 +4431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4294,7 +4446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4307,27 +4459,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_17815_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17815_RXN3O-581>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -4335,47 +4498,50 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58190>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_FERROCYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4042> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-4042>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_58299_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58299_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+          <http://model.geneontology.org/CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -4383,7 +4549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4398,7 +4564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4411,44 +4577,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000066_reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller>
+          <http://model.geneontology.org/reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -4456,7 +4624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4471,7 +4639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4483,22 +4651,20 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' 'null' 'a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002413_RXN3O-680_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_15378_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-680>
+          <http://model.geneontology.org/CHEBI_15378_RXN3O-663>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -4506,7 +4672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4517,7 +4683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4530,7 +4696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4547,7 +4713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4567,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4576,20 +4742,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000066_reaction_RXN3O-458_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN3O-458>
+          <http://model.geneontology.org/reaction_RXN3O-458_location_lociGO_0005829>
 ] .
 
 <http://identifiers.org/sgd/S000004250>
@@ -4600,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4611,7 +4779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4619,37 +4787,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_57817_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR297W-MONOMER_RXN3O-1380_controller>
+          <http://model.geneontology.org/CHEBI_57817_RXN3O-1380>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002333_YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller>
+          <http://model.geneontology.org/reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/SGD_S000000995_CPLX3O-78_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000995> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4657,7 +4836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4668,23 +4847,6 @@
           <http://model.geneontology.org/CHEBI_10283_CERAMIDASE-YEAST-RXN>
 ] .
 
-<http://model.geneontology.org/ed90b9d5-67a2-44eb-8052-8f77498a31c9_RXN3O-328>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a very long chain fatty acyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YLR260W-MONOMER_RXN3O-458_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004250> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4692,7 +4854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4712,7 +4874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4725,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4733,19 +4895,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-4042>
@@ -4757,7 +4919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4769,22 +4931,20 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phytosphingosine 1-phosphate + H<sub>2</sub>O &rarr; phytosphingosine + phosphate' 'null' 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_43474_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-504> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-328>
+          <http://model.geneontology.org/CHEBI_43474_RXN3O-504>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_DHS-PHOSPHATASE-RXN>
@@ -4796,7 +4956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4807,21 +4967,38 @@
 <http://identifiers.org/sgd/S000005697>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_31998_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
+          <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_31998_RXN3O-328>
 ] .
 
 <http://model.geneontology.org/RXN3O-581>
@@ -4833,9 +5010,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-581_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0d247cd1-536f-48ea-834f-f4cb19028c6e_RXN3O-581> , <http://model.geneontology.org/CHEBI_16749_RXN3O-581> ;
+                <http://model.geneontology.org/CHEBI_16749_RXN3O-581> , <http://model.geneontology.org/00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/36c08586-ccc5-43c6-8c47-11dd7c869ddc_RXN3O-581> ;
+                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-630_RXN3O-581_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -4843,7 +5020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4860,7 +5037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4880,7 +5057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4888,34 +5065,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_84531ebb-3569-4855-b78e-057302a433e2_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://identifiers.org/sgd/S000000240>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000066_reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000005978_CPLX3O-383_component_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005978_CPLX3O-383_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002411_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DHS-PHOSPHATASE-RXN>
@@ -4927,7 +5111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4937,37 +5121,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002411_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+          <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a (2'R)-2'-hydroxy-phytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; an inositol-phospho-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' 'null' 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_ca3c29b1-f17e-4569-a213-f2001e1f5459_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002413_RXN3O-663_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-663> ;
+          <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ca3c29b1-f17e-4569-a213-f2001e1f5459_RXN3O-663>
+          <http://model.geneontology.org/RXN3O-663>
 ] .
+
+<http://model.geneontology.org/59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57527>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4977,19 +5180,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-458> ;
+          <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_15377_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -4997,44 +5200,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/0d247cd1-536f-48ea-834f-f4cb19028c6e_RXN3O-581>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'sphinganine 1-phosphate + H<sub>2</sub>O &rarr; D-<i>erythro</i>-sphinganine + phosphate' 'null' 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_57817_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
+          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57817_RXN3O-1380>
+          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YLR260W-MONOMER_RXN3O-458_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -5042,7 +5230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5053,55 +5241,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_36c08586-ccc5-43c6-8c47-11dd7c869ddc_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_456216_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000066_reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SPHINGANINE-KINASE-RXN>
+          <http://model.geneontology.org/reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002333_YDR072C-MONOMER_RXN3O-680_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_16749_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller>
+          <http://model.geneontology.org/CHEBI_16749_RXN3O-680>
 ] .
 
 <http://model.geneontology.org/reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829>
@@ -5114,7 +5293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5131,7 +5310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5139,43 +5318,60 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_15377_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YOR171C-MONOMER_RXN3O-458_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-504> ;
+          <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-504>
+          <http://model.geneontology.org/YOR171C-MONOMER_RXN3O-458_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -5183,7 +5379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5198,7 +5394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5207,20 +5403,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'phytosphingosine + ATP &rarr; phytosphingosine 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-458_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-328> ;
+          <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN3O-328>
+          <http://model.geneontology.org/RXN3O-458>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
@@ -5231,7 +5429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5256,7 +5454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5269,7 +5467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5287,7 +5485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5300,27 +5498,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_36c08586-ccc5-43c6-8c47-11dd7c869ddc_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000066_reaction_RXN3O-581_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36c08586-ccc5-43c6-8c47-11dd7c869ddc_RXN3O-581>
+          <http://model.geneontology.org/reaction_RXN3O-581_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_57817_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -5328,7 +5528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5339,7 +5539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5349,37 +5549,39 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000066_reaction_RXN3O-4042_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-4042>
+          <http://model.geneontology.org/reaction_RXN3O-4042_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002333_YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-458_null_SPHINGOLIPID-SYN-PWY-1>
@@ -5387,7 +5589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5402,7 +5604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5412,46 +5614,50 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_DHS-PHOSPHATASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15377_DHS-PHOSPHATASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000066_reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+          <http://model.geneontology.org/reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller>
-        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "inositol phosphorylceramide mannosyltransferase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005978_CPLX3O-383_component> , <http://model.geneontology.org/SGD_S000000240_CPLX3O-383_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5464,7 +5670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5472,19 +5678,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-680> ;
+          <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/CHEBI_58189_RXN3O-663>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -5492,35 +5698,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/23a8d877-aa5f-4a88-abb3-f7b609355520_CERAMIDASE-YEAST-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000066_reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5528,19 +5717,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_64795_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_30616_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64795_RXN3O-458>
+          <http://model.geneontology.org/CHEBI_30616_RXN3O-458>
 ] .
 
 <http://identifiers.org/sgd/S000000469>
@@ -5549,36 +5738,25 @@
 <http://model.geneontology.org/reaction_RXN3O-504_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://purl.obolibrary.org/obo/CHEBI_58299>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
+          <http://model.geneontology.org/c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58299>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-458>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -5589,7 +5767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5604,7 +5782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5612,53 +5790,60 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-328_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_FERROCYTOCHROME-B5_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-328>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-1380>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000066_reaction_RXN3O-680_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-680> ;
+          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_64124_RXN3O-458>
@@ -5670,7 +5855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5687,7 +5872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5704,16 +5889,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19650> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/RO_0002629>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-1380>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -5724,7 +5906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5734,19 +5916,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YLR260W-MONOMER_RXN3O-458_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_64124_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-458> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR260W-MONOMER_RXN3O-458_controller>
+          <http://model.geneontology.org/CHEBI_64124_RXN3O-458>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -5758,7 +5940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5778,7 +5960,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-328_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_64124_RXN3O-328> , <http://model.geneontology.org/ed90b9d5-67a2-44eb-8052-8f77498a31c9_RXN3O-328> ;
+                <http://model.geneontology.org/1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328> , <http://model.geneontology.org/CHEBI_64124_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_RXN3O-328> , <http://model.geneontology.org/CHEBI_57287_RXN3O-328> , <http://model.geneontology.org/CHEBI_31998_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5790,7 +5972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5799,22 +5981,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'phytosphingosine + ATP &rarr; phytosphingosine 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-458_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_15377_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-1380> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-458>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-1380>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -5822,7 +6002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5833,29 +6013,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000066_reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829_null_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN> ;
+          <http://model.geneontology.org/SPHINGANINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -5863,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5874,7 +6052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5889,7 +6067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/SUCUTIL-PWY-2-SUCUTIL-PWY-2.ttl
+++ b/models/SUCUTIL-PWY-2-SUCUTIL-PWY-2.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sucrose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/TCA-EUK-PWY-TCA-EUK-PWY.ttl
+++ b/models/TCA-EUK-PWY-TCA-EUK-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17,19 +17,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
+          <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
 <http://identifiers.org/sgd/S000006205>
@@ -37,29 +37,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
+          <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
 ] .
 
 <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "peroxisome malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,14 +69,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://identifiers.org/sgd/S000005668>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component>
+        a       <http://identifiers.org/sgd/S000003964> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -83,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,21 +126,58 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000001631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_null_TCA-EUK-PWY>
@@ -134,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -168,19 +219,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -192,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,19 +259,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16810_2OXOGLUTARATEDEH-RXN>
 ] .
 
 <http://model.geneontology.org/FUMHYDR-RXN>
@@ -242,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,36 +323,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57292_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57292_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+          <http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY>
@@ -309,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "TCA cycle, aerobic respiration - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -344,13 +406,15 @@
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
 <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "NAD-dependent isocitrate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component> , <http://model.geneontology.org/SGD_S000004982_CPLX3O-679_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,19 +439,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30616_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+          <http://model.geneontology.org/CHEBI_30616_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY>
@@ -395,29 +459,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15377_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_15377_FUMHYDR-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_30031>
@@ -432,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,6 +528,23 @@
           <http://model.geneontology.org/CITSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_CITSYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
@@ -477,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -503,13 +582,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYProtein36388> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component>
+        a       <http://identifiers.org/sgd/S000003476> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -519,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -527,36 +624,56 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30031_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30031_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
+] .
+
+<http://identifiers.org/sgd/S000004982>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY>
@@ -564,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,6 +706,9 @@
 
 <http://model.geneontology.org/reaction_FUMHYDR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://identifiers.org/sgd/S000001387>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008177> ;
@@ -609,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,19 +739,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_FUMHYDR-RXN>
+          <http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY>
@@ -639,11 +759,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001568>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -654,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,36 +900,50 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_TCA-EUK-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_null_TCA-EUK-PWY>
@@ -814,14 +951,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component>
+        a       <http://identifiers.org/sgd/S000005668> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001387> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -829,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -886,20 +1041,39 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
@@ -911,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,19 +1095,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_null_TCA-EUK-PWY>
@@ -941,9 +1115,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -953,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -984,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,29 +1216,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/CHEBI_57287_2OXOGLUTARATEDEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
@@ -1065,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,13 +1276,15 @@
 ] .
 
 <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "KGDC" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component> , <http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-33_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1112,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1120,19 +1305,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_TCA-EUK-PWY>
@@ -1140,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1151,29 +1336,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY>
@@ -1181,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1192,44 +1375,42 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57287_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57287_SUCCCOASYN-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1240,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,29 +1437,62 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005486> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_ACONITATEDEHYDR-RXN_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_null_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "mitochondrial malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,43 +1500,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_null_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_ACONITATEDEHYDR-RXN_SGD_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_29806_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_29806_FUMHYDR-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008177>
@@ -1337,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,19 +1570,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/SUCCCOASYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_43474_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
@@ -1401,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1412,19 +1621,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004108>
@@ -1433,30 +1642,13 @@
 <http://identifiers.org/sgd/S000005284>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36437> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_CITSYN-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1467,12 +1659,29 @@
           <http://model.geneontology.org/CHEBI_16452_CITSYN-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36437> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1487,69 +1696,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36120> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30616_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36329> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ACONITATEHYDR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003994> ;
@@ -1572,7 +1725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,12 +1733,98 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30616_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36329> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1612,20 +1851,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30616_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CITSYN-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004295>
@@ -1643,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1659,7 +1900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1678,19 +1919,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15377_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FUMHYDR-RXN>
+          <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_TCA-EUK-PWY>
@@ -1698,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1713,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,12 +1962,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000001624>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1740,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1751,59 +1995,64 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
+          <http://model.geneontology.org/CITSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://identifiers.org/sgd/S000003964>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000006183>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
 ] .
 
 <http://model.geneontology.org/reaction_CITSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://purl.obolibrary.org/obo/CHEBI_29806>
+<http://purl.obolibrary.org/obo/GO_0004736>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004736>
+<http://purl.obolibrary.org/obo/CHEBI_29806>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1812,7 +2061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1832,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1855,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1868,7 +2117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1876,27 +2125,58 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_null_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886>
+] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
+        a       <http://identifiers.org/sgd/S000001568> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57287_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1907,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1942,19 +2222,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1963,7 +2243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,6 +2254,23 @@
           <http://model.geneontology.org/YNR001C-MONOMER_CITSYN-RXN_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
+
 <http://model.geneontology.org/reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886>
         a       <http://purl.obolibrary.org/obo/GO_0005886> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
@@ -1982,11 +2279,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_2OXOGLUTARATEDEH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_ACONITATEDEHYDR-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,19 +2313,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
+          <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16947_CITSYN-RXN>
@@ -2023,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2036,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2047,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2055,19 +2369,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
+          <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_TCA-EUK-PWY>
@@ -2075,7 +2389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2096,7 +2410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2111,7 +2425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2124,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2132,6 +2446,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_17544>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17544> ;
@@ -2142,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2155,7 +2480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2170,7 +2495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2183,11 +2508,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001631>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43474_SUCCCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -2198,7 +2526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2215,7 +2543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2231,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2239,29 +2567,48 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_456216_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "succinyl-CoA ligase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component> , <http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2272,12 +2619,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_16947>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004982_CPLX3O-679_component>
+        a       <http://identifiers.org/sgd/S000004982> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2285,19 +2652,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_null_TCA-EUK-PWY>
@@ -2305,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2317,7 +2684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2337,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2354,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2364,19 +2731,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/FUMHYDR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_null_TCA-EUK-PWY>
@@ -2384,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2392,19 +2759,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57287_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
@@ -2416,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2424,13 +2791,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003581> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,6 +2817,9 @@
           <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
 ] .
 
+<http://identifiers.org/sgd/S000003476>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2450,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2460,19 +2839,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_29806_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29806_FUMHYDR-RXN>
+          <http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
 ] .
 
 <http://model.geneontology.org/CITSYN-RXN>
@@ -2494,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2517,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2533,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2544,7 +2923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2555,27 +2934,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
+          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY>
@@ -2583,7 +2971,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2591,19 +2990,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
+          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_CITSYN-RXN>
@@ -2615,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2623,13 +3022,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2640,14 +3050,25 @@
           <http://model.geneontology.org/ACONITATEDEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000001876_CPLX3O-33_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "cytosolic malate dehydrogenase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2655,21 +3076,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_TCA-EUK-PWY>
@@ -2677,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2688,7 +3120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2703,7 +3135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2711,21 +3143,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005662> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
 <http://model.geneontology.org/SUCCCOASYN-RXN>
@@ -2747,7 +3188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2755,19 +3196,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://identifiers.org/sgd/S000003736>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003736>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2775,7 +3216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,12 +3227,29 @@
           <http://model.geneontology.org/YPR001W-MONOMER_CITSYN-RXN_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2799,11 +3257,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_2OXOGLUTARATEDEH-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2819,7 +3294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2830,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2838,19 +3313,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_null_TCA-EUK-PWY>
@@ -2858,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2869,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2894,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2904,48 +3379,59 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
+          <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886>
+          <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "SDH" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component> , <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2958,7 +3444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2969,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2982,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2998,19 +3484,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
+          <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY>
@@ -3018,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3045,19 +3531,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/SGD_S000004982_CPLX3O-679_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57292_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57292_SUCCCOASYN-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -3068,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3079,7 +3582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3090,7 +3593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3101,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3112,19 +3615,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
@@ -3136,7 +3639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3152,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3166,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3174,19 +3677,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY>
@@ -3194,7 +3697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3205,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3233,7 +3736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3246,7 +3749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3261,7 +3764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3270,37 +3773,39 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_43474_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
+          <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_TCA-EUK-PWY>
@@ -3308,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3319,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3330,7 +3835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3354,30 +3859,34 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
+          <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "minor succinate dehydrogenase (ubiquinone)" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component> , <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3387,21 +3896,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CITSYN-RXN>
+          <http://model.geneontology.org/reaction_FUMHYDR-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15377_FUMHYDR-RXN_SGD_TCA-EUK-PWY>
@@ -3409,7 +3918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3424,7 +3933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3441,7 +3950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3457,7 +3966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3468,12 +3977,29 @@
           <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3486,7 +4012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3499,7 +4025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3507,19 +4033,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
@@ -3531,13 +4057,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36533> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000002585>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000003964> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16383_ACONITATEDEHYDR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16383> ;
@@ -3548,7 +4086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3561,30 +4099,42 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CITSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002555>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3594,7 +4144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3605,6 +4155,23 @@
           <http://model.geneontology.org/ACONITATEDEHYDR-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+] .
+
 <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006183> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3612,7 +4179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3623,12 +4190,43 @@
 <http://purl.obolibrary.org/obo/CHEBI_15562>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002555> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_null_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3640,7 +4238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3651,6 +4249,17 @@
           <http://model.geneontology.org/CHEBI_16383_ACONITATEDEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -3659,7 +4268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3684,7 +4293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3701,7 +4310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3714,7 +4323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3728,40 +4337,63 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
+          <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000005486>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3769,7 +4401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3785,7 +4417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3796,7 +4428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3804,20 +4436,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+          <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_2OXOGLUTARATEDEH-RXN>
+          <http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-690_SUCCCOASYN-RXN_controller>
+] .
+
+<http://identifiers.org/sgd/S000003581>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004295> ;
@@ -3826,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3841,20 +4493,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
+          <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57292>
@@ -3869,7 +4523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3883,7 +4537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3899,7 +4553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3910,44 +4564,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+          <http://model.geneontology.org/reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_456216_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_TCA-EUK-PWY>
@@ -3955,7 +4611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3970,7 +4626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3978,24 +4634,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000001624> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MALATE-DEH-RXN>
+          <http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002236>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15562_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
@@ -4007,7 +4686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4020,39 +4699,42 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_30031_SUCCCOASYN-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FUMHYDR-RXN>
+          <http://model.geneontology.org/CHEBI_30031_SUCCCOASYN-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000005662>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN> ;
+          <http://model.geneontology.org/FUMHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+          <http://model.geneontology.org/CHEBI_15589_FUMHYDR-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY>
@@ -4060,7 +4742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4072,7 +4754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4081,6 +4763,23 @@
           <http://model.geneontology.org/CITSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_2OXOGLUTARATEDEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
@@ -4092,7 +4791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4105,7 +4804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4120,7 +4819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4130,19 +4829,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+          <http://model.geneontology.org/CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY>
@@ -4150,7 +4849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4158,19 +4857,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+          <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16383>
@@ -4178,57 +4877,70 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TCA-EUK-PWY/TCA-EUK-PWY>
+          <http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+          <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -4243,7 +4955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4257,7 +4969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4268,23 +4980,30 @@
           <http://model.geneontology.org/YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller>
 ] .
 
+<http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002236> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_null_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FUMHYDR-RXN> ;
+          <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_FUMHYDR-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-33_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY>
@@ -4292,7 +5011,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4303,18 +5033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4325,7 +5044,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_TCA-EUK-PWY/TCA-EUK-PWY_SGD_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4336,7 +5066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/THIOREDOX-PWY-THIOREDOX-PWY.ttl
+++ b/models/THIOREDOX-PWY-THIOREDOX-PWY.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thioredoxin pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/THREOCAT2-PWY-THREOCAT2-PWY.ttl
+++ b/models/THREOCAT2-PWY-THREOCAT2-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,7 +975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1294,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1308,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1338,7 +1338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,7 +1354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1531,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1579,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1629,7 +1629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1697,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1765,7 +1765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1846,7 +1846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,7 +1905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1941,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1953,7 +1953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1998,7 +1998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2049,7 +2049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2135,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2147,7 +2147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2190,7 +2190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2226,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2261,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2274,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,7 +2316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2336,7 +2336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2349,7 +2349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2361,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,7 +2377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2389,7 +2389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2420,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2434,7 +2434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2468,7 +2468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2488,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2502,7 +2502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2521,7 +2521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2553,7 +2553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2604,7 +2604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2624,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2641,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2654,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2668,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2705,7 +2705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2728,7 +2728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,7 +2756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2770,7 +2770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2798,7 +2798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2835,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2851,7 +2851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2867,7 +2867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2879,7 +2879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2905,7 +2905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2918,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2932,7 +2932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,7 +2948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2959,7 +2959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2974,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2988,7 +2988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3021,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3050,7 +3050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3070,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "threonine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3083,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3094,7 +3094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3106,7 +3106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3122,7 +3122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3133,7 +3133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3160,7 +3160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3174,7 +3174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3194,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3211,7 +3211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3230,7 +3230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3248,7 +3248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3262,7 +3262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3280,7 +3280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3297,7 +3297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3314,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,7 +3330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3346,7 +3346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3361,7 +3361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3378,7 +3378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3394,7 +3394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3409,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3425,7 +3425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3441,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3456,7 +3456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3475,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3489,7 +3489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3505,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3516,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3531,7 +3531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3548,7 +3548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3565,7 +3565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3581,7 +3581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3592,7 +3592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3604,7 +3604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3623,7 +3623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3655,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3669,7 +3669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,7 +3689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3705,7 +3705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3719,7 +3719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3734,7 +3734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3750,7 +3750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3761,7 +3761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3776,7 +3776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3789,7 +3789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3801,7 +3801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3838,7 +3838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3873,7 +3873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3887,7 +3887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3904,7 +3904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +3926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3949,7 +3949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3966,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3980,7 +3980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4003,7 +4003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4017,7 +4017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4033,7 +4033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4045,7 +4045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4065,7 +4065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/THRESYN-PWY-THRESYN-PWY.ttl
+++ b/models/THRESYN-PWY-THRESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,24 +26,13 @@
           <http://model.geneontology.org/CHEBI_15377_THRESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_null_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002411_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,6 +43,17 @@
           <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_null_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -63,7 +63,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -191,13 +191,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule66080> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_THRESYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOSERKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004072> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -218,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,41 +254,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_THRESYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -867,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1063,7 +1063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1175,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1284,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,7 +1336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,7 +1494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1536,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1549,7 +1549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1578,7 +1578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1699,7 +1699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1799,7 +1799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1815,7 +1815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1859,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1871,7 +1871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1913,7 +1913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1943,7 +1943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,12 +1977,12 @@
 <http://identifiers.org/sgd/S000000649>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002411_HOMOSERDEHYDROG-RXN_SGD_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +1994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,12 +2005,12 @@
           <http://model.geneontology.org/THRESYN-PWY/THRESYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002411_HOMOSERDEHYDROG-RXN_SGD_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2039,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2104,7 +2104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,7 +2120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2132,7 +2132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2159,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2215,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2229,7 +2229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2248,7 +2248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2264,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,7 +2320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2340,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2353,7 +2353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2365,7 +2365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2412,7 +2412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/TREDEG-YEAST-PWY-TREDEG-YEAST-PWY.ttl
+++ b/models/TREDEG-YEAST-PWY-TREDEG-YEAST-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/TRESYN-PWY-TRESYN-PWY.ttl
+++ b/models/TRESYN-PWY-TRESYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -553,7 +553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,13 +753,24 @@
           <http://model.geneontology.org/YDR074W-MONOMER_TREHALOSEPHOSPHA-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_null_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58223_TREHALOSE6PSYN-RXN_SGD_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,24 +781,13 @@
           <http://model.geneontology.org/CHEBI_58223_TREHALOSE6PSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_null_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000050_TRESYN-PWY/TRESYN-PWY_SGD_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/TRIGLSYN-PWY-TRIGLSYN-PWY.ttl
+++ b/models/TRIGLSYN-PWY-TRIGLSYN-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diacylglycerol and triacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,28 +791,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56268> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_17984_RXN-1623>
-        a       <http://purl.obolibrary.org/obo/CHEBI_17984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an acyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56374> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -825,11 +808,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56312> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_17984_RXN-1623>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an acyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56374> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,13 +1142,16 @@
           <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
 ] .
 
+<http://identifiers.org/sgd/S000001775>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_17815_RXN-12959_SGD_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1195,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1288,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1301,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1313,13 +1316,13 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/MONOMER3O-4105_RXN-1381_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000000107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1385,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1440,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1473,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1541,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1653,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,7 +1685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1694,13 +1697,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-4095_RXN-1381_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1714,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1750,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1765,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1778,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1793,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1810,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1827,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,7 +1847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1877,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1888,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1899,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1920,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1933,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1948,13 +1951,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56477> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000000107>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1964,7 +1970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1981,7 +1987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,7 +2004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2032,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2049,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,7 +2071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2082,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2118,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2180,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2195,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2246,7 +2252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2266,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2283,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2296,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2310,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2321,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2334,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2348,7 +2354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2368,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2382,7 +2388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2399,7 +2405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2426,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2437,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2448,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2463,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2476,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2491,7 +2497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2507,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2521,7 +2527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2539,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2569,7 +2575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2586,7 +2592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/TRPSYN-PWY-1-TRPSYN-PWY-1.ttl
+++ b/models/TRPSYN-PWY-1-TRPSYN-PWY-1.ttl
@@ -1,20 +1,20 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_null_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/IGPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -56,18 +56,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -76,46 +79,45 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PRAISOM-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
+          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
@@ -135,19 +137,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
+          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -158,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -245,19 +264,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_16567_PRTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29748_ANTHRANSYN-RXN>
@@ -269,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,13 +297,15 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "anthranilate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component> , <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,19 +343,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1>
@@ -342,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -353,11 +374,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +386,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
@@ -380,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,34 +426,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000000892>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_null_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IGPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -447,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,22 +536,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PRAISOM-RXN>
+          <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004048>
@@ -540,29 +560,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
 ] .
 
 <http://identifiers.org/sgd/S000002994>
@@ -577,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,19 +649,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/PRTRANS-RXN>
@@ -665,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,19 +693,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
+          <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
+          <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/IGPSYN-RXN>
@@ -709,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -743,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -775,19 +793,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16567_PRTRANS-RXN>
+          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -796,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -858,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,19 +886,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/TRYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
+          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_ANTHRANSYN-RXN>
@@ -892,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,19 +920,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
@@ -926,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -941,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -990,20 +1008,22 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
+          <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1012,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1059,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1072,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1080,19 +1100,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_59776>
@@ -1109,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1150,39 +1170,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
-] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
+] .
 
 <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002994> ;
@@ -1191,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,21 +1219,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
@@ -1224,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1233,26 +1264,37 @@
 <http://identifiers.org/sgd/S000001694>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0004425>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_TRPSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004425>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_TRPSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1263,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1282,19 +1324,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
+          <http://model.geneontology.org/PRAISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
+          <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1303,7 +1345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1330,19 +1372,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
+          <http://model.geneontology.org/PRTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
+          <http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004049>
@@ -1350,19 +1392,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/IGPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
+          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
 ] .
 
 <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
@@ -1374,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1404,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1415,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1444,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,415 +1495,12 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ANTHRANSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
-] .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000002414>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_ANTHRANSYN-RXN_SGD_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ANTHRANSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58613> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71382> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_58613>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ANTHRANSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29748>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71258> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "PRPP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71338> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57912>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
-] .
-
-<http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58613> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71382> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002414> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "N-(5'-phosphoribosyl)-anthranilate isomerase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1Protein71389> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "Biosynthesis of the aromatic amino acids tryptophan, tyrosine, and phenylalanine proceeds via a common pathway to chorismate, at which point the pathway branches |CITS:[Jones][1943992]|. One branch proceeds to tryptophan, and the other to tyrosine and phenylalanine |CITS:[Jones]|. The series of reactions to chorismate, called the shikimate pathway, and the series of reactions from chorismate to tryptophan have been found to be common to all eukaryotes and prokaryotes studied thus far (as reported in |CITS:[1943992]|). In contrast, there appears to be two separate routes from chorismate to tyrosine and phenylalanine, only one of which has been found in S. cerevisiae |CITS:[1943992]|. Aromatic amino acid biosynthesis in S. cerevisiae is controlled by a combination of feedback inhibition, activation of enzyme activity, and regulation of enzyme synthesis |CITS:[Jones][1943992]|. The first step in the tryptophan branch is feedback inhibited by tryptophan, and the first step in the phenylalanine-tyrosine branch is feedback inhibited by tyrosine and activated by tryptophan |CITS:[1943992]|. The transcriptional activator GCN4 regulates most of the genes encoding for the aromatic amino acid biosynthetic enzymes; however, no GCN4 regulation was found for TRP1 of the tryptophan branch, TYR1 of the tyrosine branch or ARO7 of the tyrosine and phenylalanine branch |CITS:[1943992]|." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-tryptophan biosynthesis" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "TRPSYN-PWY-1" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1880,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1891,12 +1530,455 @@
           <http://model.geneontology.org/TRYPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ANTHRANSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000002414>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_ANTHRANSYN-RXN_SGD_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ANTHRANSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IGPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001694> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58613> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRAISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58613>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ANTHRANSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_null_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29748>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71258> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "PRPP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71338> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRAISOM-RXN_SGD_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_TRPSYN-PWY-1/TRPSYN-PWY-1_SGD_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57912>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
+        a       <http://identifiers.org/sgd/S000000892> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
+] .
+
+<http://model.geneontology.org/CHEBI_58613_IGPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58613> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002414> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "N-(5'-phosphoribosyl)-anthranilate isomerase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1Protein71389> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/TRPSYN-PWY-1/TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "Biosynthesis of the aromatic amino acids tryptophan, tyrosine, and phenylalanine proceeds via a common pathway to chorismate, at which point the pathway branches |CITS:[Jones][1943992]|. One branch proceeds to tryptophan, and the other to tyrosine and phenylalanine |CITS:[Jones]|. The series of reactions to chorismate, called the shikimate pathway, and the series of reactions from chorismate to tryptophan have been found to be common to all eukaryotes and prokaryotes studied thus far (as reported in |CITS:[1943992]|). In contrast, there appears to be two separate routes from chorismate to tyrosine and phenylalanine, only one of which has been found in S. cerevisiae |CITS:[1943992]|. Aromatic amino acid biosynthesis in S. cerevisiae is controlled by a combination of feedback inhibition, activation of enzyme activity, and regulation of enzyme synthesis |CITS:[Jones][1943992]|. The first step in the tryptophan branch is feedback inhibited by tryptophan, and the first step in the phenylalanine-tyrosine branch is feedback inhibited by tyrosine and activated by tryptophan |CITS:[1943992]|. The transcriptional activator GCN4 regulates most of the genes encoding for the aromatic amino acid biosynthetic enzymes; however, no GCN4 regulation was found for TRP1 of the tryptophan branch, TYR1 of the tyrosine branch or ARO7 of the tyrosine and phenylalanine branch |CITS:[1943992]|." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-tryptophan biosynthesis" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "TRPSYN-PWY-1" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_TRPSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IGPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/TRYPTOPHAN-DEGRADATION-1-TRYPTOPHAN-DEGRADATION-1.ttl
+++ b/models/TRYPTOPHAN-DEGRADATION-1-TRYPTOPHAN-DEGRADATION-1.ttl
@@ -1,44 +1,144 @@
-<http://identifiers.org/sgd/S000003839>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58125>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
+          <http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+] .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,111 +146,45 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57502>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+                "formate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66949> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
+          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
 ] .
 
-<http://identifiers.org/sgd/S000003242>
+<http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16675>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -161,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,35 +203,114 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "gln" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66702> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADPH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66910> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0033754>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,94 +318,230 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
+          <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_994_RXN-5721>
-] .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58017>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "L-tryptophan degradation III (eukaryotic) - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynureninase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66880> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66675> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_456215>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
@@ -303,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,130 +560,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15740>
+<http://identifiers.org/sgd/S000001116>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66609> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66609> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003839> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Tryptophan 2,3-dioxygenase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66821> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58629_RXN-8665>
+          <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxyanthranilate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66837> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -444,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,81 +616,170 @@
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ala" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66873> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+<http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glutamine-dependent NAD synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66757> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+          <http://model.geneontology.org/RXN-5721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+          <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://identifiers.org/sgd/S000001943>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003839> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Tryptophan 2,3-dioxygenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66821> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15740>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66609> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_58629_RXN-8665>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-Formyl-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66814> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -539,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,84 +800,302 @@
           <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+<http://model.geneontology.org/CHEBI_15379_RXN-8665>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Arylformamidase" ;
+                "O<SUB>2</SUB>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66956> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66788> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/1.13.11.6-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0000334> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/RXN-5721> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-tryptophan degradation III (eukaryotic)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "TRYPTOPHAN-DEGRADATION-1" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynurenine aminotransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66824> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66962> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+          <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16675_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16675_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://identifiers.org/sgd/S000000194>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003952>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002411_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004502> ;
@@ -648,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -656,615 +1124,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
+<http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "O<SUB>2</SUB>" ;
+                "glu" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66788> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66719> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66594> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456215>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002411_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
-] .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_36559>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004061>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
-] .
-
-<http://identifiers.org/sgd/S000001943>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
-] .
-
-<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynurenine aminotransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66962> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58017>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
-] .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
-] .
-
-<http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58125> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxy-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66859> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004320>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.13.11.6-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1272,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,319 +1158,13 @@
           <http://model.geneontology.org/CHEBI_15379_RXN-8665>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58125>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030429> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/1.13.11.6-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66847> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001943> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Quinolinate phosphoribosyl transferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66658> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003952>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16675_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/RXN-8665>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033754> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57912_RXN-8665> , <http://model.geneontology.org/CHEBI_15379_RXN-8665> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58629_RXN-8665> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66775> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_994_RXN-5721>
-        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-3-carboxymuconate-6-semialdehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ala" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66873> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1606,18 +1175,12 @@
           <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0000334>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1625,233 +1188,101 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-<http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004514> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66580> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-5721>
+          <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADPH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66910> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
+<http://identifiers.org/sgd/S000002836>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004514>
+<http://identifiers.org/sgd/S000004320>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66675> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' 'null' '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
+          <http://model.geneontology.org/RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002411_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66609> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1859,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,80 +1300,13 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
 ] .
-
-<http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16675> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "quinolinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66562> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_15377_RXN-5721>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1950,433 +1314,94 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "formate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0033754>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004320> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66772> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58629> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-Formyl-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66814> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0030429>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58437> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "nicotinate adenine dinucleotide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66688> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57912_RXN-8665>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57912> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "trp" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66802> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
+<http://purl.obolibrary.org/obo/CHEBI_16675>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxyanthranilate" ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66837> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+          <http://model.geneontology.org/RXN-5721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_994_RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2388,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2399,54 +1424,109 @@
           <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "glutamine-dependent NAD synthase" ;
+                "ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66757> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66661> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
 ] .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://identifiers.org/sgd/S000003596>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16675> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "quinolinate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66562> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0004061>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NaMN" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66622> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2457,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2467,106 +1547,20 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "L-tryptophan degradation III (eukaryotic) - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "AMP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66735> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2577,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2585,78 +1579,119 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
-] .
+<http://purl.obolibrary.org/obo/GO_0000334>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
-] .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "gln" ;
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001943> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Quinolinate phosphoribosyl transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66702> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66658> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_16675_RXN-5721>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16675> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "quinolinate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66562> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2677,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2685,57 +1720,82 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000004221>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
+] .
 
-<http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
+<http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
+                "AMP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66925> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66735> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_57959>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2747,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2758,292 +1818,13 @@
           <http://model.geneontology.org/CHEBI_57912_RXN-8665>
 ] .
 
-<http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004061> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller> , <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66935> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58125> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxy-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66859> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-<http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_57972>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66675> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
-] .
-
-<http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66766> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16675_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN>
-] .
-
-<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynureninase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66880> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
-] .
-
-<http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66661> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3054,29 +1835,687 @@
           <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_994>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_58629_RXN-8665>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-Formyl-L-kynurenine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66814> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Arylformamidase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66956> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-3-carboxymuconate-6-semialdehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004514>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_57972>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66895> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57959>
+<http://purl.obolibrary.org/obo/CHEBI_57912>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15379>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NaMN" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66622> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN-5721>
+] .
+
+<http://model.geneontology.org/CHEBI_15377_RXN-5721>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0030429>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58629> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-Formyl-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66814> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58125> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxy-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66859> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58629>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66609> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66675> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+<http://identifiers.org/sgd/S000003242>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
@@ -3098,7 +2537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3106,56 +2545,337 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004320> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66772> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/GO_0004061> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN> , <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller> , <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66935> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66594> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58629_RXN-8665>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+] .
+
+<http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000003839>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_58437_NAD-SYNTH-GLN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58437> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "nicotinate adenine dinucleotide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66688> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
+          <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "O<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66788> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66895> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16675_RXN-5721>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66609> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3163,7 +2883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3174,144 +2894,109 @@
           <http://model.geneontology.org/CHEBI_57959_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/RXN-8665>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033754> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-3-carboxymuconate-6-semialdehyde" ;
+                "L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_57912_RXN-8665> , <http://model.geneontology.org/CHEBI_15379_RXN-8665> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_58629_RXN-8665> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66543> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66775> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0004515>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66719> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000000194>
+<http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58437>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15379>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+          <http://model.geneontology.org/RXN-5721> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
+          <http://model.geneontology.org/CHEBI_16675_RXN-5721>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
@@ -3323,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3331,12 +3016,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3344,152 +3057,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58629_ARYLFORMAMIDASE-RXN>
-] .
-
-<http://model.geneontology.org/CHEBI_57502_NICONUCADENYLYLTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57502> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NaMN" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66622> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0004502>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000003786>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15379_RXN-8665>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "O<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66788> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-tryptophan degradation III (eukaryotic)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "TRYPTOPHAN-DEGRADATION-1" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57912>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' 'null' '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-5721>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3497,8 +3069,167 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_994_RXN-5721>
+        a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-3-carboxymuconate-6-semialdehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66925> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Nicotinamide/nicotinic acid mononucleotide adenylyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66766> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3506,7 +3237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3517,81 +3248,121 @@
           <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003786> ;
+<http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxyanthranilic acid dioxygenase" ;
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66844> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1.13.11.6-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
+          <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000000194> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3600,7 +3371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3609,65 +3380,174 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
+] .
+
+<http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030429> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN> , <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/1.13.11.6-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66847> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
+          <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58437>
+<http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58629>
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000003786>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58125> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxy-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66859> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_36559>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3675,75 +3555,82 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003786> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxyanthranilic acid dioxygenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66844> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002411_QUINOPRIBOTRANS-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_3-HYDROXY-KYNURENINASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_null_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
+] .
 
-<http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NaMN" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66622> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000004221>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_16675_RXN-5721>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16675> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "quinolinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66562> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
@@ -3754,7 +3641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3762,32 +3649,148 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004514> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN> , <http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66580> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_57912_RXN-8665>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57912> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "trp" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66802> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1>
+] .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
+] .
+
+<http://model.geneontology.org/1.13.11.6-RXN>
+        a       <http://purl.obolibrary.org/obo/GO_0000334> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/TRYPTOPHAN-DEGRADATION-1/TRYPTOPHAN-DEGRADATION-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_36559_1.13.11.6-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN> , <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN-5721> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66824> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/UDPNAGSYN-YEAST-PWY-UDPNAGSYN-YEAST-PWY.ttl
+++ b/models/UDPNAGSYN-YEAST-PWY-UDPNAGSYN-YEAST-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -51,11 +51,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_4525c28f-6e0e-4258-b70c-1a06b0a7a7c6_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4525c28f-6e0e-4258-b70c-1a06b0a7a7c6_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+          <http://model.geneontology.org/7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,13 +103,35 @@
           <http://model.geneontology.org/CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002233_CHEBI_57513_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,36 +142,14 @@
           <http://model.geneontology.org/CHEBI_57513_PHOSACETYLGLUCOSAMINEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000066_reaction_PHOSACETYLGLUCOSAMINEMUT-RXN_location_lociGO_0005829_null_UDPNAGSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,23 +199,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/4525c28f-6e0e-4258-b70c-1a06b0a7a7c6_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "D-glucosamine 6-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -225,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -246,6 +229,9 @@
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -256,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,8 +250,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -273,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,11 +280,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_07509060-f251-4ec9-b482-0bdfab166806_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +292,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/07509060-f251-4ec9-b482-0bdfab166806_GLUCOSAMINEPNACETYLTRANS-RXN>
+          <http://model.geneontology.org/9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN>
@@ -310,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,19 +378,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "D-glucosamine 6-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -404,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,13 +435,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -441,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -454,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -540,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -623,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -755,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -838,24 +860,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42511> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_4525c28f-6e0e-4258-b70c-1a06b0a7a7c6_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -866,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,24 +931,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYProtein42433> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_07509060-f251-4ec9-b482-0bdfab166806_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_46398_NAG1P-URIDYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_46398> ;
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UDP-N-acetylglucosamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/4525c28f-6e0e-4258-b70c-1a06b0a7a7c6_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,17 +1104,6 @@
 <http://identifiers.org/sgd/S000001877>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1123,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,13 +1123,24 @@
           <http://model.geneontology.org/reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1325,7 +1325,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1337,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,16 +1359,22 @@
           <http://model.geneontology.org/CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "D-glucosamine 6-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1368,7 +1385,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/07509060-f251-4ec9-b482-0bdfab166806_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1378,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,57 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/07509060-f251-4ec9-b482-0bdfab166806_GLUCOSAMINEPNACETYLTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "D-glucosamine 6-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_46398_NAG1P-URIDYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002333_YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1473,7 +1440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,6 +1450,39 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29888_NAG1P-URIDYLTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_46398_NAG1P-URIDYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002333_YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000784>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/VALSYN-PWY-VALSYN-PWY.ttl
+++ b/models/VALSYN-PWY-VALSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -25,20 +25,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000000515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -49,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,19 +82,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_VALSYN-PWY/VALSYN-PWY_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_49072_DIHYDROXYISOVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/VALSYN-PWY/VALSYN-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -107,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,13 +121,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_58476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,22 +319,20 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_null_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
@@ -349,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,6 +396,23 @@
           <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_VALSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
 <http://model.geneontology.org/VALSYN-PWY>
@@ -403,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-valine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -532,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,19 +603,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_VALSYN-PWY/VALSYN-PWY_SGD_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+          <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/VALSYN-PWY/VALSYN-PWY>
+          <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -619,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -664,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,15 +724,52 @@
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_VALSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
+] .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
+        a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_null_VALSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,9 +943,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000515> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -903,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -955,20 +1022,23 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002411_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000004714>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -979,7 +1049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1005,13 +1075,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58476_ACETOLACTREDUCTOISOM-RXN_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1060,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1092,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1250,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1261,19 +1342,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
+          <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
@@ -1285,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1312,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,7 +1456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,20 +1468,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_null_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
+          <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
@@ -1414,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,13 +1558,15 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "acetolactate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component> , <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1505,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1516,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-4AMINOBUTMETAB-PWY-YEAST-4AMINOBUTMETAB-PWY.ttl
+++ b/models/YEAST-4AMINOBUTMETAB-PWY-YEAST-4AMINOBUTMETAB-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobutyrate degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-DE-NOVO-PYRMID-DNT-YEAST-DE-NOVO-PYRMID-DNT.ttl
+++ b/models/YEAST-DE-NOVO-PYRMID-DNT-YEAST-DE-NOVO-PYRMID-DNT.ttl
@@ -3,29 +3,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + dCMP &rarr; ADP + dCDP' 'null' 'dCDP + ATP &rarr; dCTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002413_DCDPKIN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_60471_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7913> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DCDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_60471_RXN-14122>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_30616_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -33,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -44,29 +42,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000066_reaction_DUDPKIN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DUDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DUDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -74,7 +70,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -82,19 +89,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_30616_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_CDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DCDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://geneontology.org/lego/evidence>
@@ -105,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -116,27 +123,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_60471_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60471_UDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000066_reaction_DTMPKI-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT>
@@ -144,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -152,19 +176,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_246422_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_456216_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DUDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -172,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -197,19 +221,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_61555_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_61481_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61555_DCTP-DEAM-RXN>
+          <http://model.geneontology.org/CHEBI_61481_DCDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_DCDPKIN-RXN>
@@ -221,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -248,11 +272,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Red-Thioredoxin_UDPREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,27 +312,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7913> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002413_DUTP-PYROP-RXN_null_YEAST-DE-NOVO-PYRMID-DNT>
@@ -299,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -309,20 +352,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_63528_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000066_reaction_DTDPKIN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DTDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_DTMPKI-RXN>
+          <http://model.geneontology.org/reaction_DTDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DCDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -330,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,19 +411,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_8324807b-0e43-439b-b7af-5da68cb82f50_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_57566_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-7913> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8324807b-0e43-439b-b7af-5da68cb82f50_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57566_RXN-7913>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_60471_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -386,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,22 +458,20 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'dUDP + ATP &rarr; dUTP + ADP' 'null' 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002413_DUTP-PYROP-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002333_YJR057W-MONOMER_DTMPKI-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DUTP-PYROP-RXN>
+          <http://model.geneontology.org/YJR057W-MONOMER_DTMPKI-RXN_controller>
 ] .
 
 <http://model.geneontology.org/RXN-14122>
@@ -450,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,19 +503,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DTMPKI-RXN_null_YEAST-DE-NOVO-PYRMID-DNT>
@@ -480,9 +523,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -491,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -564,13 +616,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44902> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000066_reaction_UDPREDUCT-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_UDPREDUCT-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/CHEBI_61555_DUDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61555> ;
@@ -581,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,19 +662,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_30616_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_61555_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN-14122>
+          <http://model.geneontology.org/CHEBI_61555_DUTP-PYROP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -612,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,23 +696,43 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_456216_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_61481_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTDPKIN-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DTDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_61481_DCTP-DEAM-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_61555>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_DUDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -652,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,19 +753,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002333_YJR057W-MONOMER_RXN-14122_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/YJR057W-MONOMER_RXN-14122_controller>
 ] .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DUDPKIN-RXN_controller>
@@ -684,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,20 +784,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000066_reaction_DTMPKI-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DUDPKIN-RXN>
+          <http://model.geneontology.org/reaction_DTMPKI-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_246422>
@@ -719,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,19 +822,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_58593_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_CDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58593_DCDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://identifiers.org/sgd/S000003818>
@@ -755,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -774,19 +867,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_UDPREDUCT-RXN>
+          <http://model.geneontology.org/f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -797,19 +890,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_29888_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_61555_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_DUTP-PYROP-RXN>
+          <http://model.geneontology.org/CHEBI_61555_DUDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_37568>
@@ -822,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,22 +924,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'dCTP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + dUTP' 'null' 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002413_DUTP-PYROP-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DCDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DUTP-PYROP-RXN>
+          <http://model.geneontology.org/YKL067W-MONOMER_DCDPKIN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/DUTP-PYROP-RXN>
@@ -868,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -881,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,6 +1001,34 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002333_CPLX3O-270_UDPREDUCT-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller>
+] .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -918,7 +1037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -955,22 +1074,20 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000066_reaction_RXN-7913_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7913> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-7913_location_lociGO_0005829>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
 <http://model.geneontology.org/CHEBI_61555_DUTP-PYROP-RXN>
@@ -982,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,19 +1109,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_456216_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_30616_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DTDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DTMPKI-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DTDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/THYMIDYLATESYN-RXN>
@@ -1016,9 +1133,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/d0f0d598-2889-45ae-8268-87fda7112588_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8324807b-0e43-439b-b7af-5da68cb82f50_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1026,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1039,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1050,19 +1167,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_456216_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-7913> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_456216_RXN-7913>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_UDPREDUCT-RXN>
@@ -1074,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,20 +1251,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'dTMP + ATP &rarr; dTDP + ADP' 'null' 'dTDP + ATP &rarr; dTTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002413_DTDPKIN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/DTDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -1155,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1177,48 +1296,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000066_reaction_DCTP-DEAM-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DCTP-DEAM-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' 'null' 'dTMP + ATP &rarr; dTDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DTMPKI-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-7913> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DTMPKI-RXN>
+          <http://model.geneontology.org/CHEBI_58593_RXN-7913>
 ] .
 
 <http://model.geneontology.org/DCTP-DEAM-RXN>
@@ -1238,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,29 +1366,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000066_reaction_DUTP-PYROP-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DUTP-PYROP-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_61481_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -1281,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1296,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1311,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1320,20 +1433,22 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15377_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000066_reaction_DCDPKIN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DCTP-DEAM-RXN>
+          <http://model.geneontology.org/reaction_DCDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -1341,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1361,22 +1476,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_57566>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/d0f0d598-2889-45ae-8268-87fda7112588_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_15377_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_UDPREDUCT-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58369_DTDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58369> ;
@@ -1387,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1397,19 +1512,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_456216_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_15378_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN-14122>
+          <http://model.geneontology.org/CHEBI_15378_DUTP-PYROP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1418,7 +1533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,25 +1561,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DTDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_28938_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTDPKIN-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DTDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_28938_DCTP-DEAM-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-7913_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -1472,23 +1598,26 @@
 <http://purl.obolibrary.org/obo/GO_0008829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'ATP + dUMP &rarr; ADP + dUDP' 'null' 'dUDP + ATP &rarr; dUTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002413_DUDPKIN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/DUDPKIN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_63528>
@@ -1496,19 +1625,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_60471_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_30616_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60471_DUDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DTMPKI-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_60471>
@@ -1516,29 +1645,31 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_456216_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DCDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "thymidylate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1554,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1565,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1573,27 +1704,30 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_58223_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58223_UDPREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_58369_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1618,7 +1752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1631,47 +1765,49 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002333_YBR252W-MONOMER_DUTP-PYROP-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DUDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR252W-MONOMER_DUTP-PYROP-RXN_controller>
+          <http://model.geneontology.org/YKL067W-MONOMER_DUDPKIN-RXN_controller>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'dCDP + ATP &rarr; dCTP + ADP' 'null' 'dCTP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + dUTP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002413_DCTP-DEAM-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTDPKIN-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/DCTP-DEAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_8324807b-0e43-439b-b7af-5da68cb82f50_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1682,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1704,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1719,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1732,11 +1868,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002411_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DUDPKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_CHEBI_15377_CDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,20 +1901,22 @@
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_30616_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000066_reaction_RXN-14122_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7913> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN-7913>
+          <http://model.geneontology.org/reaction_RXN-14122_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_61481_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -1769,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1780,19 +1935,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_58369_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_58369_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DTDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58369_DTMPKI-RXN>
+          <http://model.geneontology.org/CHEBI_58369_DTDPKIN-RXN>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -1803,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1814,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1824,10 +1979,12 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1877,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1892,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1901,20 +2058,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'ATP + dCMP &rarr; ADP + dCDP' 'null' 'dCDP + ATP &rarr; dCTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002413_DCDPKIN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/RXN-7913> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/DCDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_DTDPKIN-RXN>
@@ -1926,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1943,7 +2102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1952,20 +2111,22 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_15377_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000066_reaction_DUDPKIN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DUTP-PYROP-RXN>
+          <http://model.geneontology.org/reaction_DUDPKIN-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004170>
@@ -1980,7 +2141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1993,19 +2154,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15378_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_30616_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DCTP-DEAM-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DCDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/UDPREDUCT-RXN>
@@ -2027,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2040,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2055,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,19 +2226,36 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_60471_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_60471_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_60471_UDPREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_246422_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60471_RXN-14122>
+          <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2086,7 +2264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,7 +2280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2110,19 +2288,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_61555_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/CHEBI_61555_DCTP-DEAM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000066_reaction_RXN-14122_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2130,7 +2308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2144,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2155,7 +2333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2169,19 +2347,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-7913> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
 <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN>
@@ -2193,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,19 +2384,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_456216_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_63528_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_DUDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_63528_DTMPKI-RXN>
 ] .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DTDPKIN-RXN_controller>
@@ -2228,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2238,19 +2416,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_61481_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61481_DCDPKIN-RXN>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_61481_DCDPKIN-RXN>
@@ -2262,13 +2440,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule45025> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000005600>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004748> ;
@@ -2289,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,19 +2480,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_UDPREDUCT-RXN>
+          <http://model.geneontology.org/7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2319,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2328,23 +2509,26 @@
 <http://model.geneontology.org/reaction_DUDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58593>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15378_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2359,7 +2543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2369,25 +2553,22 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'dUDP + ATP &rarr; dUTP + ADP' 'null' 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002413_DUTP-PYROP-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/DUTP-PYROP-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_58593>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58223_UDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58223> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2398,7 +2579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2415,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2424,23 +2605,32 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000066_reaction_DTDPKIN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTDPKIN-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DTDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -2450,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2475,19 +2665,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_57566_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_246422_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7913> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57566_RXN-7913>
+          <http://model.geneontology.org/CHEBI_246422_RXN-14122>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_58369_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2495,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2503,19 +2693,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002333_YJR057W-MONOMER_DTMPKI-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_37568_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DTDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR057W-MONOMER_DTMPKI-RXN_controller>
+          <http://model.geneontology.org/CHEBI_37568_DTDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/DTMPKI-RXN>
@@ -2537,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2545,12 +2735,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_456216_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2558,19 +2757,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_456216_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_30616_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7913> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN-7913>
+          <http://model.geneontology.org/CHEBI_30616_RXN-14122>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_15377_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2578,7 +2777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2589,7 +2788,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000872>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2604,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2613,22 +2826,20 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'dTMP + ATP &rarr; dTDP + ADP' 'null' 'dTDP + ATP &rarr; dTTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002413_DTDPKIN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_456216_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DTDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DTDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DTDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_DCDPKIN-RXN>
@@ -2640,7 +2851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2660,7 +2871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2670,38 +2881,47 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_CDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000066_reaction_UDPREDUCT-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_UDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -2716,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2729,19 +2949,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_61555_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61555_DUTP-PYROP-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DUDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_456216_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2749,27 +2969,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+        a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_61481_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_58593_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61481_DCTP-DEAM-RXN>
+          <http://model.geneontology.org/CHEBI_58593_DCDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_60471_UDPREDUCT-RXN>
@@ -2781,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2797,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2808,11 +3037,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Red-Thioredoxin_UDPREDUCT-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2826,7 +3072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2843,7 +3089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2856,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2864,38 +3110,38 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002333_YJR057W-MONOMER_RXN-14122_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_29888_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR057W-MONOMER_RXN-14122_controller>
+          <http://model.geneontology.org/CHEBI_29888_DUTP-PYROP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Provides Input For Rule. The relation 'dCTP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + dUTP' 'null' 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000066_reaction_DTMPKI-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002413_DUTP-PYROP-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DTMPKI-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/DUTP-PYROP-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002333_YJR057W-MONOMER_RXN-14122_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2903,11 +3149,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2917,7 +3180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2928,7 +3191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2939,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2949,20 +3212,22 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_d0f0d598-2889-45ae-8268-87fda7112588_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000066_reaction_RXN-7913_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-7913> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d0f0d598-2889-45ae-8268-87fda7112588_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/reaction_RXN-7913_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002413_THYMIDYLATESYN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2970,7 +3235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2981,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2989,39 +3254,50 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_61555_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_456216_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61555_DUDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DTMPKI-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000456>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DCDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DCDPKIN-RXN_controller>
+          <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002333_YBR252W-MONOMER_DUTP-PYROP-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3029,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3040,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3051,7 +3327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3059,19 +3335,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002333_CPLX3O-270_UDPREDUCT-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller>
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_CDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3079,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3087,17 +3363,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
@@ -3107,7 +3383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3118,27 +3394,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_30616_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000066_reaction_DCTP-DEAM-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTDPKIN-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DTDPKIN-RXN>
+          <http://model.geneontology.org/reaction_DCTP-DEAM-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_60471_DUDPKIN-RXN>
@@ -3150,7 +3428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3158,12 +3436,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_30616_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3174,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3185,7 +3474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3197,7 +3486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3211,6 +3500,9 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_58369_DTMPKI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58369> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3220,7 +3512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3231,25 +3523,16 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_d0f0d598-2889-45ae-8268-87fda7112588_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-270_CDPREDUCT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ribonucleotide reductase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component> , <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3257,62 +3540,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://purl.obolibrary.org/obo/CHEBI_58069>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_456216_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7913> ;
+          <http://model.geneontology.org/RXN-14122> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58593_RXN-7913>
+          <http://model.geneontology.org/CHEBI_456216_RXN-14122>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_58069>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_UDPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DTDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+          <http://model.geneontology.org/YKL067W-MONOMER_DTDPKIN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/8324807b-0e43-439b-b7af-5da68cb82f50_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_DCTP-DEAM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3323,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3336,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3351,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3363,22 +3629,20 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000066_reaction_DCDPKIN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_CDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DCDPKIN-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_456216_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3386,27 +3650,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_15377_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_UDPREDUCT-RXN>
+          <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_30616_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3414,27 +3680,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_15378_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_60471_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+          <http://model.geneontology.org/DUDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DUTP-PYROP-RXN>
+          <http://model.geneontology.org/CHEBI_60471_DUDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_57566_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3442,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3453,14 +3722,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_DUTP-PYROP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -3471,7 +3737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3488,7 +3754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3501,19 +3767,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_28938_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_456216_DCDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
+          <http://model.geneontology.org/DCDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_DCTP-DEAM-RXN>
+          <http://model.geneontology.org/CHEBI_456216_DCDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_DTMPKI-RXN_location_lociGO_0005829>
@@ -3523,23 +3789,41 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'ATP + dUMP &rarr; ADP + dUDP' 'null' 'dUDP + ATP &rarr; dUTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002413_DUDPKIN-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_58223_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DUDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_58223_UDPREDUCT-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002333_YBR252W-MONOMER_DUTP-PYROP-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR252W-MONOMER_DUTP-PYROP-RXN_controller>
+] .
+
+<http://identifiers.org/sgd/S000003563>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_RXN-14122>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -3550,7 +3834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3560,23 +3844,34 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_30616_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTMPKI-RXN> ;
+          <http://model.geneontology.org/DTDPKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DTMPKI-RXN>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
 <http://model.geneontology.org/reaction_DCTP-DEAM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_DUTP-PYROP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3587,7 +3882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3607,7 +3902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3624,7 +3919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3637,19 +3932,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_30616_RXN-7913_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+          <http://model.geneontology.org/RXN-7913> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_30616_RXN-7913>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002333_YJR057W-MONOMER_DTMPKI-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3657,7 +3952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3668,7 +3963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3676,19 +3971,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DUDPKIN-RXN_controller_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_58369_DTMPKI-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUDPKIN-RXN> ;
+          <http://model.geneontology.org/DTMPKI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL067W-MONOMER_DUDPKIN-RXN_controller>
+          <http://model.geneontology.org/CHEBI_58369_DTMPKI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_15377_UDPREDUCT-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3696,29 +3991,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'dCDP + ATP &rarr; dCTP + ADP' 'null' 'dCTP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + dUTP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002413_DCTP-DEAM-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DCDPKIN-RXN> ;
+          <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DCTP-DEAM-RXN>
+          <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3726,7 +4028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3751,7 +4053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3760,20 +4062,22 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' 'null' 'dTMP + ATP &rarr; dTDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002411_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DTMPKI-RXN_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DUDPKIN-RXN>
+          <http://model.geneontology.org/DTMPKI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58593_RXN-7913>
@@ -3785,7 +4089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3802,7 +4106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3815,7 +4119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3825,53 +4129,70 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000066_reaction_RXN-14122_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000066_reaction_DUTP-PYROP-RXN_location_lociGO_0005829_null_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-14122_location_lociGO_0005829>
+          <http://model.geneontology.org/reaction_DUTP-PYROP-RXN_location_lociGO_0005829>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_58369_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15377_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTDPKIN-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58369_DTDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15377_DCTP-DEAM-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_246422_RXN-14122_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_15377_DUTP-PYROP-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14122> ;
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_RXN-14122>
+          <http://model.geneontology.org/CHEBI_15377_DUTP-PYROP-RXN>
 ] .
 
 <http://model.geneontology.org/RXN-7913>
@@ -3891,7 +4212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3908,7 +4229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +4247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3936,19 +4257,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_37568_DTDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15378_DCTP-DEAM-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DTDPKIN-RXN> ;
+          <http://model.geneontology.org/DCTP-DEAM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37568_DTDPKIN-RXN>
+          <http://model.geneontology.org/CHEBI_15378_DCTP-DEAM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -3956,7 +4277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-FAO-PWY-YEAST-FAO-PWY.ttl
+++ b/models/YEAST-FAO-PWY-YEAST-FAO-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,11 +20,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -32,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -59,18 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_fde34630-db36-4636-bd69-355778b40537_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,20 +104,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_6d01d1a7-109a-4f04-a524-9cc9d95732a7_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -132,7 +127,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15455_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d1e4a06e-c23d-454c-9dbb-13ebef0f22d4_ENOYL-COA-HYDRAT-RXN> , <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> ;
+                <http://model.geneontology.org/b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN> , <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -140,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,23 +180,6 @@
 <http://purl.obolibrary.org/obo/GO_0003988>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/25d0cb2a-e12f-4d20-9604-23aa3857465b_KETOACYLCOATHIOL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 2,3,4-saturated fatty acid + ATP + coenzyme A &rarr; a 2,3,4-saturated fatty acyl CoA + AMP + diphosphate' 'null' 'a 2,3,4-saturated fatty acyl CoA + oxygen &rarr; a <i>trans</i>-2-enoyl-CoA + hydrogen peroxide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -210,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -254,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -265,6 +243,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004300>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -281,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,15 +343,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_71627_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> , <http://model.geneontology.org/81bf7df5-d0da-4d96-9bc7-be1e3a49900c_ACYLCOASYN-RXN> ;
+                <http://model.geneontology.org/e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YMR246W-MONOMER_ACYLCOASYN-RXN_controller> ;
+                <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YMR246W-MONOMER_ACYLCOASYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-11026> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,11 +466,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_6aff8ba6-a8db-413f-94a2-ec958a5a1806_RXN-11026_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +478,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6aff8ba6-a8db-413f-94a2-ec958a5a1806_RXN-11026>
+          <http://model.geneontology.org/5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN>
@@ -495,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,11 +526,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59316> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -544,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -583,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,11 +611,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_fde34630-db36-4636-bd69-355778b40537_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +623,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fde34630-db36-4636-bd69-355778b40537_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller>
@@ -621,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -665,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid oxidation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -678,11 +690,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (3Z)-alk-3-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -690,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -767,35 +796,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYProtein59392> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_6aff8ba6-a8db-413f-94a2-ec958a5a1806_RXN-11026_SGD_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_d7cebfa0-6da7-4181-a0f2-8609b4b3a184_RXN-11026_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -806,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,11 +878,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -883,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,29 +935,12 @@
           <http://model.geneontology.org/YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/6d01d1a7-109a-4f04-a524-9cc9d95732a7_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -975,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -983,11 +990,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_d7cebfa0-6da7-4181-a0f2-8609b4b3a184_RXN-11026_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +1002,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d7cebfa0-6da7-4181-a0f2-8609b4b3a184_RXN-11026>
+          <http://model.geneontology.org/b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY>
@@ -1003,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,11 +1035,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_81bf7df5-d0da-4d96-9bc7-be1e3a49900c_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1047,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACYLCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/81bf7df5-d0da-4d96-9bc7-be1e3a49900c_ACYLCOASYN-RXN>
+          <http://model.geneontology.org/e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -1052,7 +1059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,30 +1070,13 @@
           <http://model.geneontology.org/RXN-11026>
 ] .
 
-<http://model.geneontology.org/6aff8ba6-a8db-413f-94a2-ec958a5a1806_RXN-11026>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000050_YEAST-FAO-PWY/YEAST-FAO-PWY_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,23 +1087,12 @@
           <http://model.geneontology.org/YEAST-FAO-PWY/YEAST-FAO-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_d1e4a06e-c23d-454c-9dbb-13ebef0f22d4_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1153,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1168,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,7 +1217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1280,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1296,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1304,40 +1283,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/fde34630-db36-4636-bd69-355778b40537_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (3Z)-alk-3-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_25d0cb2a-e12f-4d20-9604-23aa3857465b_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000050_YEAST-FAO-PWY/YEAST-FAO-PWY_SGD_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,7 +1351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,23 +1382,12 @@
           <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_81bf7df5-d0da-4d96-9bc7-be1e3a49900c_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1456,12 +1396,34 @@
 <http://model.geneontology.org/reaction_ACYLCOASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829_null_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1473,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,13 +1446,24 @@
           <http://model.geneontology.org/CHEBI_15455_OHACYL-COA-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_6d01d1a7-109a-4f04-a524-9cc9d95732a7_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1471,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6d01d1a7-109a-4f04-a524-9cc9d95732a7_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN>
@@ -1510,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1523,7 +1496,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1554,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1581,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1592,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,16 +1601,27 @@
           <http://model.geneontology.org/reaction_RXN-11026_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_d1e4a06e-c23d-454c-9dbb-13ebef0f22d4_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1634,7 +1629,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-HYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d1e4a06e-c23d-454c-9dbb-13ebef0f22d4_ENOYL-COA-HYDRAT-RXN>
+          <http://model.geneontology.org/b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1643,7 +1638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,11 +1657,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004860>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1683,7 +1706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,7 +1723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1722,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1733,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1747,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,7 +1842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1832,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1847,7 +1870,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_KETOACYLCOATHIOL-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/25d0cb2a-e12f-4d20-9604-23aa3857465b_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> ;
+                <http://model.geneontology.org/56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57287_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/CHEBI_15489_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1857,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1875,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1906,7 +1929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1923,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1933,23 +1956,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/d1e4a06e-c23d-454c-9dbb-13ebef0f22d4_ENOYL-COA-HYDRAT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004165>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1962,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1973,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1985,7 +1991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2004,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2047,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2064,9 +2070,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/fde34630-db36-4636-bd69-355778b40537_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/6d01d1a7-109a-4f04-a524-9cc9d95732a7_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> , <http://model.geneontology.org/YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2074,13 +2080,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYBiochemicalReaction59379> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2093,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2108,7 +2131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2119,30 +2142,13 @@
           <http://model.geneontology.org/KETOACYLCOATHIOL-RXN>
 ] .
 
-<http://model.geneontology.org/d7cebfa0-6da7-4181-a0f2-8609b4b3a184_RXN-11026>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2170,29 +2176,12 @@
           <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/81bf7df5-d0da-4d96-9bc7-be1e3a49900c_ACYLCOASYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002333_YIL160C-MONOMER_KETOACYLCOATHIOL-RXN_controller_SGD_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2203,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2214,7 +2203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2229,7 +2218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2246,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2260,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2276,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2287,7 +2276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2295,11 +2284,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_25d0cb2a-e12f-4d20-9604-23aa3857465b_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2307,7 +2296,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KETOACYLCOATHIOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/25d0cb2a-e12f-4d20-9604-23aa3857465b_KETOACYLCOATHIOL-RXN>
+          <http://model.geneontology.org/56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2316,7 +2305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2336,9 +2325,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11026_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d7cebfa0-6da7-4181-a0f2-8609b4b3a184_RXN-11026> , <http://model.geneontology.org/CHEBI_15379_RXN-11026> ;
+                <http://model.geneontology.org/CHEBI_15379_RXN-11026> , <http://model.geneontology.org/b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/6aff8ba6-a8db-413f-94a2-ec958a5a1806_RXN-11026> , <http://model.geneontology.org/CHEBI_16240_RXN-11026> ;
+                <http://model.geneontology.org/CHEBI_16240_RXN-11026> , <http://model.geneontology.org/5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL205W-MONOMER_RXN-11026_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2346,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2359,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2371,7 +2360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2391,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2405,7 +2394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2421,7 +2410,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2434,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YEAST-GALACT-METAB-PWY-YEAST-GALACT-METAB-PWY.ttl
+++ b/models/YEAST-GALACT-METAB-PWY-YEAST-GALACT-METAB-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,54 +71,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001610> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphoglucomutase" ;
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY_SGD_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYProtein27414> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002413_GALACTOKIN-RXN_null_YEAST-GALACT-METAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_27667_ALDOSE1EPIM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_27667> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "&beta;-D-galactopyranose" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27354> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_GALACTOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -129,13 +108,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27514> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001610> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphoglucomutase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYProtein27414> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -145,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "galactose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -173,16 +167,22 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY_SGD_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_27667_ALDOSE1EPIM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_27667> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "&beta;-D-galactopyranose" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27354> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,30 +204,13 @@
 <http://model.geneontology.org/reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/CHEBI_58601_GALACTURIDYLYLTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58601> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "&alpha;-D-glucopyranose 1-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27393> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,6 +221,23 @@
           <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_58601_GALACTURIDYLYLTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58601> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "&alpha;-D-glucopyranose 1-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27393> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -766,24 +766,13 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,17 +783,6 @@
           <http://model.geneontology.org/CHEBI_58601_GALACTURIDYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_GALACTOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -814,13 +792,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27486> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
         a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,7 +1006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,23 +1015,6 @@
           <http://model.geneontology.org/ALDOSE1EPIM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ALDOSE1EPIM-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY_SGD_YEAST-GALACT-METAB-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY>
 ] .
 
 <http://model.geneontology.org/GALACTURIDYLYLTRANS-RXN>
@@ -1055,13 +1038,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYBiochemicalReaction27448> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY_SGD_YEAST-GALACT-METAB-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-03-14" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_4170>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1088,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1315,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1408,20 +1408,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1444,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1452,13 +1441,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY_SGD_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1526,7 +1526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,7 +1545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1635,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YEAST-RIBOSYN-PWY-YEAST-RIBOSYN-PWY.ttl
+++ b/models/YEAST-RIBOSYN-PWY-YEAST-RIBOSYN-PWY.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "riboflavin, FMN and FAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -472,11 +472,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002895>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -486,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -652,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,15 +681,12 @@
           <http://model.geneontology.org/CHEBI_57986_RIBOFLAVIN-SYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0106029>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_57540_RXN-10057_SGD_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1183,13 +1183,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-89_DIOHBUTANONEPSYN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000002895> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "3,4-dihydroxy-2-butanone-4-phosphate synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,12 +1234,15 @@
           <http://model.geneontology.org/CHEBI_15378_RIBOFLAVINKIN-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000000460>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000050_YEAST-RIBOSYN-PWY/YEAST-RIBOSYN-PWY_SGD_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1251,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1296,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1341,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,7 +1377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,11 +1430,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000357>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN-10058>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1450,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1463,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1489,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1517,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1548,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1565,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1579,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1632,7 +1638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1695,7 +1701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1706,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1718,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1752,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1797,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1843,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1859,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1870,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1896,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1910,7 +1916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1930,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1943,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1954,7 +1960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1986,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2003,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2019,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2030,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2042,7 +2048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2054,13 +2060,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-27_RXN3O-110_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000357> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "diaminohydroxyphoshoribosylaminopyrimidine deaminase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,7 +2085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2096,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2116,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2139,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2161,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2176,7 +2182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2215,7 +2221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2228,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2239,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2251,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2284,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2299,7 +2305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2339,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2355,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2372,7 +2378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2391,7 +2397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2410,7 +2416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2426,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2437,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2452,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2466,7 +2472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2482,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2493,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2504,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2515,7 +2521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2527,7 +2533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2549,7 +2555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2574,7 +2580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,7 +2596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,7 +2615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2621,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2640,7 +2646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2655,7 +2661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2675,7 +2681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2689,7 +2695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2709,7 +2715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2722,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2737,7 +2743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2760,7 +2766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2773,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2784,7 +2790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2802,7 +2808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2819,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2846,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2860,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2880,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2893,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2905,7 +2911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2928,7 +2934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2941,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2952,18 +2958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000050_YEAST-RIBOSYN-PWY/YEAST-RIBOSYN-PWY_SGD_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2978,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2986,15 +2981,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000050_YEAST-RIBOSYN-PWY/YEAST-RIBOSYN-PWY_SGD_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15377_RXN-10058_SGD_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3006,7 +3009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3026,7 +3029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3046,7 +3049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3058,7 +3061,7 @@
 ] .
 
 <http://model.geneontology.org/RXN3O-164>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0106029> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one &rarr; 5-amino-6-(D-ribitylamino)uracil" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -3076,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3089,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3101,7 +3104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3122,7 +3125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3135,7 +3138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3147,7 +3150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3163,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3174,7 +3177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3186,7 +3189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3202,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3214,7 +3217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3233,7 +3236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3253,7 +3256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3270,7 +3273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3304,7 +3307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3326,7 +3329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3346,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3359,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3374,7 +3377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3394,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3414,7 +3417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3427,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3439,7 +3442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3455,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3468,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3482,7 +3485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3498,7 +3501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3510,7 +3513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3533,7 +3536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3552,7 +3555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3568,20 +3571,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000000460> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "riboflavine synthetase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3601,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3617,7 +3620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3637,7 +3640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3651,7 +3654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3667,7 +3670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3685,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3698,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3712,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3728,7 +3731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3740,7 +3743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3763,7 +3766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3779,7 +3782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3797,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3811,7 +3814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3827,7 +3830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3842,7 +3845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3859,7 +3862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3875,7 +3878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3900,7 +3903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3913,7 +3916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3936,7 +3939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3953,7 +3956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3970,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3983,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3994,7 +3997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-RNT-SALV-YEAST-RNT-SALV.ttl
+++ b/models/YEAST-RNT-SALV-YEAST-RNT-SALV.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,24 +208,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57865>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_15378_CYTIDINEKIN-RXN_SGD_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_28938_CYTDEAM-RXN_SGD_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,6 +225,17 @@
           <http://model.geneontology.org/CHEBI_28938_CYTDEAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_15378_CYTIDINEKIN-RXN_SGD_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17568_URACIL-PRIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17568> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -922,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1154,7 +1154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,7 +1352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1525,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1537,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1578,7 +1578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1672,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1686,7 +1686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,24 +1697,13 @@
           <http://model.geneontology.org/YEAST-RNT-SALV/YEAST-RNT-SALV>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_456216_URIDINEKIN-RXN_SGD_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_28938_CYTIDEAM2-RXN_SGD_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,6 +1713,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_28938_CYTIDEAM2-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_456216_URIDINEKIN-RXN_SGD_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1751,7 +1751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,9 +1761,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_CDPKIN-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CYTIDEAM2-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004126> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1784,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1792,12 +1789,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000050_YEAST-RNT-SALV/YEAST-RNT-SALV_SGD_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1812,7 +1812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1840,7 +1840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1856,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1868,7 +1868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1915,7 +1915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1960,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1996,17 +1996,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16040>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_CDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2016,13 +2005,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46617> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-03-14" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/URIDINEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004849> ;
@@ -2041,7 +2041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2058,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2071,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2103,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2116,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2131,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2164,7 +2164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,7 +2181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2211,7 +2211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2242,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2256,7 +2256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2286,7 +2286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2323,7 +2323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2340,7 +2340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2357,7 +2357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2386,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2404,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2439,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2455,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2467,7 +2467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,7 +2487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2518,7 +2518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2545,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2560,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2574,7 +2574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2590,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2602,7 +2602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2619,7 +2619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,7 +2638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2669,7 +2669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2686,7 +2686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2703,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2717,7 +2717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2773,7 +2773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2793,7 +2793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2806,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2817,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2831,7 +2831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2866,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2885,7 +2885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2903,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2917,7 +2917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2933,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2945,7 +2945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3015,7 +3015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3035,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3051,7 +3051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3069,7 +3069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3086,7 +3086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3100,7 +3100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,7 +3117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3137,7 +3137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3150,7 +3150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3161,7 +3161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3179,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3199,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3213,7 +3213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3230,7 +3230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3264,7 +3264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3295,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3311,7 +3311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3326,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3339,7 +3339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3350,7 +3350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3362,7 +3362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YEAST-SALV-PYRMID-DNTP-YEAST-SALV-PYRMID-DNTP.ttl
+++ b/models/YEAST-SALV-PYRMID-DNTP-YEAST-SALV-PYRMID-DNTP.ttl
@@ -9,7 +9,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,7 +1020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,7 +1299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1436,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1499,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1778,7 +1778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1798,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1851,7 +1851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1898,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1915,7 +1915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1964,7 +1964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2030,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2043,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2070,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2098,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2135,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2149,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2193,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2222,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2256,7 +2256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2289,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2329,7 +2329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2359,7 +2359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2021-11-16" ;
+          "2022-03-14" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2403,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2414,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2432,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2447,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2021-11-16" ;
+                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>


### PR DESCRIPTION
Only change is that complexes are correctly emitted now - https://github.com/geneontology/pathways2GO/issues/154.

Example in `models/SO4ASSIM-PWY-SO4ASSIM-PWY.ttl` "assimilatory sulfate reduction I":
![image](https://user-images.githubusercontent.com/2678599/158274935-8a9a2f8b-93c9-4348-84c1-2f1ca201d934.png)
